### PR TITLE
Add Docker bootstrap for first admin invite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,13 @@ MEMORY_COMPACTED_MAX_CHARS=2000
 BOT_PROFILE=default_dev
 BOT_PROFILES_DIR=bot_profiles
 
+# Optional first-admin bootstrap. When both email and bot username are set,
+# Docker startup creates one admin invite after migrations if no admin exists.
+BOOTSTRAP_ADMIN_EMAIL=
+BOOTSTRAP_BOT_USERNAME=
+BOOTSTRAP_ADMIN_INVITE_TTL_HOURS=24
+BOOTSTRAP_ADMIN_INVITE_FORCE=false
+
 # Required usage policy versions. Changing either value requires users to
 # accept the policy again before protected bot functionality is available.
 BOT_POLICY_VERSION=2026-05-08
@@ -83,4 +90,3 @@ MESSAGE_MAX_RETRIES=1
 # acceptance and defaults to disabled.
 BOT_ANALYTICS_CONSENT_ENABLED=false
 BOT_TRAINING_CONSENT_ENABLED=false
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ RUN python -m pip install --no-cache-dir --upgrade pip \
 RUN useradd --system --create-home --home-dir /home/botforge botforge
 USER botforge
 
-CMD ["sh", "-c", "python -c 'from forge_bot.config import validate_settings; validate_settings()' && alembic upgrade head && python -m forge_bot.main"]
+CMD ["sh", "-c", "python -c 'from forge_bot.config import validate_settings; validate_settings()' && alembic upgrade head && python -m forge_bot.bootstrap_admin_invite && python -m forge_bot.main"]

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ NVIDIA_MODEL=nvidia/llama-3.1-nemotron-nano-8b-v1
 
 BOT_PROFILE=default_dev
 BOT_PROFILES_DIR=bot_profiles
+
+BOOTSTRAP_ADMIN_EMAIL=
+BOOTSTRAP_BOT_USERNAME=
+BOOTSTRAP_ADMIN_INVITE_TTL_HOURS=24
+BOOTSTRAP_ADMIN_INVITE_FORCE=false
 ```
 
 Notes:
@@ -115,6 +120,12 @@ Notes:
 - `BOT_PROFILE` selects the active bot-specific behavior. The default
   `default_dev` profile lives in `bot_profiles/default_dev/`.
 - `BOT_PROFILES_DIR` points to the directory that contains profile folders.
+- `BOOTSTRAP_ADMIN_EMAIL` and `BOOTSTRAP_BOT_USERNAME` optionally create the
+  first admin invite during Docker startup, after migrations run. Leave them
+  blank to disable the bootstrap. If an admin user already exists, no invite is
+  created.
+- `BOOTSTRAP_ADMIN_INVITE_FORCE=true` creates a fresh admin invite even when an
+  unused admin invite for the same email already exists.
 - Do not commit `.env`.
 
 ## Bot Profiles And Prompt Configuration
@@ -503,6 +514,22 @@ UPDATE users
 SET role = 'admin'
 WHERE username = '<bot_user>';
 ```
+
+Alternatively, let Docker startup create the first admin invite. Set these in
+`.env`, then run `docker compose up` and copy the printed invite link from the
+`botforge` logs:
+
+```env
+BOOTSTRAP_ADMIN_EMAIL=you@example.com
+BOOTSTRAP_BOT_USERNAME=<bot_username>
+BOOTSTRAP_ADMIN_INVITE_TTL_HOURS=24
+BOOTSTRAP_ADMIN_INVITE_FORCE=false
+```
+
+The startup bootstrap runs after migrations. It skips creation when an active
+admin user already exists, and it also skips when an unused admin invite for the
+same email is still valid. Set `BOOTSTRAP_ADMIN_INVITE_FORCE=true` only if you
+lost the original link and need a new one.
 
 Supported roles are `admin`, `professional`, and `user`. New users default to
 `user`; `professional` is reserved for future behavior and does not grant admin

--- a/src/forge_bot/bootstrap_admin_invite.py
+++ b/src/forge_bot/bootstrap_admin_invite.py
@@ -1,0 +1,206 @@
+"""Bootstrap helpers for creating the first admin invite in Docker."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from os import environ
+
+import psycopg
+
+from . import database
+
+logger = logging.getLogger(__name__)
+
+BOOTSTRAP_ADMIN_EMAIL = "BOOTSTRAP_ADMIN_EMAIL"
+BOOTSTRAP_BOT_USERNAME = "BOOTSTRAP_BOT_USERNAME"
+BOOTSTRAP_ADMIN_INVITE_TTL_HOURS = "BOOTSTRAP_ADMIN_INVITE_TTL_HOURS"
+BOOTSTRAP_ADMIN_INVITE_FORCE = "BOOTSTRAP_ADMIN_INVITE_FORCE"
+
+
+@dataclass(frozen=True)
+class BootstrapAdminInviteResult:
+    status: str
+    invite_link: str | None = None
+    app_link: str | None = None
+    reason: str | None = None
+
+
+def bootstrap_admin_invite_from_env(
+    env: Mapping[str, str] = environ,
+) -> BootstrapAdminInviteResult:
+    """Create the first admin invite when bootstrap env vars are configured."""
+    email = database.normalize_invite_email(env.get(BOOTSTRAP_ADMIN_EMAIL, ""))
+    if email is None:
+        return BootstrapAdminInviteResult(
+            "skipped",
+            reason=f"{BOOTSTRAP_ADMIN_EMAIL} is not set",
+        )
+
+    bot_username = _clean(env.get(BOOTSTRAP_BOT_USERNAME))
+    if bot_username is None:
+        return BootstrapAdminInviteResult(
+            "skipped",
+            reason=f"{BOOTSTRAP_BOT_USERNAME} is not set",
+        )
+
+    ttl_hours = _parse_positive_int(env.get(BOOTSTRAP_ADMIN_INVITE_TTL_HOURS))
+    force = _parse_bool(env.get(BOOTSTRAP_ADMIN_INVITE_FORCE))
+    return bootstrap_admin_invite(
+        email=email,
+        bot_username=bot_username,
+        ttl_hours=ttl_hours,
+        force=force,
+    )
+
+
+def bootstrap_admin_invite(
+    *,
+    email: str,
+    bot_username: str,
+    ttl_hours: int | None = None,
+    force: bool = False,
+) -> BootstrapAdminInviteResult:
+    """Create an admin invite unless an admin or pending invite already exists."""
+    if _has_active_admin_user():
+        return BootstrapAdminInviteResult(
+            "skipped",
+            reason="an active admin user already exists",
+        )
+
+    if not force and _has_pending_admin_invite(email):
+        return BootstrapAdminInviteResult(
+            "skipped",
+            reason=(
+                "an unused admin invite already exists for this email; set "
+                f"{BOOTSTRAP_ADMIN_INVITE_FORCE}=true to create another"
+            ),
+        )
+
+    invite = database.create_invite_token(
+        role="admin",
+        email=email,
+        ttl_hours=ttl_hours,
+        bot_username=bot_username,
+    )
+    if invite is None:
+        return BootstrapAdminInviteResult(
+            "error",
+            reason="database connection failed",
+        )
+
+    return BootstrapAdminInviteResult(
+        "created",
+        invite_link=invite.invite_link,
+        app_link=invite.app_link,
+    )
+
+
+def _has_active_admin_user() -> bool:
+    conn = database.conect_db()
+    if not conn:
+        return False
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute("""
+                SELECT id
+                FROM users
+                WHERE role = 'admin'
+                  AND deleted_at IS NULL
+                LIMIT 1
+                """)
+            return cursor.fetchone() is not None
+    except psycopg.Error:
+        logger.exception("bootstrap_admin_user_check_failed")
+        return False
+    finally:
+        conn.close()
+
+
+def _has_pending_admin_invite(email: str) -> bool:
+    conn = database.conect_db()
+    if not conn:
+        return False
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT id
+                FROM invite_tokens
+                WHERE role = 'admin'
+                  AND lower(email) = lower(%s)
+                  AND used_at IS NULL
+                  AND expires_at > CURRENT_TIMESTAMP
+                LIMIT 1
+                """,
+                (email,),
+            )
+            return cursor.fetchone() is not None
+    except psycopg.Error:
+        logger.exception("bootstrap_admin_invite_check_failed email=%s", email)
+        return False
+    finally:
+        conn.close()
+
+
+def _clean(value: str | None) -> str | None:
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _parse_positive_int(value: str | None) -> int | None:
+    cleaned = _clean(value)
+    if cleaned is None:
+        return None
+    try:
+        parsed = int(cleaned)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid %s value: %s",
+            BOOTSTRAP_ADMIN_INVITE_TTL_HOURS,
+            value,
+        )
+        return None
+    if parsed <= 0:
+        logger.warning(
+            "Ignoring non-positive %s value: %s",
+            BOOTSTRAP_ADMIN_INVITE_TTL_HOURS,
+            value,
+        )
+        return None
+    return parsed
+
+
+def _parse_bool(value: str | None) -> bool:
+    cleaned = _clean(value)
+    if cleaned is None:
+        return False
+    return cleaned.lower() in {"1", "true", "yes", "on"}
+
+
+def _report_result(result: BootstrapAdminInviteResult) -> None:
+    if result.status == "created":
+        print("Bootstrap admin invite created.")
+        if result.invite_link:
+            print(f"Invite link: {result.invite_link}")
+        if result.app_link:
+            print(f"Telegram app link: {result.app_link}")
+        return
+
+    if result.status == "skipped":
+        print(f"Bootstrap admin invite skipped: {result.reason}.")
+        return
+
+    print(f"Bootstrap admin invite failed: {result.reason}.")
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    _report_result(bootstrap_admin_invite_from_env())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bootstrap_admin_invite.py
+++ b/tests/test_bootstrap_admin_invite.py
@@ -1,0 +1,131 @@
+from datetime import datetime, timezone
+from typing import Any
+
+from forge_bot import bootstrap_admin_invite
+from forge_bot.database import InviteToken
+
+
+class FakeCursor:
+    def __init__(self, fetchone_result: dict[str, Any] | None) -> None:
+        self.fetchone_result = fetchone_result
+        self.statements: list[str] = []
+        self.params: list[tuple[Any, ...] | None] = []
+
+    def __enter__(self) -> "FakeCursor":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def execute(
+        self,
+        statement: str,
+        params: tuple[Any, ...] | None = None,
+    ) -> None:
+        self.statements.append(" ".join(statement.split()))
+        self.params.append(params)
+
+    def fetchone(self) -> dict[str, Any] | None:
+        return self.fetchone_result
+
+
+class FakeConnection:
+    def __init__(self, fetchone_result: dict[str, Any] | None) -> None:
+        self.cursor_obj = FakeCursor(fetchone_result)
+        self.closed = False
+
+    def cursor(self) -> FakeCursor:
+        return self.cursor_obj
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_bootstrap_admin_invite_from_env_skips_without_email(monkeypatch) -> None:
+    create_calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "forge_bot.bootstrap_admin_invite.database.create_invite_token",
+        lambda **kwargs: create_calls.append(kwargs),
+    )
+
+    result = bootstrap_admin_invite.bootstrap_admin_invite_from_env({})
+
+    assert result.status == "skipped"
+    assert "BOOTSTRAP_ADMIN_EMAIL" in str(result.reason)
+    assert create_calls == []
+
+
+def test_bootstrap_admin_invite_skips_when_admin_exists(monkeypatch) -> None:
+    connection = FakeConnection({"id": 1})
+    monkeypatch.setattr(
+        "forge_bot.bootstrap_admin_invite.database.conect_db",
+        lambda: connection,
+    )
+
+    result = bootstrap_admin_invite.bootstrap_admin_invite(
+        email="owner@example.com",
+        bot_username="test_bot",
+    )
+
+    assert result.status == "skipped"
+    assert result.reason == "an active admin user already exists"
+    assert connection.closed is True
+
+
+def test_bootstrap_admin_invite_skips_when_pending_invite_exists(monkeypatch) -> None:
+    connections = iter([FakeConnection(None), FakeConnection({"id": 2})])
+    monkeypatch.setattr(
+        "forge_bot.bootstrap_admin_invite.database.conect_db",
+        lambda: next(connections),
+    )
+
+    result = bootstrap_admin_invite.bootstrap_admin_invite(
+        email="owner@example.com",
+        bot_username="test_bot",
+    )
+
+    assert result.status == "skipped"
+    assert "unused admin invite already exists" in str(result.reason)
+
+
+def test_bootstrap_admin_invite_creates_admin_invite(monkeypatch) -> None:
+    connections = iter([FakeConnection(None), FakeConnection(None)])
+    create_calls: list[dict[str, Any]] = []
+
+    def create_invite_token(**kwargs: Any) -> InviteToken:
+        create_calls.append(kwargs)
+        return InviteToken(
+            raw_token="raw",
+            token_hash="hash",
+            role="admin",
+            email=kwargs["email"],
+            expires_at=datetime.now(timezone.utc),
+            invite_link="https://t.me/test_bot?start=raw",
+            app_link="tg://resolve?domain=test_bot&start=raw",
+        )
+
+    monkeypatch.setattr(
+        "forge_bot.bootstrap_admin_invite.database.conect_db",
+        lambda: next(connections),
+    )
+    monkeypatch.setattr(
+        "forge_bot.bootstrap_admin_invite.database.create_invite_token",
+        create_invite_token,
+    )
+
+    result = bootstrap_admin_invite.bootstrap_admin_invite(
+        email="owner@example.com",
+        bot_username="test_bot",
+        ttl_hours=24,
+    )
+
+    assert result.status == "created"
+    assert result.invite_link == "https://t.me/test_bot?start=raw"
+    assert create_calls == [
+        {
+            "role": "admin",
+            "email": "owner@example.com",
+            "ttl_hours": 24,
+            "bot_username": "test_bot",
+        }
+    ]


### PR DESCRIPTION
Closes #55.

## Summary
- Add an optional `forge_bot.bootstrap_admin_invite` startup module that creates the first admin invite after migrations run.
- Wire the bootstrap into the Docker startup command before `forge_bot.main`.
- Document the `BOOTSTRAP_ADMIN_*` settings in `.env.example` and README.
- Add focused tests for disabled bootstrap, existing admin skip, pending invite skip, and invite creation.

## Behavior
The bootstrap only runs when both `BOOTSTRAP_ADMIN_EMAIL` and `BOOTSTRAP_BOT_USERNAME` are configured. It skips creating a new invite if an active admin already exists, and avoids duplicate pending invites for the same email unless `BOOTSTRAP_ADMIN_INVITE_FORCE=true` is set.

## Validation
- `.venv/bin/ruff check src/forge_bot/bootstrap_admin_invite.py tests/test_bootstrap_admin_invite.py`
- `.venv/bin/pytest tests/test_config.py tests/test_bootstrap_admin_invite.py`