### PR TITLE
Nutrition bot epic: active plans, orchestration, and memory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ TELEGRAM_TOKEN=<telegram_bot_token>
 # Runtime environment. Keep development locally; use production for beta.
 # Production mode rejects documented development secrets at startup.
 BOTFORGE_ENV=development
+# Default timezone for relative dates such as "hoy", "mañana" or "esta noche".
+BOT_TIMEZONE=Europe/Madrid
 
 # BotForge database configuration.
 # In Docker Compose, DB_HOST must be the PostgreSQL service name.
@@ -22,7 +24,7 @@ OLLAMA_HOST=http://ollama:11434
 # the bot tries to use another at runtime.
 OLLAMA_MODEL=gemma3:4b
 # Maximum seconds to wait for a single AI response before sending fallback text.
-AI_TIMEOUT_SECONDS=60
+AI_TIMEOUT_SECONDS=300
 # Safety cap for long model replies sent back to Telegram.
 AI_MAX_RESPONSE_CHARS=4000
 
@@ -39,6 +41,12 @@ LLM_FALLBACK_QUEUE_WAIT_SECONDS=100
 NVIDIA_API_KEY=<nvidia_api_key>
 NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
 NVIDIA_MODEL=nvidia/llama-3.3-nemotron-super-49b-v1.5
+
+# Nutrition chain routing. This first step receives only compact plan options
+# such as situation and moment keys, then normalizes free text into JSON before
+# the final answer model receives the selected meal context.
+NUTRITION_NORMALIZER_PROVIDER=nvidia
+NUTRITION_NORMALIZER_MODEL=nvidia/llama-3.3-nemotron-super-49b-v1.5
 
 # Abuse prevention and AI capacity limits. These are in-memory and reset when
 # the bot process restarts.
@@ -59,6 +67,13 @@ MEMORY_COMPACTION_TRIGGER_MESSAGES=6
 MEMORY_COMPACTION_SOURCE_MESSAGES=5
 MEMORY_MAX_MESSAGE_CHARS=4000
 MEMORY_COMPACTED_MAX_CHARS=2000
+
+# Debug conversation transcripts. Disabled by default. When enabled in Docker
+# Compose, transcripts are written to ./debug_conversations on the host.
+DEBUG_CONVERSATION_LOG_ENABLED=false
+DEBUG_CONVERSATION_LOG_DIR=/home/botforge/debug_conversations
+# Raw transcript logging is blocked in production unless this is explicit.
+DEBUG_CONVERSATION_LOG_ALLOW_PRODUCTION=false
 
 # Active bot profile configuration.
 # Add new profiles under bot_profiles/<profile_id>/profile.json.

--- a/.env.example
+++ b/.env.example
@@ -26,9 +26,10 @@ AI_TIMEOUT_SECONDS=60
 # Safety cap for long model replies sent back to Telegram.
 AI_MAX_RESPONSE_CHARS=4000
 
-# LLM provider routing. BotForge tries Ollama first, then uses NVIDIA NIM when
-# Ollama fails or when a request waited too long before processing started.
-LLM_PRIMARY_PROVIDER=ollama
+# LLM provider routing. Use "profile" so each bot profile selects its own
+# primary provider. Set "ollama" or "nvidia" here only to force a global
+# override for every profile.
+LLM_PRIMARY_PROVIDER=profile
 LLM_FALLBACK_PROVIDER=nvidia
 LLM_FALLBACK_QUEUE_WAIT_SECONDS=100
 
@@ -37,7 +38,7 @@ LLM_FALLBACK_QUEUE_WAIT_SECONDS=100
 # development; the bot only requires it if fallback is actually used.
 NVIDIA_API_KEY=<nvidia_api_key>
 NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
-NVIDIA_MODEL=nvidia/llama-3.1-nemotron-nano-8b-v1
+NVIDIA_MODEL=nvidia/llama-3.3-nemotron-super-49b-v1.5
 
 # Abuse prevention and AI capacity limits. These are in-memory and reset when
 # the bot process restarts.

--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ venv.bak/
 
 # Local operational artifacts
 backups/
+debug_conversations/
 *.dump
 
 # Spyder project settings

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ bot_profiles/
   default_dev/
     profile.json
     system_prompt.md
+  nutrition/
+    profile.json
+    system_prompt.md
+    docs/
 ```
 
 `profile.json` defines the assistant identity, model choice, feature flags,
@@ -171,6 +175,18 @@ To create a new bot profile:
 6. Set `BOT_PROFILE=<new_profile_id>` in `.env`.
 7. If the model changed, set `OLLAMA_MODEL` to the same value so Compose pulls it.
 8. Restart the bot container.
+
+The built-in nutrition profile can be enabled with:
+
+```env
+BOT_PROFILE=nutrition
+```
+
+Its product notes, user journeys, data contracts, and roadmap live under
+`bot_profiles/nutrition/docs/`. The first version is intentionally conservative:
+it helps interpret a plan provided by the user, asks for missing context before
+giving quantities, and avoids inventing diets, medical advice, macros, or JSON
+details unless the user explicitly asks.
 
 The prompt assembler in `src/forge_bot/prompting.py` builds prompts in a
 deterministic order: bot system prompt and rules first, optional memory, recent

--- a/README.md
+++ b/README.md
@@ -821,6 +821,13 @@ Tests (CI: `tests.yml`):
 python -m pytest
 ```
 
+Opt-in live tests can validate NVIDIA connectivity and model behavior with the
+real API. They are skipped by default to avoid consuming provider quota:
+
+```bash
+RUN_LIVE_NVIDIA_TESTS=1 python -m pytest tests/test_nutrition_live_nvidia.py
+```
+
 ## Current Limitations
 
 - Conversation memory is bounded to the latest configured raw messages plus a

--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ DB_PORT=5432
 OLLAMA_HOST=http://ollama:11434
 OLLAMA_MODEL=gemma3:4b
 
-LLM_PRIMARY_PROVIDER=ollama
+LLM_PRIMARY_PROVIDER=profile
 LLM_FALLBACK_PROVIDER=nvidia
 LLM_FALLBACK_QUEUE_WAIT_SECONDS=100
 NVIDIA_API_KEY=
 NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
-NVIDIA_MODEL=nvidia/llama-3.1-nemotron-nano-8b-v1
+NVIDIA_MODEL=nvidia/llama-3.3-nemotron-super-49b-v1.5
 
 BOT_PROFILE=default_dev
 BOT_PROFILES_DIR=bot_profiles
@@ -104,14 +104,14 @@ Notes:
   using this stack outside your local machine.
 - `DB_HOST` must be `postgres` when running inside Docker Compose.
 - `OLLAMA_HOST` must be `http://ollama:11434` when running inside Docker Compose.
-- `OLLAMA_MODEL` is used by the `ollama-pull` container. Keep it aligned with
-  the active profile's `llm_model`. The default is `gemma3:4b`, a balanced
-  Gemma model for local development on machines with limited RAM. If these
-  values drift, Compose can pull one model while the bot tries to use another
-  at runtime.
-- `LLM_PRIMARY_PROVIDER=ollama` keeps local inference as the first choice.
-  `LLM_FALLBACK_PROVIDER=nvidia` enables fallback through NVIDIA NIM when
-  Ollama errors or when the lifecycle queue wait exceeds
+- `OLLAMA_MODEL` is used only by the `ollama-pull` container. Keep it aligned
+  with the active profile's `llm_model` only when that profile uses Ollama.
+  The default is `gemma3:4b`, a balanced Gemma model for local development on
+  machines with limited RAM.
+- `LLM_PRIMARY_PROVIDER=profile` lets each bot profile select its own provider.
+  Set it to `ollama` or `nvidia` only when you want to force one provider for
+  every profile. `LLM_FALLBACK_PROVIDER=nvidia` enables fallback through NVIDIA
+  NIM when the primary provider errors or when the lifecycle queue wait exceeds
   `LLM_FALLBACK_QUEUE_WAIT_SECONDS`.
 - `NVIDIA_BASE_URL` defaults to NVIDIA's OpenAI-compatible hosted NIM endpoint,
   `https://integrate.api.nvidia.com/v1`. Choose `NVIDIA_MODEL` from the current
@@ -171,9 +171,10 @@ To create a new bot profile:
 2. Update `profile.json`, making sure `bot_profile_id` matches the folder name.
 3. Edit `system_prompt.md` with the assistant's role and behavior.
 4. Put domain-specific rules in `domain_rules`.
-5. Set `llm_model` to the Ollama model the bot should use.
+5. Set `llm_provider` and `llm_model` to the provider/model the bot should use.
 6. Set `BOT_PROFILE=<new_profile_id>` in `.env`.
-7. If the model changed, set `OLLAMA_MODEL` to the same value so Compose pulls it.
+7. If the profile uses Ollama and the model changed, set `OLLAMA_MODEL` to the
+   same value so Compose pulls it.
 8. Restart the bot container.
 
 The built-in nutrition profile can be enabled with:
@@ -369,23 +370,26 @@ Telegram chat alone. Users can remove their recent and compacted memory with
 
 ## 7. LLM Provider Fallback
 
-BotForge uses a small provider abstraction around model calls. The primary
-provider is Ollama by default. If Ollama is unavailable or returns an error, the
-engine tries the configured fallback provider once and sends only that single
-answer to the user.
+BotForge uses a small provider abstraction around model calls. By default,
+`LLM_PRIMARY_PROVIDER=profile`, so the active bot profile selects the primary
+provider with its `llm_provider` field. The `default_dev` profile uses Ollama;
+the `nutrition` profile uses NVIDIA NIM. Set `LLM_PRIMARY_PROVIDER=ollama` or
+`LLM_PRIMARY_PROVIDER=nvidia` only to force a global override. If the primary
+provider is unavailable or returns an error, the engine tries the configured
+fallback provider once and sends only that single answer to the user.
 
 The request lifecycle also records how long a message waited before processing
 started. When that wait is greater than `LLM_FALLBACK_QUEUE_WAIT_SECONDS`
 (default: 100), BotForge selects the fallback provider immediately instead of
 starting local inference.
 
-NVIDIA NIM fallback is configured with:
+NVIDIA NIM is configured with:
 
 ```env
 LLM_FALLBACK_PROVIDER=nvidia
 NVIDIA_API_KEY=<nvidia_api_key>
 NVIDIA_BASE_URL=https://integrate.api.nvidia.com/v1
-NVIDIA_MODEL=nvidia/llama-3.1-nemotron-nano-8b-v1
+NVIDIA_MODEL=nvidia/llama-3.3-nemotron-super-49b-v1.5
 ```
 
 The NVIDIA API Catalog exposes hosted NIM language models through
@@ -817,8 +821,9 @@ python -m pytest
   facts beyond what was compacted.
 - Telegram updates that were never delivered to the bot and are older than
   Telegram's pending-update retention window cannot be recovered.
-- The default AI profile uses `gemma3:4b`. Change the active profile's
-  `llm_model` to use a different runtime model.
+- Provider/model selection is profile-driven by default. `default_dev` uses
+  Ollama with `gemma3:4b`; `nutrition` uses NVIDIA NIM with the configured
+  `NVIDIA_MODEL`.
 - The application uses Telegram polling, so it should run as one active bot
   container per Telegram token.
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ bot_profiles/
   nutrition/
     profile.json
     system_prompt.md
+    demo_plan.json
     docs/
 ```
 
@@ -188,6 +189,12 @@ Its product notes, user journeys, data contracts, and roadmap live under
 it helps interpret a plan provided by the user, asks for missing context before
 giving quantities, and avoids inventing diets, medical advice, macros, or JSON
 details unless the user explicitly asks.
+
+For local validation before user-level persistence exists, the nutrition profile
+also loads `bot_profiles/nutrition/demo_plan.json` as read-only profile context.
+That demo plan includes `situaciones` plus `comidas`, so the bot can answer
+questions such as "hoy tengo crossfit, que como al mediodia?" by resolving the
+day situation and meal moment to the matching food block.
 
 The prompt assembler in `src/forge_bot/prompting.py` builds prompts in a
 deterministic order: bot system prompt and rules first, optional memory, recent

--- a/README.md
+++ b/README.md
@@ -191,14 +191,13 @@ giving quantities, and avoids inventing diets, medical advice, macros, or JSON
 details unless the user explicitly asks.
 
 For local validation before user-level persistence exists, the nutrition profile
-also loads `bot_profiles/nutrition/demo_plan.json` as read-only profile context.
-That demo plan includes `situaciones` plus `comidas`, so the bot can answer
-questions such as "hoy tengo crossfit, que como al mediodia?" by resolving the
-day situation and meal moment to the matching food block.
+uses `bot_profiles/nutrition/demo_plan.json` through `nutrition_plan_file`. The
+runtime loads that plan locally, resolves `situacion + momento` to a matching
+`comida` block, and sends only the resolved chunk to the LLM.
 
 The prompt assembler in `src/forge_bot/prompting.py` builds prompts in a
-deterministic order: bot system prompt and rules first, optional memory, recent
-conversation messages, then the current user message.
+deterministic order: bot system prompt and rules first, optional memory/recent
+conversation context inside the system message, then the current user message.
 
 When memory is enabled globally and in the active bot profile, BotForge stores a
 bounded recent window per internal user and bot profile. The default window keeps

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ NVIDIA_MODEL=nvidia/llama-3.3-nemotron-super-49b-v1.5
 
 BOT_PROFILE=default_dev
 BOT_PROFILES_DIR=bot_profiles
+BOT_TIMEZONE=Europe/Madrid
 
 BOOTSTRAP_ADMIN_EMAIL=
 BOOTSTRAP_BOT_USERNAME=
@@ -120,6 +121,9 @@ Notes:
 - `BOT_PROFILE` selects the active bot-specific behavior. The default
   `default_dev` profile lives in `bot_profiles/default_dev/`.
 - `BOT_PROFILES_DIR` points to the directory that contains profile folders.
+- `BOT_TIMEZONE` is the default IANA timezone used for relative dates such as
+  "today", "tomorrow", and "tonight". Set it to the main timezone of the bot's
+  users until per-user timezones exist.
 - `BOOTSTRAP_ADMIN_EMAIL` and `BOOTSTRAP_BOT_USERNAME` optionally create the
   first admin invite during Docker startup, after migrations run. Leave them
   blank to disable the bootstrap. If an admin user already exists, no invite is
@@ -142,7 +146,6 @@ bot_profiles/
   nutrition/
     profile.json
     system_prompt.md
-    demo_plan.json
     docs/
 ```
 
@@ -166,6 +169,21 @@ memory_enabled
 analytics_enabled
 ```
 
+Optional profile fields include:
+
+```text
+memory_backend
+context_files
+```
+
+`memory_backend` defaults to `postgres`. The nutrition profile currently uses
+`langchain_postgres`, which stores recent conversation turns with LangChain's
+maintained `PostgresChatMessageHistory` implementation. BotForge still owns
+account scoping, privacy deletion, and compact summaries, but raw chat history
+is handled by the LangChain PostgreSQL integration instead of BotForge-specific
+message tables. This lets each bot profile swap the prompt-facing memory
+implementation without changing Telegram routing or the LLM engine.
+
 To create a new bot profile:
 
 1. Copy `bot_profiles/default_dev/` to `bot_profiles/<new_profile_id>/`.
@@ -173,10 +191,11 @@ To create a new bot profile:
 3. Edit `system_prompt.md` with the assistant's role and behavior.
 4. Put domain-specific rules in `domain_rules`.
 5. Set `llm_provider` and `llm_model` to the provider/model the bot should use.
-6. Set `BOT_PROFILE=<new_profile_id>` in `.env`.
-7. If the profile uses Ollama and the model changed, set `OLLAMA_MODEL` to the
+6. Set `memory_enabled` and, if needed, `memory_backend`.
+7. Set `BOT_PROFILE=<new_profile_id>` in `.env`.
+8. If the profile uses Ollama and the model changed, set `OLLAMA_MODEL` to the
    same value so Compose pulls it.
-8. Restart the bot container.
+9. Restart the bot container.
 
 The built-in nutrition profile can be enabled with:
 
@@ -190,10 +209,16 @@ it helps interpret a plan provided by the user, asks for missing context before
 giving quantities, and avoids inventing diets, medical advice, macros, or JSON
 details unless the user explicitly asks.
 
-For local validation before user-level persistence exists, the nutrition profile
-uses `bot_profiles/nutrition/demo_plan.json` through `nutrition_plan_file`. The
-runtime loads that plan locally, resolves `situacion + momento` to a matching
-`comida` block, and sends only the resolved chunk to the LLM.
+Nutrition plans are user data and live in PostgreSQL, not in the repository.
+Users can send `/set_plan` and then upload `situaciones.json` and `comidas.json`
+as Telegram documents without captions; a combined JSON is also accepted. The
+bot validates the parts, stores them as the user's active plan once both are
+present, resolves
+`situacion + momento` to a matching `comida` block, and sends only the resolved
+chunk to the LLM.
+Users can run `/get_plan` for a short summary, `/get_plan situaciones` or
+`/get_plan comidas` to export the stored JSON documents, and `/get_plan all` to
+export a combined review file.
 
 The prompt assembler in `src/forge_bot/prompting.py` builds prompts in a
 deterministic order: bot system prompt and rules first, optional memory/recent
@@ -204,8 +229,10 @@ bounded recent window per internal user and bot profile. The default window keep
 the last 10 user/assistant messages. After 6 unsummarized messages are present,
 the bot asks the configured LLM to compact the oldest 5 into a durable summary
 of important dates, tastes, preferences, priorities, goals, and constraints. The
-process keeps a per-user/profile cache in memory after the first database load,
-so normal follow-up prompts do not reread the same context from PostgreSQL.
+LangChain-backed backend reads bounded database windows instead of loading the
+whole chat history for every prompt. Profiles can choose the prompt-facing
+memory backend with `memory_backend`; supported values are `postgres` and
+`langchain_postgres`. Unsupported backend names fail profile loading.
 
 ## 2. Build And Start The Stack
 
@@ -215,7 +242,13 @@ docker compose up -d --build
 
 This starts PostgreSQL, starts Ollama, pulls the configured model, and starts the
 BotForge container after the dependencies are healthy. The BotForge container
-runs database migrations before starting the Telegram polling process.
+runs database migrations before starting the Telegram polling process. The base
+Compose file stays production-like. For local bind mounts while developing, add
+the dev overlay explicitly:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+```
 
 To use a different Ollama model for this command only, set `OLLAMA_MODEL` before
 the Compose command:
@@ -373,6 +406,39 @@ MEMORY_COMPACTED_MAX_CHARS=2000
 Memory is scoped by internal `users.id` and `bot_profile_id`, not by a shared
 Telegram chat alone. Users can remove their recent and compacted memory with
 `/memory_clear`; broader account deletion also clears memory.
+
+Each profile may also set `memory_backend`:
+
+```json
+{
+  "memory_enabled": true,
+  "memory_backend": "langchain_postgres"
+}
+```
+
+Supported backends:
+
+- `postgres`: existing BotForge PostgreSQL recent-turn and compaction memory.
+- `langchain_postgres`: LangChain's maintained
+  `PostgresChatMessageHistory` PostgreSQL implementation for raw chat history,
+  plus BotForge's user/profile mapping and compact summary table.
+
+The backend is selected per bot profile, so a simple bot can keep `postgres`
+while a domain bot such as `nutrition` can opt into the LangChain adapter.
+
+For local debugging, BotForge can also write a plain-text transcript per
+user/profile. This is disabled by default and should be used only during
+development because it stores raw user and assistant text on disk:
+
+```env
+DEBUG_CONVERSATION_LOG_ENABLED=true
+DEBUG_CONVERSATION_LOG_DIR=/home/botforge/debug_conversations
+DEBUG_CONVERSATION_LOG_ALLOW_PRODUCTION=false
+```
+
+With Docker Compose, that path is mounted to `./debug_conversations/` on the
+host and ignored by git. Production startup rejects raw transcript logging
+unless `DEBUG_CONVERSATION_LOG_ALLOW_PRODUCTION=true` is set explicitly.
 
 ## 7. LLM Provider Fallback
 
@@ -778,7 +844,7 @@ You can use the same Docker stack for development:
 
 ```bash
 cp .env.example .env
-docker compose up -d postgres ollama ollama-pull
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d postgres ollama ollama-pull
 python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
@@ -829,9 +895,10 @@ RUN_LIVE_NVIDIA_TESTS=1 python -m pytest tests/test_nutrition_live_nvidia.py
 
 ## Current Limitations
 
-- Conversation memory is bounded to the latest configured raw messages plus a
-  compacted summary. It is not vector search and does not retrieve arbitrary old
-  facts beyond what was compacted.
+- Conversation memory is pluggable per bot profile, but the current storage is
+  still bounded to the latest configured raw messages plus a compacted summary.
+  It is not vector search and does not retrieve arbitrary old facts beyond what
+  was compacted.
 - Telegram updates that were never delivered to the bot and are older than
   Telegram's pending-update retention window cannot be recovered.
 - Provider/model selection is profile-driven by default. `default_dev` uses

--- a/bot_profiles/nutrition/demo_plan.json
+++ b/bot_profiles/nutrition/demo_plan.json
@@ -7,6 +7,72 @@
     "No mostrar macros salvo que el usuario los pida.",
     "Si falta tipo de dia o momento, preguntar una aclaracion breve."
   ],
+  "momentos": {
+    "desayuno": {
+      "label": "Desayuno",
+      "aliases": [
+        "desayuno",
+        "desayunar",
+        "primera comida"
+      ]
+    },
+    "media_manana": {
+      "label": "Media mañana",
+      "aliases": [
+        "media mañana",
+        "media manana",
+        "tentempie de mañana",
+        "tentempie de manana",
+        "snack de mañana",
+        "snack de manana"
+      ]
+    },
+    "almuerzo": {
+      "label": "Almuerzo",
+      "aliases": [
+        "almuerzo",
+        "comida",
+        "comer",
+        "mediodia",
+        "medio dia"
+      ]
+    },
+    "pre_entreno": {
+      "label": "Pre entreno",
+      "aliases": [
+        "pre entreno",
+        "preentreno",
+        "antes de entrenar",
+        "antes del entreno"
+      ]
+    },
+    "post_entreno": {
+      "label": "Post entreno",
+      "aliases": [
+        "post entreno",
+        "postentreno",
+        "despues de entrenar",
+        "despues del entreno"
+      ]
+    },
+    "merienda": {
+      "label": "Merienda",
+      "aliases": [
+        "merienda",
+        "merendar",
+        "media tarde"
+      ]
+    },
+    "cena": {
+      "label": "Cena",
+      "aliases": [
+        "cena",
+        "cenar",
+        "ceno",
+        "noche"
+      ]
+    }
+  },
   "situaciones": {
     "crossfit": {
       "label": "CrossFit o entrenamiento de fuerza alta intensidad",

--- a/bot_profiles/nutrition/demo_plan.json
+++ b/bot_profiles/nutrition/demo_plan.json
@@ -1,0 +1,1279 @@
+{
+  "plan_id": "demo_nutrition_plan_v1",
+  "description": "Plan demo cargado desde el repo para validar respuestas del bot nutricionista antes de persistencia por usuario.",
+  "usage_notes": [
+    "situaciones enruta tipo de dia + momento a una clave de comidas.",
+    "comidas contiene cantidades y opciones; no inventar cantidades fuera de estos bloques.",
+    "No mostrar macros salvo que el usuario los pida.",
+    "Si falta tipo de dia o momento, preguntar una aclaracion breve."
+  ],
+  "situaciones": {
+    "crossfit": {
+      "label": "CrossFit o entrenamiento de fuerza alta intensidad",
+      "aliases": [
+        "crossfit",
+        "fuerza",
+        "gym",
+        "gimnasio",
+        "entrenamiento de fuerza",
+        "hiit"
+      ],
+      "tipo_dia": "entrenamiento_fuerza_por_la_tarde",
+      "suplementacion": [
+        "10g de creatina monohidrato creapure"
+      ],
+      "momentos": {
+        "desayuno": "comida_1",
+        "almuerzo": "comida_2",
+        "comida": "comida_2",
+        "mediodia": "comida_2",
+        "merienda": "comida_0",
+        "cena": "comida_3"
+      }
+    },
+    "futbol": {
+      "label": "Futbol",
+      "aliases": [
+        "futbol",
+        "partido",
+        "entreno de futbol",
+        "futbito"
+      ],
+      "tipo_dia": "entrenamiento_de_futbol",
+      "suplementacion": [
+        "10g de creatina monohidrato creapure"
+      ],
+      "momentos": {
+        "desayuno": "comida_1",
+        "almuerzo": "comida_4",
+        "comida": "comida_4",
+        "mediodia": "comida_4",
+        "merienda": "comida_0",
+        "cena": "comida_3"
+      }
+    },
+    "ciclismo": {
+      "label": "Ciclismo",
+      "aliases": [
+        "ciclismo",
+        "bici",
+        "bicicleta",
+        "salida en bici",
+        "rodillo"
+      ],
+      "tipo_dia": "entrenamiento_resistencia",
+      "suplementacion": [
+        "10g de creatina monohidrato creapure"
+      ],
+      "momentos": {
+        "desayuno": "comida_1",
+        "almuerzo": "comida_2",
+        "comida": "comida_2",
+        "mediodia": "comida_2",
+        "merienda": "comida_0",
+        "cena": "comida_3"
+      }
+    },
+    "atletismo": {
+      "label": "Atletismo o carrera",
+      "aliases": [
+        "atletismo",
+        "correr",
+        "running",
+        "carrera",
+        "series",
+        "tirada"
+      ],
+      "tipo_dia": "entrenamiento_resistencia",
+      "suplementacion": [
+        "10g de creatina monohidrato creapure"
+      ],
+      "momentos": {
+        "desayuno": "comida_1",
+        "almuerzo": "comida_2",
+        "comida": "comida_2",
+        "mediodia": "comida_2",
+        "merienda": "comida_0",
+        "cena": "comida_3"
+      }
+    },
+    "no_entreno": {
+      "label": "Dia sin entrenamiento",
+      "aliases": [
+        "no entreno",
+        "descanso",
+        "rest day",
+        "sin entrenar",
+        "no_entreno"
+      ],
+      "tipo_dia": "no_entreno",
+      "suplementacion": [
+        "10g de creatina monohidrato creapure"
+      ],
+      "momentos": {
+        "desayuno": "comida_1",
+        "almuerzo": "comida_5",
+        "comida": "comida_5",
+        "mediodia": "comida_5",
+        "merienda": "comida_0",
+        "cena": "comida_3"
+      }
+    }
+  },
+  "comidas": {
+    "comida_0": {
+      "descripcion": "Merienda simple",
+      "macros_plan": {
+        "codigos": {
+          "actual": "0.2.0"
+        },
+        "interpretacion": {
+          "actual": {
+            "hidratos_g": 0,
+            "proteina_g": 20,
+            "grasa_g": 0
+          }
+        }
+      },
+      "and": [
+        {
+          "nombre": "proteina",
+          "or": [
+            "25g de proteína Whey"
+          ]
+        }
+      ]
+    },
+    "comida_1": {
+      "descripcion": "Elige una de las siguientes opciones",
+      "macros_plan": {
+        "codigos": {
+          "anterior": "4.2.1,5",
+          "actual": "4.2.2"
+        },
+        "interpretacion": {
+          "anterior": {
+            "hidratos_g": 40,
+            "proteina_g": 20,
+            "grasa_g": 15
+          },
+          "actual": {
+            "hidratos_g": 40,
+            "proteina_g": 20,
+            "grasa_g": 20
+          }
+        }
+      },
+      "or": [
+        {
+          "nombre": "pan_proteina_grasa",
+          "and": [
+            {
+              "nombre": "pan",
+              "or": [
+                "80g de pan integral"
+              ]
+            },
+            {
+              "nombre": "proteina",
+              "or": [
+                "120g de pavo",
+                "110g de jamón cocido",
+                "2 latas de atún al natural",
+                "60g de lomo embuchado",
+                "80g de jamón serrano sin veta"
+              ]
+            },
+            {
+              "nombre": "grasa",
+              "or": [
+                "2 cucharadas soperas de aceite de oliva (20g)",
+                "32g de frutos secos",
+                "70g de queso Philadelphia Original",
+                "40g de crema de cacahuete",
+                "160g de aguacate",
+                "20g de mantequilla"
+              ]
+            }
+          ]
+        },
+        {
+          "nombre": "leche_pan_proteina_grasa",
+          "and": [
+            {
+              "nombre": "leche",
+              "or": [
+                "220ml de leche entera"
+              ]
+            },
+            {
+              "nombre": "pan",
+              "or": [
+                "60g de pan integral"
+              ]
+            },
+            {
+              "nombre": "proteina",
+              "or": [
+                "90g de pavo",
+                "70g de jamón cocido",
+                "1.5 latas de atún al natural",
+                "45g de lomo embuchado",
+                "60g de jamón serrano sin veta"
+              ]
+            },
+            {
+              "nombre": "grasa",
+              "or": [
+                "1.5 cucharadas soperas de aceite de oliva (15g)",
+                "24g de frutos secos",
+                "50g de queso Philadelphia Original",
+                "30g de crema de cacahuete",
+                "120g de aguacate"
+              ]
+            }
+          ]
+        },
+        {
+          "nombre": "pan_proteina_grasa_queso_curado",
+          "and": [
+            {
+              "nombre": "pan",
+              "or": [
+                "80g de pan integral"
+              ]
+            },
+            {
+              "nombre": "proteina",
+              "or": [
+                "90g de pavo",
+                "70g de jamón cocido",
+                "1.5 latas de atún al natural",
+                "45g de lomo embuchado",
+                "60g de jamón serrano sin veta"
+              ]
+            },
+            {
+              "nombre": "grasa",
+              "or": [
+                "1 cucharada sopera de aceite de oliva (10g)",
+                "16g de frutos secos",
+                "35g de queso Philadelphia Original",
+                "20g de crema de cacahuete",
+                "80g de aguacate"
+              ]
+            },
+            {
+              "nombre": "queso",
+              "or": [
+                "30g de queso curado"
+              ]
+            }
+          ]
+        },
+        {
+          "nombre": "pan_tomate_proteina_grasa_fruta",
+          "and": [
+            {
+              "nombre": "pan",
+              "or": [
+                "60g de pan integral"
+              ]
+            },
+            {
+              "nombre": "tomate",
+              "or": [
+                "tomate restregado opcional"
+              ]
+            },
+            {
+              "nombre": "proteina",
+              "or": [
+                "120g de pavo",
+                "2 latas de atún al natural",
+                "80g de jamón serrano sin veta",
+                "60g de lomo embuchado"
+              ]
+            },
+            {
+              "nombre": "grasa",
+              "or": [
+                "2 cucharadas soperas de aceite de oliva (20g)",
+                "32g de frutos secos",
+                "160g de aguacate"
+              ]
+            },
+            {
+              "nombre": "fruta",
+              "or": [
+                "80g de piña",
+                "80g de kiwi",
+                "80g de manzana verde",
+                "80g de ciruela",
+                "80g de granada",
+                "80g de higo",
+                "80g de mandarinas",
+                "80g de mango",
+                "80g de nectarina",
+                "80g de uva",
+                "135g de melocotón",
+                "135g de albaricoque",
+                "135g de frambuesa",
+                "135g de naranja",
+                "165g de fresas",
+                "165g de sandía",
+                "65g de plátano",
+                "100ml de zumo de naranja natural"
+              ]
+            }
+          ]
+        },
+        {
+          "nombre": "huevos_pan_fruta_grasa",
+          "and": [
+            {
+              "nombre": "huevos",
+              "or": [
+                "2 huevos"
+              ]
+            },
+            {
+              "nombre": "pan",
+              "or": [
+                "60g de pan integral"
+              ]
+            },
+            {
+              "nombre": "fruta",
+              "or": [
+                "80g de piña",
+                "80g de kiwi",
+                "80g de manzana verde",
+                "80g de ciruela",
+                "80g de granada",
+                "80g de higo",
+                "80g de mandarinas",
+                "80g de mango",
+                "80g de nectarina",
+                "80g de uva",
+                "135g de melocotón",
+                "135g de albaricoque",
+                "135g de frambuesa",
+                "135g de naranja",
+                "165g de fresas",
+                "165g de sandía",
+                "65g de plátano",
+                "100ml de zumo de naranja natural"
+              ]
+            },
+            {
+              "nombre": "grasa",
+              "or": [
+                "1 cucharada de aceite de oliva (10g)",
+                "16g de frutos secos",
+                "20g de crema de cacahuete"
+              ]
+            }
+          ]
+        },
+        {
+          "nombre": "creppe_harina_claras_grasa_queso",
+          "and": [
+            {
+              "nombre": "harina",
+              "or": [
+                "60g de harina de avena",
+                "60g de harina de trigo",
+                "60g de harina de arroz"
+              ]
+            },
+            {
+              "nombre": "claras",
+              "or": [
+                "200ml de clara de huevo Hacendado"
+              ]
+            },
+            {
+              "nombre": "grasa",
+              "or": [
+                "media cucharada sopera de aceite de oliva",
+                "8g de frutos secos",
+                "10g de crema de cacahuete"
+              ]
+            },
+            {
+              "nombre": "queso",
+              "or": [
+                "50g de queso Philadelphia Original"
+              ]
+            }
+          ]
+        },
+        {
+          "nombre": "bizcocho_avena_claras_grasa_cacao",
+          "and": [
+            {
+              "nombre": "avena",
+              "or": [
+                "60g de avena"
+              ]
+            },
+            {
+              "nombre": "claras",
+              "or": [
+                "200ml de clara de huevo"
+              ]
+            },
+            {
+              "nombre": "grasa",
+              "or": [
+                "40g de crema de cacahuete",
+                "32g de frutos secos"
+              ]
+            },
+            {
+              "nombre": "cacao",
+              "or": [
+                "10g de cacao puro desgrasado"
+              ]
+            }
+          ]
+        },
+        {
+          "nombre": "chocolate_yogures_fruta",
+          "and": [
+            {
+              "nombre": "chocolate",
+              "or": [
+                "40g de chocolate negro 90%"
+              ]
+            },
+            {
+              "nombre": "yogur",
+              "or": [
+                "2 yogures Hacendado +Prote arándanos"
+              ]
+            },
+            {
+              "nombre": "fruta",
+              "or": [
+                "160g de piña",
+                "160g de kiwi",
+                "160g de manzana verde",
+                "160g de ciruela",
+                "160g de granada",
+                "160g de higo",
+                "160g de mandarinas",
+                "160g de mango",
+                "160g de nectarina",
+                "160g de uva",
+                "270g de melocotón",
+                "270g de albaricoque",
+                "270g de frambuesa",
+                "270g de naranja",
+                "330g de fresas",
+                "330g de sandía",
+                "130g de plátano"
+              ]
+            }
+          ]
+        },
+        {
+          "nombre": "yogures_proteina_frutos_secos_fruta",
+          "and": [
+            {
+              "nombre": "yogur",
+              "or": [
+                "2 yogures de proteína natural Hacendado",
+                "2 yogures de proteína arándanos Hacendado",
+                "2 yogures de proteína fresa Hacendado",
+                "2 yogures de proteína mango Hacendado",
+                "2 yogures de proteína limón Hacendado"
+              ]
+            },
+            {
+              "nombre": "grasa",
+              "or": [
+                "32g de frutos secos"
+              ]
+            },
+            {
+              "nombre": "fruta",
+              "or": [
+                "160g de piña",
+                "160g de kiwi",
+                "160g de manzana verde",
+                "160g de ciruela",
+                "160g de granada",
+                "160g de higo",
+                "160g de mandarinas",
+                "160g de mango",
+                "160g de nectarina",
+                "160g de uva",
+                "270g de melocotón",
+                "270g de albaricoque",
+                "270g de frambuesa",
+                "270g de naranja",
+                "330g de fresas",
+                "330g de sandía",
+                "130g de plátano"
+              ]
+            }
+          ]
+        },
+        {
+          "nombre": "yogures_chocolate_frutos_secos_fruta",
+          "and": [
+            {
+              "nombre": "yogur",
+              "or": [
+                "2 yogures de proteínas chocolate Hacendado"
+              ]
+            },
+            {
+              "nombre": "grasa",
+              "or": [
+                "32g de frutos secos"
+              ]
+            },
+            {
+              "nombre": "fruta",
+              "or": [
+                "240g de piña",
+                "240g de kiwi",
+                "240g de manzana verde",
+                "240g de ciruela",
+                "240g de granada",
+                "240g de higo",
+                "240g de mandarinas",
+                "240g de mango",
+                "240g de nectarina",
+                "240g de uva",
+                "400g de melocotón",
+                "400g de albaricoque",
+                "400g de frambuesa",
+                "400g de naranja",
+                "500g de fresas",
+                "500g de sandía",
+                "200g de plátano"
+              ]
+            }
+          ]
+        },
+        {
+          "nombre": "leche_cereales_frutos_secos_proteina",
+          "and": [
+            {
+              "nombre": "leche",
+              "or": [
+                "220ml de leche entera"
+              ]
+            },
+            {
+              "nombre": "cereal",
+              "or": [
+                "60g de cereales de espelta"
+              ]
+            },
+            {
+              "nombre": "grasa",
+              "or": [
+                "32g de frutos secos"
+              ]
+            },
+            {
+              "nombre": "proteina",
+              "or": [
+                "90g de pavo",
+                "60g de jamón serrano sin veta",
+                "45g de lomo embuchado"
+              ]
+            }
+          ]
+        },
+        {
+          "nombre": "yogures_chocolate_frutos_secos_cereal",
+          "and": [
+            {
+              "nombre": "yogur",
+              "or": [
+                "2 yogures de proteínas chocolate"
+              ]
+            },
+            {
+              "nombre": "grasa",
+              "or": [
+                "32g de frutos secos"
+              ]
+            },
+            {
+              "nombre": "cereal",
+              "or": [
+                "45g de corn flakes",
+                "45g de avena"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "comida_2": {
+      "descripcion": "Elige y combina. E.F",
+      "macros_plan": {
+        "codigos": {
+          "anterior": "4.9.2",
+          "actual": "3.9.2"
+        },
+        "interpretacion": {
+          "anterior": {
+            "hidratos_g": 40,
+            "proteina_g": 90,
+            "grasa_g": 20
+          },
+          "actual": {
+            "hidratos_g": 30,
+            "proteina_g": 90,
+            "grasa_g": 20
+          }
+        }
+      },
+      "and": [
+        {
+          "nombre": "grasas",
+          "or": [
+            "Cocinar con 2 cucharadas soperas de aceite de oliva (20g)",
+            "160g de aguacate",
+            "80g de aceitunas"
+          ]
+        },
+        {
+          "nombre": "hidratos",
+          "and": [
+            {
+              "nombre": "verdura",
+              "or": [
+                "verdura hasta 375g"
+              ]
+            },
+            {
+              "nombre": "fuente_hidrato",
+              "or": [
+                "30g de arroz integral",
+                "30g de pasta integral",
+                "140g de patata",
+                "100g de boniato",
+                "40g de legumbres",
+                "40g de pan integral",
+                "160g de piña",
+                "160g de kiwi",
+                "160g de manzana verde",
+                "160g de ciruela",
+                "160g de granada",
+                "160g de higo",
+                "160g de mandarinas",
+                "160g de mango",
+                "160g de nectarina",
+                "160g de uva",
+                "270g de melocotón",
+                "270g de albaricoque",
+                "270g de frambuesa",
+                "270g de naranja",
+                "330g de fresas",
+                "330g de sandía",
+                "130g de plátano"
+              ]
+            }
+          ]
+        },
+        {
+          "nombre": "proteinas",
+          "or": [
+            {
+              "nombre": "opcion_1",
+              "or": [
+                "360g de pechuga de pollo",
+                "360g de pavo",
+                "360g de ternera",
+                "360g de conejo",
+                "360g de cualquier carne magra",
+                "450g de solomillo de cerdo",
+                "360g de lomo de cerdo",
+                "360g de muslo de pollo",
+                "360g de cordero",
+                "360g de secreto de cerdo",
+                "360g de presa de cerdo",
+                "360g de cualquier carne grasa"
+              ],
+              "condiciones": [
+                "si eliges una carne grasa, eliminar el aceite"
+              ]
+            },
+            {
+              "nombre": "opcion_2",
+              "or": [
+                "495g de dorada",
+                "495g de merluza",
+                "495g de panga",
+                "495g de cazón",
+                "495g de calamares",
+                "495g de lubina",
+                "495g de bacalao",
+                "495g de cualquier pescado blanco o marisco",
+                "495g de caballa fresca",
+                "495g de atún fresco",
+                "495g de salmón fresco",
+                "495g de pez espada",
+                "495g de cualquier pescado azul"
+              ],
+              "condiciones": [
+                "si eliges pescado azul, eliminar el aceite"
+              ]
+            },
+            {
+              "nombre": "opcion_3_huevos",
+              "and": [
+                {
+                  "nombre": "huevos",
+                  "or": [
+                    "3 huevos"
+                  ]
+                },
+                {
+                  "nombre": "acompañamiento",
+                  "or": [
+                    "240g de carne fresca",
+                    "330g de pescado"
+                  ]
+                }
+              ],
+              "condiciones": [
+                "eliminar 1.5 cucharadas de aceite de oliva"
+              ]
+            },
+            {
+              "nombre": "opcion_3_claras",
+              "and": [
+                {
+                  "nombre": "claras",
+                  "or": [
+                    "300ml de clara de huevo"
+                  ]
+                },
+                {
+                  "nombre": "acompañamiento",
+                  "or": [
+                    "240g de carne fresca",
+                    "330g de pescado"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "comida_3": {
+      "descripcion": "Elige una opción de cada grupo y combina",
+      "macros_plan": {
+        "codigos": {
+          "actual": "1.7.2"
+        },
+        "interpretacion": {
+          "actual": {
+            "hidratos_g": 10,
+            "proteina_g": 70,
+            "grasa_g": 20
+          }
+        }
+      },
+      "and": [
+        {
+          "nombre": "grasas",
+          "or": [
+            "Cocinar con 2 cucharadas soperas de aceite de oliva (20g)",
+            "160g de aguacate",
+            "80g de aceitunas",
+            "32g de frutos secos"
+          ]
+        },
+        {
+          "nombre": "hc",
+          "or": [
+            "verdura hasta 375g (brócoli o coliflor o lechuga o judías verdes o pimiento o tomate o espárrago o espinacas o acelgas o berenjenas)",
+            "hasta 250g de champiñones"
+          ],
+          "notas": [
+            "Puedes combinar verduras dividiendo las cantidades"
+          ]
+        },
+        {
+          "nombre": "proteinas",
+          "or": [
+            {
+              "nombre": "opcion_1",
+              "or": [
+                "240g de pechuga de pollo",
+                "240g de pavo",
+                "240g de ternera",
+                "240g de conejo",
+                "240g de cualquier carne magra",
+                "300g de solomillo de cerdo",
+                "240g de lomo de cerdo",
+                "240g de muslo de pollo",
+                "240g de cordero",
+                "240g de secreto de cerdo",
+                "240g de presa de cerdo",
+                "240g de cualquier carne grasa"
+              ],
+              "condiciones": [
+                "si eliges una carne grasa, eliminar el aceite"
+              ]
+            },
+            {
+              "nombre": "opcion_2",
+              "or": [
+                "330g de dorada",
+                "330g de merluza",
+                "330g de panga",
+                "330g de cazón",
+                "330g de calamares",
+                "330g de lubina",
+                "330g de bacalao",
+                "330g de cualquier pescado blanco o marisco",
+                "330g de caballa fresca",
+                "330g de atún fresco",
+                "330g de salmón fresco",
+                "330g de pez espada",
+                "330g de cualquier pescado azul"
+              ],
+              "condiciones": [
+                "si eliges pescado azul, eliminar el aceite"
+              ]
+            },
+            {
+              "nombre": "opcion_3_huevos_4",
+              "and": [
+                {
+                  "nombre": "huevos",
+                  "or": [
+                    "4 huevos"
+                  ]
+                },
+                {
+                  "nombre": "acompañamiento",
+                  "or": [
+                    "120g de pavo",
+                    "80g de jamón serrano sin veta"
+                  ]
+                }
+              ],
+              "condiciones": [
+                "eliminar 2 cucharadas de aceite de oliva"
+              ]
+            },
+            {
+              "nombre": "opcion_3_huevos_2",
+              "and": [
+                {
+                  "nombre": "huevos",
+                  "or": [
+                    "2 huevos"
+                  ]
+                },
+                {
+                  "nombre": "acompañamiento",
+                  "or": [
+                    "160g de carne fresca",
+                    "220g de pescado"
+                  ]
+                }
+              ],
+              "condiciones": [
+                "eliminar 1 cucharada de aceite de oliva"
+              ]
+            },
+            {
+              "nombre": "opcion_3_claras",
+              "and": [
+                {
+                  "nombre": "claras",
+                  "or": [
+                    "200ml de clara huevo"
+                  ]
+                },
+                {
+                  "nombre": "acompañamiento",
+                  "or": [
+                    "160g de carne fresca",
+                    "220g de pescado"
+                  ]
+                }
+              ],
+              "condiciones": [
+                "eliminar 1 cucharada de aceite de oliva"
+              ]
+            }
+          ]
+        },
+        {
+          "nombre": "postre",
+          "or": [
+            "1 yogur de proteína Hacendado"
+          ]
+        }
+      ]
+    },
+    "comida_4": {
+      "descripcion": "Elige y combina. EFUT",
+      "macros_plan": {
+        "codigos": {
+          "anterior": "3.7.1,5",
+          "actual": "2.7.1,5"
+        },
+        "interpretacion": {
+          "anterior": {
+            "hidratos_g": 30,
+            "proteina_g": 70,
+            "grasa_g": 15
+          },
+          "actual": {
+            "hidratos_g": 20,
+            "proteina_g": 70,
+            "grasa_g": 15
+          }
+        }
+      },
+      "and": [
+        {
+          "nombre": "grasas",
+          "or": [
+            "Cocinar con 1.5 cucharadas soperas de aceite de oliva (15g)",
+            "120g de aguacate",
+            "60g de aceitunas"
+          ]
+        },
+        {
+          "nombre": "h_carbono",
+          "and": [
+            {
+              "nombre": "verdura",
+              "or": [
+                "verdura (la que quieras desde 50g hasta 375g)"
+              ]
+            },
+            {
+              "nombre": "fuente_hidrato",
+              "or": [
+                "15g de arroz",
+                "15g de pasta integral",
+                "70g de patata",
+                "50g de boniato",
+                "20g de legumbres",
+                "20g de pan integral",
+                "80g de piña",
+                "80g de kiwi",
+                "80g de manzana verde",
+                "80g de ciruela",
+                "80g de granada",
+                "80g de higo",
+                "80g de mandarinas",
+                "80g de mango",
+                "80g de nectarina",
+                "80g de uva",
+                "135g de melocotón",
+                "135g de albaricoque",
+                "135g de frambuesa",
+                "135g de naranja",
+                "165g de fresas",
+                "165g de sandía",
+                "65g de plátano"
+              ]
+            }
+          ]
+        },
+        {
+          "nombre": "proteinas",
+          "or": [
+            {
+              "nombre": "opcion_1",
+              "or": [
+                "280g de pechuga de pollo",
+                "280g de pavo",
+                "280g de ternera",
+                "280g de conejo",
+                "280g de cualquier carne magra",
+                "350g de solomillo de cerdo",
+                "280g de lomo de cerdo",
+                "280g de muslo de pollo",
+                "280g de cordero",
+                "280g de secreto de cerdo",
+                "280g de presa de cerdo",
+                "280g de cualquier carne grasa"
+              ],
+              "condiciones": [
+                "si eliges una carne grasa, eliminar el aceite"
+              ]
+            },
+            {
+              "nombre": "opcion_2",
+              "or": [
+                "375g de dorada",
+                "375g de merluza",
+                "375g de panga",
+                "375g de cazón",
+                "375g de calamares",
+                "375g de lubina",
+                "375g de bacalao",
+                "375g de cualquier pescado blanco o marisco",
+                "375g de caballa fresca",
+                "375g de atún fresco",
+                "375g de salmón fresco",
+                "375g de pez espada",
+                "375g de cualquier pescado azul"
+              ],
+              "condiciones": [
+                "si eliges pescado azul, eliminar el aceite"
+              ]
+            },
+            {
+              "nombre": "opcion_3_huevos_4",
+              "and": [
+                {
+                  "nombre": "huevos",
+                  "or": [
+                    "4 huevos"
+                  ]
+                },
+                {
+                  "nombre": "acompañamiento",
+                  "or": [
+                    "180g de pavo",
+                    "120g de jamón serrano sin veta"
+                  ]
+                }
+              ],
+              "condiciones": [
+                "eliminar 2 cucharadas de aceite de oliva"
+              ]
+            },
+            {
+              "nombre": "opcion_3_huevos_2",
+              "and": [
+                {
+                  "nombre": "huevos",
+                  "or": [
+                    "2 huevos"
+                  ]
+                },
+                {
+                  "nombre": "acompañamiento",
+                  "or": [
+                    "200g de carne fresca",
+                    "275g de pescado"
+                  ]
+                }
+              ],
+              "condiciones": [
+                "eliminar 1 cucharada de aceite de oliva"
+              ]
+            },
+            {
+              "nombre": "opcion_3_claras",
+              "and": [
+                {
+                  "nombre": "claras",
+                  "or": [
+                    "200ml de clara de huevo"
+                  ]
+                },
+                {
+                  "nombre": "acompañamiento",
+                  "or": [
+                    "200g de carne fresca",
+                    "275g de pescado"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "comida_5": {
+      "descripcion": "Elige y combina. N.E",
+      "macros_plan": {
+        "codigos": {
+          "anterior": "3.7.2",
+          "actual": "2.7.2"
+        },
+        "interpretacion": {
+          "anterior": {
+            "hidratos_g": 30,
+            "proteina_g": 70,
+            "grasa_g": 20
+          },
+          "actual": {
+            "hidratos_g": 20,
+            "proteina_g": 70,
+            "grasa_g": 20
+          }
+        }
+      },
+      "and": [
+        {
+          "nombre": "grasas",
+          "or": [
+            "Cocinar con 2 cucharadas soperas de aceite de oliva (20g)",
+            "160g de aguacate",
+            "80g de aceitunas"
+          ]
+        },
+        {
+          "nombre": "hc",
+          "and": [
+            {
+              "nombre": "verdura",
+              "or": [
+                "verdura hasta 375g"
+              ]
+            },
+            {
+              "nombre": "fuente_hidrato",
+              "or": [
+                "15g de arroz",
+                "15g de pasta integral",
+                "70g de patata",
+                "50g de boniato",
+                "20g de legumbres",
+                "20g de pan integral",
+                "80g de piña",
+                "80g de kiwi",
+                "80g de manzana verde",
+                "80g de ciruela",
+                "80g de granada",
+                "80g de higo",
+                "80g de mandarinas",
+                "80g de mango",
+                "80g de nectarina",
+                "80g de uva",
+                "135g de melocotón",
+                "135g de albaricoque",
+                "135g de frambuesa",
+                "135g de naranja",
+                "165g de fresas",
+                "165g de sandía",
+                "65g de plátano"
+              ]
+            }
+          ]
+        },
+        {
+          "nombre": "proteinas",
+          "or": [
+            {
+              "nombre": "opcion_1",
+              "or": [
+                "280g de pechuga de pollo",
+                "280g de pavo",
+                "280g de ternera",
+                "280g de conejo",
+                "280g de cualquier carne magra",
+                "350g de solomillo de cerdo",
+                "280g de lomo de cerdo",
+                "280g de muslo de pollo",
+                "280g de cordero",
+                "280g de secreto de cerdo",
+                "280g de presa de cerdo",
+                "280g de cualquier carne grasa"
+              ],
+              "condiciones": [
+                "si eliges una carne grasa, eliminar el aceite"
+              ]
+            },
+            {
+              "nombre": "opcion_2",
+              "or": [
+                "375g de dorada",
+                "375g de merluza",
+                "375g de panga",
+                "375g de cazón",
+                "375g de calamares",
+                "375g de lubina",
+                "375g de bacalao",
+                "375g de cualquier pescado blanco o marisco",
+                "375g de caballa fresca",
+                "375g de atún fresco",
+                "375g de salmón fresco",
+                "375g de pez espada",
+                "375g de cualquier pescado azul"
+              ],
+              "condiciones": [
+                "si eliges pescado azul, eliminar el aceite"
+              ]
+            },
+            {
+              "nombre": "opcion_3_huevos_4",
+              "and": [
+                {
+                  "nombre": "huevos",
+                  "or": [
+                    "4 huevos"
+                  ]
+                },
+                {
+                  "nombre": "acompañamiento",
+                  "or": [
+                    "180g de pavo",
+                    "120g de jamón serrano sin veta"
+                  ]
+                }
+              ],
+              "condiciones": [
+                "eliminar 2 cucharadas de aceite de oliva"
+              ]
+            },
+            {
+              "nombre": "opcion_3_huevos_2",
+              "and": [
+                {
+                  "nombre": "huevos",
+                  "or": [
+                    "2 huevos"
+                  ]
+                },
+                {
+                  "nombre": "acompañamiento",
+                  "or": [
+                    "200g de carne fresca",
+                    "275g de pescado"
+                  ]
+                }
+              ],
+              "condiciones": [
+                "eliminar 1 cucharada de aceite de oliva"
+              ]
+            },
+            {
+              "nombre": "opcion_3_claras",
+              "and": [
+                {
+                  "nombre": "claras",
+                  "or": [
+                    "200ml de clara de huevo"
+                  ]
+                },
+                {
+                  "nombre": "acompañamiento",
+                  "or": [
+                    "200g de carne fresca",
+                    "275g de pescado"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/bot_profiles/nutrition/docs/README.md
+++ b/bot_profiles/nutrition/docs/README.md
@@ -57,6 +57,17 @@ Example capabilities this design must support:
 
 In all cases, `comidas` remains the source of truth for quantities.
 
+Runtime principle:
+
+```text
+detect situation + detect moment -> resolve comida -> send only that chunk
+```
+
+The bot should not send the full plan to the LLM when it can select the
+relevant block locally. `situaciones.*.aliases` exists so natural language such
+as "bici", "gym", "partido", or "correr" can be mapped to configured situations
+before the model is called.
+
 ## Document Map
 
 - [User journeys](user-journeys.md): complete user flows and expected outcomes.
@@ -95,3 +106,8 @@ Out of V1:
 - daily tracking;
 - advanced plan comparison;
 - batch cooking workflows.
+
+The demo-plan phase before full persistence uses the same data shape but starts
+simpler: a repository demo plan can be loaded as read-only profile context, and
+issue #94 adds a local router so only the resolved comida chunk reaches the
+LLM.

--- a/bot_profiles/nutrition/docs/README.md
+++ b/bot_profiles/nutrition/docs/README.md
@@ -1,0 +1,97 @@
+# Nutrition Bot Design Docs
+
+These documents are the versioned functional design for the nutrition bot.
+They are not user data.
+
+User-specific nutrition plans, extracted documents, recipes, situations, and
+adaptation rules must be stored in PostgreSQL as JSONB documents linked to each
+user. The filenames used in these docs, such as `meal_blocks.json`, describe
+document shapes, not repository files to create per user.
+
+V1 should keep the plan compact: the `meal_blocks` document type stores a
+`comidas` tree with `and`/`or` groups, raw food strings, raw conditions, and raw
+notes. It should not normalize every food into a large object unless a later
+feature proves that cost is worth it.
+
+## Product Goal
+
+The nutrition bot helps a Telegram user follow a nutrition plan delivered by a
+nutrition professional. The bot should not invent diets from scratch. Its job is
+to interpret structured plan data, preserve the plan's quantities, and answer in
+a simple, practical way.
+
+Primary priorities:
+
+1. Respect the user's active nutrition plan.
+2. Use the blocks and quantities defined by the plan.
+3. Adapt real meals without breaking the plan logic.
+4. Keep responses short unless the user asks for detail.
+5. Avoid moralizing, guilt, or medical diagnosis.
+
+## Plain Mental Model
+
+For a non-technical user, the product should feel like this:
+
+```text
+My nutritionist gave me a plan.
+I tell the bot what kind of day I have.
+The bot knows which meal block applies.
+The bot turns that block into a practical meal.
+```
+
+Internally, that maps to:
+
+```text
+situaciones -> chooses the right comida for a day/moment
+comidas -> defines allowed foods, quantities, macros, and conditions
+recetas -> suggests approved real dishes through RAG
+adaptation_rules -> helps adjust dishes without breaking the plan
+```
+
+Example capabilities this design must support:
+
+- "Hoy tengo crossfit, que puedo comer?"
+- "Que ceno hoy si me he saltado la media manana?"
+- "Hazme un plan de comidas y cenas para la semana: lunes ciclismo,
+  miercoles fuerza, viernes atletismo y el resto no entreno."
+
+In all cases, `comidas` remains the source of truth for quantities.
+
+## Document Map
+
+- [User journeys](user-journeys.md): complete user flows and expected outcomes.
+- [User stories](user-stories.md): implementable stories grouped by MVP.
+- [Data contracts](data-contracts.md): JSONB document shapes and validation rules.
+- [Response behavior](response-behavior.md): tone, guardrails, and answer examples.
+- [Roadmap](roadmap.md): issue order, MVP boundaries, and maintenance rules.
+- [Open considerations](open-considerations.md): nutrition safety gaps and
+  product risks to keep visible.
+
+## Maintenance Rule
+
+Every implementation issue in epic #79 must check these docs before changing
+behavior. If a PR changes a journey, story, JSONB contract, response rule, or
+roadmap assumption, it must update the relevant document in the same PR.
+
+## Current Scope
+
+V1 focuses on creating a draft plan through `/new_plan`:
+
+- user starts `/new_plan`;
+- bot accepts compact `comidas` JSON, pasted text, or PDF;
+- bot uses valid `comidas` JSON directly when available;
+- bot extracts text only for text/PDF flows;
+- bot generates only a compact `meal_blocks` JSONB document;
+- bot validates the document minimally;
+- bot stores it as a draft plan;
+- bot replies with a short summary and warnings.
+
+Out of V1:
+
+- OCR for images;
+- full recipe generation;
+- full situation mapping;
+- recipe RAG;
+- daily tracking;
+- advanced plan comparison;
+- batch cooking workflows.

--- a/bot_profiles/nutrition/docs/README.md
+++ b/bot_profiles/nutrition/docs/README.md
@@ -50,6 +50,8 @@ adaptation_rules -> helps adjust dishes without breaking the plan
 
 Example capabilities this design must support:
 
+- "Que ceno hoy dia de no entreno?" -> one concrete dinner option with plan
+  quantities.
 - "Hoy tengo crossfit, que puedo comer?"
 - "Que ceno hoy si me he saltado la media manana?"
 - "Hazme un plan de comidas y cenas para la semana: lunes ciclismo,
@@ -60,7 +62,8 @@ In all cases, `comidas` remains the source of truth for quantities.
 Runtime principle:
 
 ```text
-detect situation + detect moment -> resolve comida -> send only that chunk
+detect situation + detect moment -> resolve comida -> choose valid option path
+-> answer with plan quantities
 ```
 
 The bot should not send the full plan to the LLM when it can select the
@@ -108,6 +111,5 @@ Out of V1:
 - batch cooking workflows.
 
 The demo-plan phase before full persistence uses the same data shape but starts
-simpler: a repository demo plan can be loaded as read-only profile context, and
-issue #94 adds a local router so only the resolved comida chunk reaches the
-LLM.
+simpler: a repository demo plan is configured through `nutrition_plan_file`, and
+issue #94 adds a local router so only the resolved comida chunk reaches the LLM.

--- a/bot_profiles/nutrition/docs/README.md
+++ b/bot_profiles/nutrition/docs/README.md
@@ -5,13 +5,14 @@ They are not user data.
 
 User-specific nutrition plans, extracted documents, recipes, situations, and
 adaptation rules must be stored in PostgreSQL as JSONB documents linked to each
-user. The filenames used in these docs, such as `meal_blocks.json`, describe
-document shapes, not repository files to create per user.
+user. The filenames used in these docs describe document shapes, not repository
+files to create per user.
 
-V1 should keep the plan compact: the `meal_blocks` document type stores a
-`comidas` tree with `and`/`or` groups, raw food strings, raw conditions, and raw
-notes. It should not normalize every food into a large object unless a later
-feature proves that cost is worth it.
+V1 should keep the plan compact: the active plan stores separate `situaciones`
+and `comidas` JSONB documents. `situaciones` routes day context and meal moment
+to a comida key; `comidas` keeps the `and`/`or` tree, raw food strings, raw
+conditions, macros from the plan, and notes. It should not normalize every food
+into a large object unless a later feature proves that cost is worth it.
 
 ## Product Goal
 
@@ -54,6 +55,8 @@ Example capabilities this design must support:
   quantities.
 - "Hoy tengo crossfit, que puedo comer?"
 - "Que ceno hoy si me he saltado la media manana?"
+- "Esta manana era dia de crossfit, pero al final no he ido. Ajustame la cena."
+- "Cambio crossfit por natacion, que ceno?"
 - "Hazme un plan de comidas y cenas para la semana: lunes ciclismo,
   miercoles fuerza, viernes atletismo y el resto no entreno."
 
@@ -77,6 +80,8 @@ before the model is called.
 - [User stories](user-stories.md): implementable stories grouped by MVP.
 - [Data contracts](data-contracts.md): JSONB document shapes and validation rules.
 - [Response behavior](response-behavior.md): tone, guardrails, and answer examples.
+- [Orchestration](orchestration.md): LangChain pipeline, model routing, and
+  future MCP tool boundaries.
 - [Roadmap](roadmap.md): issue order, MVP boundaries, and maintenance rules.
 - [Open considerations](open-considerations.md): nutrition safety gaps and
   product risks to keep visible.
@@ -89,20 +94,26 @@ roadmap assumption, it must update the relevant document in the same PR.
 
 ## Current Scope
 
-V1 focuses on creating a draft plan through `/new_plan`:
+V1 now focuses on setting one active user plan through `/set_plan`:
 
-- user starts `/new_plan`;
-- bot accepts compact `comidas` JSON, pasted text, or PDF;
-- bot uses valid `comidas` JSON directly when available;
-- bot extracts text only for text/PDF flows;
-- bot generates only a compact `meal_blocks` JSONB document;
-- bot validates the document minimally;
-- bot stores it as a draft plan;
-- bot replies with a short summary and warnings.
+- user sends `/set_plan`, then attaches `situaciones.json` and `comidas.json`
+  as `.json`/`.txt` files without needing captions, in either order;
+- if only one file has arrived, bot keeps a draft and tells the user which part
+  is missing;
+- a combined JSON with both roots is also accepted;
+- bot asks the configured normalization model only when a combined payload needs
+  cleanup; already-valid split files use local validation;
+- bot stores `situaciones` and `comidas` as PostgreSQL JSONB documents under
+  the user's active plan;
+- any previous active plan for that user is archived;
+- bot replies with a short summary.
+- user can run `/get_plan` for a summary or `/get_plan situaciones`,
+  `/get_plan comidas`, `/get_plan all` to export review files.
 
 Out of V1:
 
 - OCR for images;
+- PDF support;
 - full recipe generation;
 - full situation mapping;
 - recipe RAG;
@@ -110,6 +121,11 @@ Out of V1:
 - advanced plan comparison;
 - batch cooking workflows.
 
-The demo-plan phase before full persistence uses the same data shape but starts
-simpler: a repository demo plan is configured through `nutrition_plan_file`, and
-issue #94 adds a local router so only the resolved comida chunk reaches the LLM.
+The current implementation loads the active plan from PostgreSQL. Issue #95
+adds the first LangChain orchestration layer around the router. It separates
+local understanding, optional LLM normalization, plan-context selection, and
+final-answer generation so each step can use a different model or future MCP
+tool. It also introduces the first daily nutrition log in PostgreSQL: one
+editable state per user/profile/date so the bot can remember today's current
+day type, skipped meals, and logged meals without depending only on free-form
+chat memory.

--- a/bot_profiles/nutrition/docs/data-contracts.md
+++ b/bot_profiles/nutrition/docs/data-contracts.md
@@ -96,6 +96,110 @@ Rules:
 
 This shape is intentionally cheaper in tokens than object-per-food structures.
 
+## Situations Router Document
+
+`situaciones` is the operational router between natural day context and meal
+blocks. It does not contain food quantities. It only answers:
+
+```text
+tipo de dia + momento -> comida_key
+```
+
+Current compact shape:
+
+```json
+{
+  "situaciones": {
+    "crossfit": {
+      "label": "CrossFit o entrenamiento de fuerza alta intensidad",
+      "aliases": ["crossfit", "fuerza", "gym", "gimnasio", "hiit"],
+      "tipo_dia": "entrenamiento_fuerza_por_la_tarde",
+      "suplementacion": ["10g de creatina monohidrato creapure"],
+      "momentos": {
+        "desayuno": "comida_1",
+        "almuerzo": "comida_2",
+        "merienda": "comida_0",
+        "cena": "comida_3"
+      }
+    }
+  }
+}
+```
+
+Rules:
+
+- Top-level `situaciones` is required when day routing is enabled.
+- Each situation key is stable and internal, for example `crossfit`,
+  `futbol`, `ciclismo`, `atletismo`, or `no_entreno`.
+- `aliases` is part of the practical contract. It lets the local router map
+  natural language such as `bici`, `gym`, `partido`, or `correr` to stable
+  situation keys without a model call.
+- `momentos` maps natural meal moments to existing `comidas` keys.
+- Every `momentos.*` value must reference an existing key in `comidas`.
+- `suplementacion` must be an array of strings. Preserve it, but do not mention
+  it in every meal response unless the user asks about supplements or daily
+  planning.
+- Situation names are configurable. The code must not hardcode only crossfit,
+  football, or rest days.
+
+Moment aliases can be handled by runtime rules before lookup:
+
+```text
+desayuno, desayunar -> desayuno
+comida, almuerzo, mediodia, medio dia -> almuerzo
+merienda, media tarde, pre entreno -> merienda
+cena, cenar, noche -> cena
+```
+
+If a plan adds a custom moment, for example `post_entreno`, the router can
+support it later through plan-provided aliases.
+
+## Runtime Chunking Contract
+
+The full plan should not be sent to the LLM when the runtime can resolve a
+smaller slice locally.
+
+Preferred V1 flow:
+
+```text
+mensaje del usuario
+-> normalizar texto
+-> detectar situation_key desde situaciones.*.aliases
+-> detectar moment_key desde reglas/aliases de momentos
+-> resolver situaciones[situation_key].momentos[moment_key]
+-> obtener comidas[comida_key]
+-> llamar al LLM solo con ese chunk
+```
+
+Chunk sent to the LLM when resolution is complete:
+
+```json
+{
+  "nutrition_context": {
+    "situation_key": "crossfit",
+    "moment_key": "almuerzo",
+    "meal_block_key": "comida_2",
+    "supplementation": ["10g de creatina monohidrato creapure"],
+    "meal_block": {
+      "descripcion": "Elige y combina. E.F",
+      "and": []
+    }
+  }
+}
+```
+
+Rules:
+
+- The chunk is read-only context.
+- The LLM may explain and format the block, but must not invent quantities.
+- If `situation_key` or `moment_key` is missing, ask one short clarification
+  instead of sending the full plan.
+- If multiple situations match with similar confidence, ask the user to choose.
+- If the resolved `meal_block_key` is missing from `comidas`, treat it as
+  configuration error.
+- The full `comidas` document may be used for validation or local lookup, not
+  as routine prompt payload.
+
 ## Node Contract
 
 Nodes represent a recursive logical tree. Nutrition plans often nest choices,

--- a/bot_profiles/nutrition/docs/data-contracts.md
+++ b/bot_profiles/nutrition/docs/data-contracts.md
@@ -1,0 +1,824 @@
+# Nutrition Bot Data Contracts
+
+These contracts describe JSONB documents stored per user in PostgreSQL. They
+are not repository files per user.
+
+The V1 contract should stay compact. The bot needs a faithful structured plan,
+not a fully normalized food database. Expensive enrichment such as food tags,
+parsed quantities, recipe matching, or substitutions can be computed later and
+only for the relevant meal/query.
+
+## Storage Model
+
+V1 storage:
+
+- `nutrition_plans`: one row per uploaded/generated plan.
+- `nutrition_plan_documents`: JSONB documents belonging to a plan.
+- `nutrition_plan_upload_sessions`: state for `/new_plan` uploads.
+
+`nutrition_plans.user_id` references `users(id)` as `INTEGER`.
+
+Plan states:
+
+- `draft`
+- `active`
+- `failed`
+- `archived`
+
+Upload session states:
+
+- `waiting_for_plan_upload`
+- `processing`
+- `completed`
+- `cancelled`
+- `failed`
+- `expired`
+
+Document types live in the database row, not necessarily inside the JSONB
+content. For V1:
+
+- `nutrition_plan_documents.document_type = meal_blocks`
+- `nutrition_plan_documents.content = compact comidas document`
+
+Input priority for `/new_plan`:
+
+1. Valid compact JSON with root `comidas`: validate and store directly.
+2. Pasted text: extract/generate compact `comidas`.
+3. PDF: extract text, then generate compact `comidas`.
+
+Direct JSON is the most reliable and lowest-cost path. It should bypass LLM
+generation.
+
+## V1 Compact Meal Blocks Document
+
+V1 stores the same functional shape as the extracted `comidas.json` example:
+
+```json
+{
+  "comidas": {
+    "comida_0": {
+      "descripcion": "Merienda simple",
+      "macros_plan": {
+        "codigos": {
+          "actual": "0.2.0"
+        },
+        "interpretacion": {
+          "actual": {
+            "hidratos_g": 0,
+            "proteina_g": 20,
+            "grasa_g": 0
+          }
+        }
+      },
+      "and": [
+        {
+          "nombre": "proteina",
+          "or": ["25g de proteina Whey"]
+        }
+      ]
+    }
+  }
+}
+```
+
+Rules:
+
+- Top-level `comidas` is required.
+- `comidas` is an object keyed by stable ids such as `comida_0`.
+- Each comida must have `descripcion`.
+- Each comida should have exactly one root operator: `and` or `or`.
+- `and` and `or` may be nested at any depth.
+- Food leaves remain plain strings.
+- The original food text must never be discarded.
+- `condiciones` and `notas` remain arrays of strings.
+- `warnings` may be added at document, comida, or node level when extraction is
+  ambiguous.
+
+This shape is intentionally cheaper in tokens than object-per-food structures.
+
+## Node Contract
+
+Nodes represent a recursive logical tree. Nutrition plans often nest choices,
+for example: choose one breakfast option, then inside that option combine pan,
+protein, and fat, then choose one item from each of those groups.
+
+Group node:
+
+```json
+{
+  "nombre": "proteinas",
+  "or": [
+    "240g de pechuga de pollo",
+    {
+      "nombre": "opcion_pescado",
+      "or": ["330g de salmon fresco"],
+      "condiciones": ["si eliges pescado azul, eliminar el aceite"]
+    }
+  ],
+  "notas": ["Texto original importante"],
+  "condiciones": ["Texto original de condicion"]
+}
+```
+
+Nested `or -> and -> or` example:
+
+```json
+{
+  "descripcion": "Elige una de las siguientes opciones",
+  "or": [
+    {
+      "nombre": "pan_proteina_grasa",
+      "and": [
+        {
+          "nombre": "pan",
+          "or": ["80g de pan integral"]
+        },
+        {
+          "nombre": "proteina",
+          "or": ["120g de pavo", "2 latas de atun al natural"]
+        },
+        {
+          "nombre": "grasa",
+          "or": ["20g de aceite de oliva", "160g de aguacate"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Nested `and -> or -> and -> or` example:
+
+```json
+{
+  "descripcion": "Elige y combina",
+  "and": [
+    {
+      "nombre": "grasas",
+      "or": ["20g de aceite de oliva", "160g de aguacate"]
+    },
+    {
+      "nombre": "proteinas",
+      "or": [
+        "240g de pechuga de pollo",
+        {
+          "nombre": "huevos_con_acompanamiento",
+          "and": [
+            {
+              "nombre": "huevos",
+              "or": ["2 huevos"]
+            },
+            {
+              "nombre": "acompanamiento",
+              "or": ["160g de carne fresca", "220g de pescado"]
+            }
+          ],
+          "condiciones": ["eliminar 1 cucharada de aceite de oliva"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Allowed fields:
+
+- `nombre`: short semantic group name.
+- `and`: all children are combined.
+- `or`: choose one compatible child.
+- `condiciones`: raw condition text.
+- `notas`: raw notes from the plan.
+- `warnings`: extraction or interpretation warnings.
+
+Child values may be:
+
+- strings for food/options;
+- nested nodes for grouped choices.
+
+Validation rules:
+
+- A node must have exactly one of `and` or `or`.
+- `and` and `or` must be non-empty arrays.
+- Children may be strings or nested objects at any depth.
+- A string child is already valid raw food text.
+- Empty groups are invalid for activation.
+- A parent `or` can contain nested `and` groups.
+- A parent `and` can contain nested `or` groups.
+- The validator must recurse until it reaches string leaves.
+
+Semantic rules:
+
+- `and` means all children in that array belong to the same valid selection.
+- `or` means choose one compatible child from that array.
+- The meaning is local to the node. Do not flatten the full tree.
+- Preserve the nutritionist's grouping when possible, because nesting carries
+  meal logic.
+
+## Macros
+
+Keep both compact codes and interpreted grams when available.
+
+```json
+{
+  "macros_plan": {
+    "codigos": {
+      "anterior": "4.2.1,5",
+      "actual": "4.2.2"
+    },
+    "interpretacion": {
+      "anterior": {
+        "hidratos_g": 40,
+        "proteina_g": 20,
+        "grasa_g": 15
+      },
+      "actual": {
+        "hidratos_g": 40,
+        "proteina_g": 20,
+        "grasa_g": 20
+      }
+    }
+  }
+}
+```
+
+Compact format:
+
+```text
+hidratos.proteina.grasa
+```
+
+Each number represents tens of grams:
+
+- `0.2.0`: 0 g carbs, 20 g protein, 0 g fat
+- `1.7.2`: 10 g carbs, 70 g protein, 20 g fat
+- `2.7.1,5`: 20 g carbs, 70 g protein, 15 g fat
+
+Kcal can be calculated on demand when all macro grams are known:
+
+- carbs: 4 kcal/g
+- protein: 4 kcal/g
+- fat: 9 kcal/g
+
+The bot must not show macros by default.
+
+## Conditions And Notes
+
+V1 keeps conditions as raw strings.
+
+```json
+{
+  "nombre": "opcion_pescado",
+  "or": [
+    "330g de merluza",
+    "330g de salmon fresco",
+    "330g de cualquier pescado azul"
+  ],
+  "condiciones": [
+    "si eliges pescado azul, eliminar el aceite"
+  ]
+}
+```
+
+Do not force conditions into structured trigger/effect objects in V1. That
+inflates JSON and prompt tokens. Convert a condition into a structured action
+only at response time if it is needed for the current query.
+
+## Warnings
+
+Warnings should be compact and local.
+
+Recommended shape:
+
+```json
+{
+  "type": "ambiguous_group_operator",
+  "message": "No queda claro si estas opciones son AND u OR.",
+  "path": "comidas.comida_1.or[2]"
+}
+```
+
+Recommended warning types:
+
+- `unparsed_quantity`
+- `unknown_unit`
+- `ambiguous_group_operator`
+- `missing_macro_plan`
+- `unstructured_condition`
+- `possible_duplicate_block`
+- `empty_group`
+- `low_confidence_extraction`
+
+Warnings are for extraction review. They should not be sent to the model on
+every normal user query unless the warning affects the selected comida.
+
+## Token Budget Rules
+
+When answering a user query, do not send the whole plan if a small slice is
+enough.
+
+Preferred context order:
+
+1. Situation keys and moment mapping only when resolving context.
+2. Selected comida only after context is resolved.
+3. Relevant sibling choices inside that comida.
+4. Relevant `condiciones` and `notas`.
+5. Retrieved approved recipe candidates only when the user asks for a real dish
+   or recipe-like recommendation.
+6. Macros only if the user asks about macros, calories, quantities, or progress.
+7. Document-level warnings only if they affect the selected comida.
+
+Avoid passing:
+
+- all comidas for a single meal question;
+- the full situaciones document after the comida key is resolved;
+- the full recetas catalog;
+- future documents not needed by the query;
+- parsed food objects when raw strings are enough;
+- full extraction warnings for normal recommendations.
+
+## situaciones Document
+
+`situaciones` is a compact routing document. It maps:
+
+```text
+day situation + meal moment -> comida key
+```
+
+It does not contain quantities, recipes, cooking instructions, calories, or
+adaptation rules. After resolving a comida key, the bot must read that comida
+from the compact `comidas` document.
+
+Current Spanish shape:
+
+```json
+{
+  "situaciones": {
+    "crossfit": {
+      "tipo_dia": "entrenamiento_fuerza_por_la_tarde",
+      "suplementacion": [
+        "10g de creatina monohidrato creapure"
+      ],
+      "momentos": {
+        "desayuno": "comida_1",
+        "almuerzo": "comida_2",
+        "merienda": "comida_0",
+        "cena": "comida_3"
+      }
+    },
+    "no_entreno": {
+      "tipo_dia": "no_entreno",
+      "suplementacion": [
+        "10g de creatina monohidrato creapure"
+      ],
+      "momentos": {
+        "desayuno": "comida_1",
+        "almuerzo": "comida_5",
+        "merienda": "comida_0",
+        "cena": "comida_3"
+      }
+    }
+  }
+}
+```
+
+Resolution examples:
+
+- `crossfit + almuerzo -> comida_2`
+- `futbol + cena -> comida_3`
+- `no_entreno + almuerzo -> comida_5`
+
+Resolution function:
+
+```python
+def resolve_comida_key(
+    situaciones_doc: dict,
+    situation_key: str,
+    moment_key: str,
+) -> str | None:
+    situations = situaciones_doc.get("situaciones", {})
+    situation = situations.get(situation_key)
+    if not situation:
+        return None
+    moments = situation.get("momentos", {})
+    return moments.get(moment_key)
+```
+
+Rules:
+
+- Root `situaciones` is required.
+- Each key under `situaciones` is an allowed day context configured for that
+  user or plan.
+- Activity keys are not limited to `crossfit`, `futbol`, or `no_entreno`.
+  They may include any real user context, such as `ciclismo`, `atletismo`,
+  `fuerza`, `natacion`, `senderismo`, `competicion`, `viaje`,
+  `descanso_activo`, or `no_entreno`.
+- `tipo_dia` is descriptive context. The operational key is the object key.
+- `momentos` is required for every situation.
+- Each `momentos` value must be a string reference to an existing comida key.
+- `suplementacion` must be an array of strings and may be empty.
+- Supplementation should be preserved, but not repeated in every meal answer.
+  Mention it only for daily planning or when the user asks about supplements.
+- Missing situation context should trigger a short clarification.
+- The clarification should use the configured situation keys for that user,
+  not a hardcoded list of sports.
+- Missing meal moment should trigger a short clarification or a low-confidence
+  time-based suggestion in a future version.
+- Missing moment mapping must not invent a comida.
+- A reference to a missing comida is a validation error.
+
+Validation rules:
+
+- `situaciones` must be an object.
+- Every situation must be an object.
+- `momentos` must be a non-empty object.
+- Every `momentos.*` value must be a string.
+- Every referenced comida key must exist in `comidas`.
+- `suplementacion`, when present, must be an array of strings.
+
+Generic future aliases may be supported later:
+
+```json
+{
+  "situations": {
+    "training_day": {
+      "label": "Training day",
+      "description": "Day with strength or high intensity training",
+      "supplementation": ["creatine"],
+      "moments": {
+        "breakfast": "meal_block_001",
+        "lunch": "meal_block_002"
+      }
+    }
+  }
+}
+```
+
+For the Spanish V1/V2 contract, prefer `situaciones`, `tipo_dia`,
+`suplementacion`, and `momentos` because that matches the current source data.
+Do not hardcode sports in the product logic; treat situation keys as plan data.
+
+## recetas Document
+
+`recetas` is a catalog of real dishes that can make plan-based answers more
+natural. The catalog may become large, so normal user answers should retrieve
+candidate recipes through search/RAG instead of passing the full catalog to the
+LLM.
+
+It never replaces `comidas`. Recipes do not define final quantities. They only
+describe dish shapes that may be adapted to the selected comida.
+
+Functional order:
+
+```text
+situaciones -> chooses comida key
+comidas -> defines quantities, macros, groups, and conditions
+recetas -> proposes real dishes compatible with that comida
+adaptation_rules -> helps adapt the recipe to the comida
+```
+
+Correct use:
+
+1. Resolve situation and moment.
+2. Load the selected comida from `comidas`.
+3. Retrieve a small set of approved candidate recipes through search/RAG.
+4. Filter candidates compatible with the moment and comida.
+5. Adapt the selected recipe using quantities and conditions from the comida.
+6. Answer with the adapted dish.
+
+Wrong use:
+
+```text
+User: Que como?
+Bot: Pasta bolonesa.
+```
+
+That skips context resolution and plan quantities.
+
+### Recipe Lifecycle
+
+Recipes have review status.
+
+Allowed statuses:
+
+- `draft`: created by admin/professional but incomplete.
+- `pending_review`: submitted by user or imported automatically.
+- `approved`: reviewed and usable by the bot.
+- `rejected`: reviewed and not usable.
+- `archived`: preserved for history but not usable.
+
+The bot may use only:
+
+- `status = approved`
+
+The bot must not use `draft`, `pending_review`, `rejected`, or `archived`
+recipes for normal user recommendations. Exceptions are admin/professional
+review flows.
+
+### Approved Recipe Shape
+
+```json
+{
+  "nombre": "salmon_con_ensalada",
+  "nombre_visible": "Salmon con ensalada",
+  "tipo_comida": ["cena", "almuerzo"],
+  "proteina_principal": ["salmon"],
+  "tipo_proteina": "pescado_azul",
+  "hidratos": [],
+  "nivel_hidratos": "ninguno",
+  "verduras": ["lechuga", "tomate", "ensalada"],
+  "grasas": ["grasa_intrinseca_pescado_azul"],
+  "nivel_grasa": "intrinseca_alta",
+  "tags": ["pescado_azul", "ligero", "cena", "sin_hidrato_directo"],
+  "compatibilidad": {
+    "almuerzo": "media",
+    "cena": "alta"
+  },
+  "notas_adaptacion": [
+    "Eliminar el aceite si se usa como pescado azul del bloque.",
+    "Anadir hidrato solo si el bloque lo pide."
+  ],
+  "status": "approved",
+  "created_by_role": "professional"
+}
+```
+
+Required fields for approval:
+
+- `nombre`
+- `nombre_visible`
+- `tipo_comida`
+- `proteina_principal`
+- `tipo_proteina`
+- `hidratos`
+- `nivel_hidratos`
+- `grasas`
+- `nivel_grasa`
+- `compatibilidad`
+- `tags`
+- `notas_adaptacion`
+- `status = approved`
+
+### Main Fields
+
+`nombre` is the stable internal key. It should use snake_case and must be
+unique.
+
+`nombre_visible` is the human-readable name shown to users.
+
+`tipo_comida` lists compatible moments, such as `desayuno`, `almuerzo`,
+`merienda`, or `cena`. Future generic aliases may include `breakfast`, `lunch`,
+`snack`, `dinner`, `pre_workout`, or `post_workout`.
+
+`proteina_principal` lists main protein ingredients.
+
+`tipo_proteina` classifies the protein for adaptation. Recommended values:
+
+- `carne_magra`
+- `carne_grasa`
+- `pescado_blanco`
+- `pescado_azul`
+- `pescado_blanco_o_marisco`
+- `huevo`
+- `claras`
+- `mixta`
+- `variable`
+
+`hidratos` lists carb sources present in the dish.
+
+`nivel_hidratos` classifies carb level. Recommended values:
+
+- `ninguno`
+- `bajo`
+- `medio`
+- `medio_alto`
+- `alto`
+
+`verduras` lists usual vegetables in the recipe.
+
+`grasas` lists fat sources present in the recipe.
+
+`nivel_grasa` classifies fat level. Recommended values:
+
+- `baja`
+- `controlable`
+- `media`
+- `alta`
+- `intrinseca_alta`
+- `alta_o_dificil_controlar`
+- `media_o_dificil_controlar`
+
+`compatibilidad` maps moment keys to compatibility level. Recommended values:
+
+- `muy_baja`
+- `baja`
+- `media`
+- `alta`
+- `muy_alta`
+
+`notas_adaptacion` are hints for adapting the dish, but they do not override
+`comidas` or explicit conditions in the selected comida.
+
+### User Submitted Recipes
+
+Users may propose recipes, but those recipes must not become approved
+automatically.
+
+Flow:
+
+```text
+user submits recipe
+-> bot detects proposal
+-> bot stores recipe as pending_review
+-> bot informs user
+-> admin/professional reviews
+-> admin/professional edits, approves, rejects, or archives
+-> approved recipes become usable by the bot
+```
+
+User-facing response:
+
+```text
+He guardado la receta como propuesta.
+Un profesional tendra que revisarla antes de que el bot pueda usarla dentro del plan.
+```
+
+Pending recipe shape:
+
+```json
+{
+  "nombre": "user_submitted_2026_05_22_001",
+  "nombre_visible": "Arroz con atun y huevo",
+  "tipo_comida": [],
+  "proteina_principal": [],
+  "tipo_proteina": null,
+  "hidratos": [],
+  "nivel_hidratos": null,
+  "verduras": [],
+  "grasas": [],
+  "nivel_grasa": null,
+  "tags": [],
+  "compatibilidad": {},
+  "notas_adaptacion": [],
+  "status": "pending_review",
+  "created_by_role": "user",
+  "submitted_by_user_id": 123456,
+  "raw_submission": {
+    "text": "Arroz con atun, huevo cocido, pimientos y un poco de aceite.",
+    "attachments": []
+  },
+  "review": {
+    "reviewed_by": null,
+    "reviewed_at": null,
+    "decision": null,
+    "notes": []
+  }
+}
+```
+
+Review decisions:
+
+- `approve`
+- `reject`
+- `edit`
+- `archive`
+
+Rejected recipe review shape:
+
+```json
+{
+  "review": {
+    "reviewed_by": "admin_001",
+    "reviewed_at": "2026-05-22T18:00:00Z",
+    "decision": "rejected",
+    "notes": [
+      "Receta demasiado ambigua. Faltan cantidades y metodo de preparacion."
+    ]
+  }
+}
+```
+
+### Recipe Storage
+
+Simple starting point:
+
+- `nutrition_plan_documents.document_type = recipes`
+- `nutrition_plan_documents.content = recetas JSONB catalog`
+
+Likely future shape when recipes grow one by one:
+
+- `nutrition_recipes.id`
+- `nutrition_recipes.plan_id`
+- `nutrition_recipes.recipe_key`
+- `nutrition_recipes.visible_name`
+- `nutrition_recipes.status`
+- `nutrition_recipes.created_by_role`
+- `nutrition_recipes.submitted_by_user_id`
+- `nutrition_recipes.content JSONB`
+- `nutrition_recipes.created_at`
+- `nutrition_recipes.updated_at`
+- `nutrition_recipes.reviewed_by`
+- `nutrition_recipes.reviewed_at`
+
+For MVP planning, JSONB catalog is acceptable. Row-per-recipe becomes useful
+when user submissions, review queues, and admin/professional editing exist.
+
+### Recipe Retrieval And RAG
+
+The recipe catalog should be treated as retrievable knowledge, not prompt
+context.
+
+Source of truth:
+
+- approved recipe JSONB records or catalog entries;
+- review metadata and status;
+- raw submission for pending recipes.
+
+Retrieval index:
+
+- built only from `status = approved` recipes for normal user queries;
+- includes searchable text from `nombre_visible`, ingredients, tags,
+  `tipo_comida`, `tipo_proteina`, `nivel_hidratos`, `nivel_grasa`,
+  `compatibilidad`, and `notas_adaptacion`;
+- excludes `pending_review`, `draft`, `rejected`, and `archived` recipes unless
+  the caller is in admin/professional review mode.
+
+Prompt rule:
+
+- do not pass the full recipe catalog to the LLM;
+- retrieve a small candidate set first;
+- pass only the selected comida, relevant conditions, and top recipe
+  candidates;
+- keep recipe candidates compact, preferably `nombre_visible`, key fields, and
+  adaptation notes.
+
+Example retrieval query:
+
+```json
+{
+  "moment": "cena",
+  "selected_comida": "comida_3",
+  "desired_food": "salmon",
+  "constraints": ["sin_hidrato_directo"],
+  "prefer": ["compatibilidad.cena alta", "nivel_hidratos ninguno"]
+}
+```
+
+Example compact candidate sent to the LLM:
+
+```json
+{
+  "nombre": "salmon_con_ensalada",
+  "nombre_visible": "Salmon con ensalada",
+  "tipo_proteina": "pescado_azul",
+  "nivel_hidratos": "ninguno",
+  "nivel_grasa": "intrinseca_alta",
+  "compatibilidad": {
+    "cena": "alta"
+  },
+  "notas_adaptacion": [
+    "Eliminar el aceite si se usa como pescado azul del bloque."
+  ]
+}
+```
+
+### Recipe Matching
+
+When proposing a recipe, filter by:
+
+1. `status = approved`.
+2. Retrieval/search relevance.
+3. Compatible meal moment.
+4. Carb level compatible with the selected comida.
+5. Protein type compatible with the selected comida.
+6. User restrictions.
+7. User preferences.
+
+Dinner defaults:
+
+- Prioritize `nivel_hidratos = ninguno` or `bajo`.
+- Prioritize `compatibilidad.cena = alta` or `muy_alta`.
+- Avoid `nivel_hidratos = alto` unless the selected comida requires it.
+
+Lunch defaults:
+
+- Allow carb-based recipes when the selected comida has a carb source.
+- Adjust carb source to the selected comida quantity.
+
+Do not:
+
+- use pending recipes in normal recommendations;
+- invent final quantities from recipes;
+- approve user recipes automatically;
+- modify approved recipes without admin/professional role;
+- mix recipes with incompatible comidas;
+- use high-carb dinner recipes without warning and plan support.
+
+## Future Documents
+
+Future document types may be added as separate JSONB rows:
+
+- `adaptation_rules`: defines generic interpretation rules.
+
+The active source of truth for quantities remains the compact `comidas`
+document. Future documents may select or explain plan blocks, but they must not
+silently override quantities.

--- a/bot_profiles/nutrition/docs/data-contracts.md
+++ b/bot_profiles/nutrition/docs/data-contracts.md
@@ -109,6 +109,32 @@ Current compact shape:
 
 ```json
 {
+  "momentos": {
+    "desayuno": {
+      "label": "Desayuno",
+      "aliases": ["desayuno", "desayunar"]
+    },
+    "media_manana": {
+      "label": "Media mañana",
+      "aliases": ["media mañana", "media manana"]
+    },
+    "almuerzo": {
+      "label": "Almuerzo",
+      "aliases": ["almuerzo", "comida", "mediodia", "medio dia"]
+    },
+    "pre_entreno": {
+      "label": "Pre entreno",
+      "aliases": ["pre entreno", "antes de entrenar"]
+    },
+    "post_entreno": {
+      "label": "Post entreno",
+      "aliases": ["post entreno", "despues de entrenar"]
+    },
+    "cena": {
+      "label": "Cena",
+      "aliases": ["cena", "cenar", "ceno", "noche"]
+    }
+  },
   "situaciones": {
     "crossfit": {
       "label": "CrossFit o entrenamiento de fuerza alta intensidad",
@@ -134,25 +160,23 @@ Rules:
 - `aliases` is part of the practical contract. It lets the local router map
   natural language such as `bici`, `gym`, `partido`, or `correr` to stable
   situation keys without a model call.
-- `momentos` maps natural meal moments to existing `comidas` keys.
+- Root `momentos` defines the meal moments supported by that plan and their
+  natural-language aliases.
+- `situaciones.*.momentos` maps plan-specific meal moments to existing
+  `comidas` keys.
 - Every `momentos.*` value must reference an existing key in `comidas`.
 - `suplementacion` must be an array of strings. Preserve it, but do not mention
   it in every meal response unless the user asks about supplements or daily
   planning.
 - Situation names are configurable. The code must not hardcode only crossfit,
   football, or rest days.
-
-Moment aliases can be handled by runtime rules before lookup:
-
-```text
-desayuno, desayunar -> desayuno
-comida, almuerzo, mediodia, medio dia -> almuerzo
-merienda, media tarde, pre entreno -> merienda
-cena, cenar, noche -> cena
-```
-
-If a plan adds a custom moment, for example `post_entreno`, the router can
-support it later through plan-provided aliases.
+- Moment names are configurable. Some users may have `media_manana`,
+  `pre_entreno`, `post_entreno`, or no `merienda`; that must be plan data, not
+  hardcoded runtime behavior.
+- Training timing is also plan data. If morning and afternoon training change
+  the routing, model them as distinct situation keys such as
+  `crossfit_manana` and `crossfit_tarde`, with aliases that capture natural
+  language. If the user says only `crossfit`, ask which situation applies.
 
 ## Runtime Chunking Contract
 
@@ -165,7 +189,8 @@ Preferred V1 flow:
 mensaje del usuario
 -> normalizar texto
 -> detectar situation_key desde situaciones.*.aliases
--> detectar moment_key desde reglas/aliases de momentos
+-> detectar si el usuario pide un dia completo
+-> detectar moment_key desde momentos.*.aliases
 -> resolver situaciones[situation_key].momentos[moment_key]
 -> obtener comidas[comida_key]
 -> llamar al LLM solo con ese chunk
@@ -176,6 +201,7 @@ Chunk sent to the LLM when resolution is complete:
 ```json
 {
   "nutrition_context": {
+    "mode": "single_meal",
     "situation_key": "crossfit",
     "moment_key": "almuerzo",
     "meal_block_key": "comida_2",
@@ -188,12 +214,42 @@ Chunk sent to the LLM when resolution is complete:
 }
 ```
 
+Chunk sent to the LLM when the user asks for the whole day:
+
+```json
+{
+  "nutrition_context": {
+    "mode": "full_day",
+    "situation_key": "ciclismo",
+    "supplementation": ["10g de creatina monohidrato creapure"],
+    "meal_blocks": [
+      {
+        "moment_key": "desayuno",
+        "moment_label": "Desayuno",
+        "meal_block_key": "comida_1",
+        "meal_block": {}
+      },
+      {
+        "moment_key": "almuerzo",
+        "moment_label": "Almuerzo",
+        "meal_block_key": "comida_2",
+        "meal_block": {}
+      }
+    ]
+  }
+}
+```
+
 Rules:
 
 - The chunk is read-only context.
 - The LLM may explain and format the block, but must not invent quantities.
 - If `situation_key` or `moment_key` is missing, ask one short clarification
   instead of sending the full plan.
+- If the user clearly asks for the whole day, resolve all canonical moments
+  configured for that situation and send only those meal blocks. Do not include
+  alias-only moment keys such as `comida` or `mediodia` when they point to the
+  same canonical `almuerzo` block.
 - If multiple situations match with similar confidence, ask the user to choose.
 - If the resolved `meal_block_key` is missing from `comidas`, treat it as
   configuration error.
@@ -440,126 +496,22 @@ Avoid passing:
 - parsed food objects when raw strings are enough;
 - full extraction warnings for normal recommendations.
 
-## situaciones Document
+## Situations Document Notes
 
-`situaciones` is a compact routing document. It maps:
+The canonical `situaciones` shape is defined above in
+[Situations Router Document](#situations-router-document). Keep only one
+operational contract:
 
-```text
-day situation + meal moment -> comida key
-```
+- root `momentos` defines canonical meal moments and aliases;
+- root `situaciones` defines configurable day contexts and maps each moment to a
+  `comida_*` key;
+- activity keys and moment keys are plan data, not hardcoded sports or fixed
+  meals;
+- after routing, the bot reads quantities only from the selected `comidas`
+  block.
 
-It does not contain quantities, recipes, cooking instructions, calories, or
-adaptation rules. After resolving a comida key, the bot must read that comida
-from the compact `comidas` document.
-
-Current Spanish shape:
-
-```json
-{
-  "situaciones": {
-    "crossfit": {
-      "tipo_dia": "entrenamiento_fuerza_por_la_tarde",
-      "suplementacion": [
-        "10g de creatina monohidrato creapure"
-      ],
-      "momentos": {
-        "desayuno": "comida_1",
-        "almuerzo": "comida_2",
-        "merienda": "comida_0",
-        "cena": "comida_3"
-      }
-    },
-    "no_entreno": {
-      "tipo_dia": "no_entreno",
-      "suplementacion": [
-        "10g de creatina monohidrato creapure"
-      ],
-      "momentos": {
-        "desayuno": "comida_1",
-        "almuerzo": "comida_5",
-        "merienda": "comida_0",
-        "cena": "comida_3"
-      }
-    }
-  }
-}
-```
-
-Resolution examples:
-
-- `crossfit + almuerzo -> comida_2`
-- `futbol + cena -> comida_3`
-- `no_entreno + almuerzo -> comida_5`
-
-Resolution function:
-
-```python
-def resolve_comida_key(
-    situaciones_doc: dict,
-    situation_key: str,
-    moment_key: str,
-) -> str | None:
-    situations = situaciones_doc.get("situaciones", {})
-    situation = situations.get(situation_key)
-    if not situation:
-        return None
-    moments = situation.get("momentos", {})
-    return moments.get(moment_key)
-```
-
-Rules:
-
-- Root `situaciones` is required.
-- Each key under `situaciones` is an allowed day context configured for that
-  user or plan.
-- Activity keys are not limited to `crossfit`, `futbol`, or `no_entreno`.
-  They may include any real user context, such as `ciclismo`, `atletismo`,
-  `fuerza`, `natacion`, `senderismo`, `competicion`, `viaje`,
-  `descanso_activo`, or `no_entreno`.
-- `tipo_dia` is descriptive context. The operational key is the object key.
-- `momentos` is required for every situation.
-- Each `momentos` value must be a string reference to an existing comida key.
-- `suplementacion` must be an array of strings and may be empty.
-- Supplementation should be preserved, but not repeated in every meal answer.
-  Mention it only for daily planning or when the user asks about supplements.
-- Missing situation context should trigger a short clarification.
-- The clarification should use the configured situation keys for that user,
-  not a hardcoded list of sports.
-- Missing meal moment should trigger a short clarification or a low-confidence
-  time-based suggestion in a future version.
-- Missing moment mapping must not invent a comida.
-- A reference to a missing comida is a validation error.
-
-Validation rules:
-
-- `situaciones` must be an object.
-- Every situation must be an object.
-- `momentos` must be a non-empty object.
-- Every `momentos.*` value must be a string.
-- Every referenced comida key must exist in `comidas`.
-- `suplementacion`, when present, must be an array of strings.
-
-Generic future aliases may be supported later:
-
-```json
-{
-  "situations": {
-    "training_day": {
-      "label": "Training day",
-      "description": "Day with strength or high intensity training",
-      "supplementation": ["creatine"],
-      "moments": {
-        "breakfast": "meal_block_001",
-        "lunch": "meal_block_002"
-      }
-    }
-  }
-}
-```
-
-For the Spanish V1/V2 contract, prefer `situaciones`, `tipo_dia`,
-`suplementacion`, and `momentos` because that matches the current source data.
-Do not hardcode sports in the product logic; treat situation keys as plan data.
+Future persistence may split `situaciones` into a separate JSONB document, but
+the runtime contract stays the same.
 
 ## recetas Document
 

--- a/bot_profiles/nutrition/docs/data-contracts.md
+++ b/bot_profiles/nutrition/docs/data-contracts.md
@@ -14,40 +14,46 @@ V1 storage:
 
 - `nutrition_plans`: one row per uploaded/generated plan.
 - `nutrition_plan_documents`: JSONB documents belonging to a plan.
-- `nutrition_plan_upload_sessions`: state for `/new_plan` uploads.
 
 `nutrition_plans.user_id` references `users(id)` as `INTEGER`.
 
-Plan states:
+Implemented plan states:
 
-- `draft`
 - `active`
-- `failed`
 - `archived`
 
-Upload session states:
+Reserved future plan states:
 
-- `waiting_for_plan_upload`
-- `processing`
-- `completed`
-- `cancelled`
+- `draft`
 - `failed`
-- `expired`
 
 Document types live in the database row, not necessarily inside the JSONB
 content. For V1:
 
-- `nutrition_plan_documents.document_type = meal_blocks`
-- `nutrition_plan_documents.content = compact comidas document`
+- `nutrition_plan_documents.document_type = situaciones`
+- `nutrition_plan_documents.content = {"plan_id": "...", "situaciones": {...}}`
+- `nutrition_plan_documents.document_type = comidas`
+- `nutrition_plan_documents.content = {"plan_id": "...", "comidas": {...}}`
 
-Input priority for `/new_plan`:
+Optional plan-support documents:
 
-1. Valid compact JSON with root `comidas`: validate and store directly.
-2. Pasted text: extract/generate compact `comidas`.
-3. PDF: extract text, then generate compact `comidas`.
+- `nutrition_plan_documents.document_type = reglas_adaptacion`
+- `nutrition_plan_documents.document_type = recetas`
 
-Direct JSON is the most reliable and lowest-cost path. It should bypass LLM
-generation.
+`meal_plan` is a legacy document type kept readable during the transition from
+single-document storage.
+
+Input priority for `/set_plan`:
+
+1. Attached `situaciones.json` document.
+2. Attached `comidas.json` document.
+3. Combined JSON containing both roots.
+4. Pasted JSON after `/set_plan` for small tests.
+
+Split `situaciones`/`comidas` uploads use local validation and draft storage.
+The bot asks the configured normalizer model only when a combined payload needs
+cleanup. If the model is unavailable and the input already validates, local
+validation may store it without an LLM call.
 
 ## V1 Compact Meal Blocks Document
 
@@ -510,8 +516,8 @@ operational contract:
 - after routing, the bot reads quantities only from the selected `comidas`
   block.
 
-Future persistence may split `situaciones` into a separate JSONB document, but
-the runtime contract stays the same.
+Persistence stores `situaciones` and `comidas` as separate JSONB documents. The
+runtime combines them into one `NutritionPlan` object before routing.
 
 ## recetas Document
 

--- a/bot_profiles/nutrition/docs/open-considerations.md
+++ b/bot_profiles/nutrition/docs/open-considerations.md
@@ -1,0 +1,242 @@
+# Nutrition Bot Open Considerations
+
+This document lists important gaps and design decisions that must stay visible
+before the bot gives more advanced nutrition guidance.
+
+The bot is not a clinician. It helps apply a nutrition plan already provided by
+a professional. It should stay inside that scope unless a qualified
+professional reviews and approves broader behavior.
+
+## Product Scope Risks
+
+The bot must not drift from plan interpreter to diet prescriber.
+
+Allowed:
+
+- explain the user's active plan;
+- choose the correct comida for a situation and moment;
+- adapt a real dish to the selected comida;
+- build weekly menus from configured situaciones and comidas;
+- track meals and help the user return to the plan calmly.
+
+Not allowed without professional review:
+
+- create a new diet from scratch;
+- prescribe calories or macros not present in the plan;
+- diagnose or treat medical conditions;
+- recommend aggressive compensation after missed meals or deviations;
+- approve user-submitted recipes automatically.
+
+## User Data We Probably Need
+
+Future planning will be weak unless the bot knows or can ask for:
+
+- active nutrition plan;
+- configured situaciones for that user;
+- allergies and intolerances;
+- foods the user refuses or cannot access;
+- dietary pattern such as vegetarian, vegan, halal, kosher, gluten-free, or
+  lactose-free;
+- cooking constraints, such as no kitchen, meal prep, restaurant meals, or
+  travel;
+- training schedule, including sport, day, rough time, intensity, and duration;
+- meal schedule, including skipped or shifted meals;
+- professional restrictions from the plan;
+- user preferences and budget.
+
+This data should be explicit and user-controlled. Do not infer sensitive health
+details from casual text unless the user states them clearly.
+
+## Safety Flags
+
+The bot should stop normal plan optimization and recommend professional help
+when the user mentions:
+
+- pregnancy or breastfeeding;
+- diabetes, kidney disease, cardiovascular disease, cancer, gastrointestinal
+  disease, or any condition where diet is part of treatment;
+- medication interactions or supplements used as treatment;
+- eating disorder history or signs of disordered eating;
+- repeated binge episodes, purging, fasting as punishment, or extreme
+  restriction;
+- minors or guardians asking for restrictive dieting;
+- fainting, chest pain, persistent vomiting, severe dehydration, or similar
+  acute symptoms.
+
+In those cases the bot can help organize information, but should not adjust the
+plan independently.
+
+## Eating Disorder And Compensation Guardrails
+
+The bot must avoid language that reinforces guilt or punishment.
+
+Do:
+
+- acknowledge the event neutrally;
+- recommend returning to the next planned meal;
+- suggest simple, plan-compatible choices;
+- mention professional support when distress or repeated loss of control is
+  present.
+
+Do not:
+
+- tell the user to fast as punishment;
+- double or remove full meal blocks without an explicit plan rule;
+- encourage weighing, checking, or restriction loops;
+- frame foods as moral failure.
+
+Skipped meals need special handling. If the user says they skipped `media
+manana`, the default should be to keep the next meal anchored to its comida. Do
+not move all skipped quantities into dinner unless the plan explicitly says so.
+
+## Weekly Planning Gaps
+
+Weekly planning needs more than a single meal lookup.
+
+Required inputs:
+
+- days requested;
+- situation per day, or explicit defaults like "el resto no entreno";
+- moments requested, such as comidas and cenas;
+- active situaciones document;
+- active comidas document;
+- optional approved recipe retrieval.
+
+Open decisions:
+
+- how to store a generated weekly plan;
+- whether the weekly plan is temporary chat output or persisted;
+- how users edit a day after generation;
+- how to handle activities not configured in situaciones;
+- how to avoid repeating the same recipe too often;
+- how to handle batch cooking later without turning it into a new diet.
+
+Recommended first behavior:
+
+- generate the plan as chat output only;
+- use configured situaciones only;
+- ask when an activity is unknown;
+- use quantities from comidas;
+- use RAG only for approved recipe candidates;
+- keep the table compact.
+
+## Activity And Training Context
+
+Situation keys are plan data, not hardcoded sports.
+
+The same user may have:
+
+- crossfit;
+- futbol;
+- ciclismo;
+- atletismo;
+- natacion;
+- fuerza;
+- senderismo;
+- competicion;
+- viaje;
+- descanso_activo;
+- no_entreno.
+
+The bot should not assume all training days are nutritionally identical. If the
+plan distinguishes activities, use that. If it does not, ask or use the closest
+configured option only with user confirmation.
+
+## Recipes And RAG Risks
+
+Recipe RAG is useful, but the source of truth is still the plan.
+
+Important rules:
+
+- index only `approved` recipes for normal users;
+- keep pending recipes out of normal retrieval;
+- pass only a few compact candidates to the LLM;
+- never let recipe quantities override comidas;
+- keep review metadata outside normal prompts;
+- log enough metadata to understand which recipe candidate was used.
+
+Open decisions:
+
+- vector store or database search;
+- embedding model and language handling;
+- per-user recipe catalogs vs global approved catalog;
+- how to include allergies/restrictions in retrieval;
+- how admins/professionals review user-submitted recipes.
+
+## Supplementation
+
+`situaciones.suplementacion` should be preserved, but not repeated in every meal
+answer.
+
+The bot should mention supplements only when:
+
+- the user asks about supplementation;
+- the user asks for a full day plan;
+- the supplement timing affects the requested plan;
+- the professional plan explicitly includes it.
+
+The bot should not add new supplements or change supplement dosage without
+professional review.
+
+## Allergies, Intolerances, And Food Safety
+
+Before recommending recipes broadly, the bot needs a reliable place for
+allergies and intolerances.
+
+If a recipe contains a user-declared allergen, it must not be recommended even
+if it matches the comida.
+
+Food safety should stay simple:
+
+- do not recommend unsafe handling or storage;
+- avoid risky raw foods for vulnerable groups;
+- do not override professional or medical advice.
+
+## Validation Gaps
+
+Current contracts need validators for:
+
+- `comidas` recursive and/or trees;
+- missing or empty groups;
+- references from situaciones to existing comida keys;
+- recipe statuses;
+- recipe required fields before approval;
+- pending recipe review metadata;
+- unknown or ambiguous activity mapping;
+- weekly planning defaults.
+
+Important: validation should catch configuration errors before the bot gives a
+recommendation.
+
+## Explainability
+
+For normal users, explain simply:
+
+```text
+Uso el bloque de crossfit para la comida.
+Por eso te propongo arroz con pollo y verduras, usando la cantidad del bloque.
+```
+
+For admins/professionals, provide enough traceability:
+
+- situation key;
+- moment key;
+- comida key;
+- recipe candidate key if used;
+- relevant condition applied;
+- warnings that affected the answer.
+
+Do not expose raw JSON in normal user replies unless asked.
+
+## References
+
+These are high-level safety references, not implementation requirements:
+
+- [WHO healthy diet guidance](https://www.who.int/news-room/fact-sheets/detail/healthy-diet)
+  emphasizes adequacy, balance, moderation, diversity, and food safety.
+- [USDA Dietary Health overview](https://www.usda.gov/about-food/nutrition-research-and-programs/dietary-health)
+  describes healthy eating guidance as adaptable to personal preferences,
+  cultural traditions, and budget.
+- [NIMH eating disorder information](https://www.nimh.nih.gov/health/publications/eating-disorders)
+  reinforces that eating disorder symptoms need appropriate treatment and
+  support.

--- a/bot_profiles/nutrition/docs/orchestration.md
+++ b/bot_profiles/nutrition/docs/orchestration.md
@@ -1,0 +1,188 @@
+# Nutrition Bot Orchestration
+
+This document describes the first orchestration layer for the nutrition bot.
+It exists to keep the user experience practical while avoiding token-heavy
+prompts and hardcoded logic inside the generic bot engine.
+
+## Current Pipeline
+
+Runtime flow:
+
+```text
+Telegram message
+-> profile-selected memory backend
+-> local message understanding
+-> context-aware LLM message normalization
+-> daily nutrition log read plus deferred update preview
+-> plan context selection
+-> final LLM answer
+-> persist daily nutrition log update after successful delivery
+```
+
+The current implementation uses LangChain Core as a lightweight pipeline:
+
+```text
+RunnableLambda(classify message locally)
+-> RunnableLambda(normalize message with a configured model, optional)
+-> RunnableLambda(route plan context)
+```
+
+This is intentionally small. The first step does not call an LLM. It classifies
+common nutrition intents and extracts cheap signals such as mentioned weekdays,
+foods, deviations, shopping-list requests, and macro requests.
+
+The normalization step receives compact routing options from the active user's
+plan plus bounded memory context. It exists to make short follow-ups natural,
+for example `fútbol`, `y para cenar?`, `lo de antes`, or a correction to a food
+already being discussed.
+
+```json
+{
+  "situations": ["crossfit", "futbol", "pilates", "no_entreno"],
+  "moments": ["desayuno", "media_manana", "almuerzo", "cena"],
+  "allowed_intents": ["recommend_meal", "weekly_planning"]
+}
+```
+
+It returns validated JSON such as:
+
+```json
+{
+  "intent": "recommend_meal",
+  "situation_key": "pilates",
+  "target_moment_key": "media_manana",
+  "logged_meals": [],
+  "goal": "resolver snack personalizado",
+  "confidence": "high"
+}
+```
+
+The router validates every returned key against the active plan. Invalid
+situations or moments are ignored and the deterministic router remains the
+fallback.
+
+The plan context step decides what context to send to the final model:
+
+- single meal: one resolved `comida` block;
+- full day: all resolved blocks for one situation;
+- weekly planning: the situations mentioned by the user and their referenced
+  meal blocks;
+- shopping list: plan blocks plus conversation memory, because the useful
+  weekly choices may live in recent chat.
+- unresolved follow-up: candidate plan context plus memory, letting the final
+  model infer naturally or ask one specific clarification.
+
+The daily log step stores one editable state per user, profile, and real date in
+PostgreSQL. It is not a replacement for conversation memory. During prompt
+preparation the bot reads the current log and builds an in-memory preview of
+any update implied by the message. The database write is deferred until after
+the answer has been sent successfully, so failed model calls do not mutate the
+user's day state. The log tracks:
+
+- one current day type, for example `crossfit` or `natacion`;
+- logged or skipped meal moments, preserving the user's raw text;
+- `completed=true/false` per meal moment;
+- compact notes about corrections.
+
+When the user says "esta manana era crossfit" and later "al final no he ido,
+que ceno?", the day type is updated to `no_entreno`. The same applies to
+replacements such as "cambio crossfit por natacion": the current day type
+becomes `natacion` if it exists in the active plan. The bot should use the daily
+log to avoid asking again for context that the user already gave, while still
+letting explicit new user input override stale state.
+
+The generic `engine.py` should not know how nutrition routing works. It only
+receives:
+
+- the prompt profile to use;
+- runtime instructions;
+- whether recent memory should be included;
+- an optional direct clarification answer;
+- optional post-success actions, such as committing a daily log update.
+
+The nutrition profile currently sets `memory_backend = langchain_postgres`.
+Recent raw turns are stored through LangChain's maintained
+`PostgresChatMessageHistory` implementation. BotForge keeps only the
+user/profile session mapping, privacy deletion hook, and compact summary. The
+backend reads bounded recent and compaction windows instead of loading the full
+chat history for every prompt. The selection is profile-level configuration so
+other bots can keep the plain PostgreSQL adapter or use a different memory
+backend later.
+
+## Model Routing Direction
+
+The desired architecture is:
+
+```text
+cheap local step
+-> tool/context retrieval
+-> high-quality remote response model
+```
+
+Examples:
+
+- local model, NVIDIA, or deterministic rules for cleaning and intent
+  classification;
+- local plan router for `situaciones + momento -> comida`;
+- RAG retrieval for approved recipes;
+- remote NVIDIA model for the final user-facing answer.
+
+The current default uses NVIDIA for the optional normalization step when
+configured, because no local model is available yet. The provider and model are
+separate from the final answer model:
+
+```text
+NUTRITION_NORMALIZER_PROVIDER=nvidia
+NUTRITION_NORMALIZER_MODEL=nvidia/llama-3.3-nemotron-super-49b-v1.5
+```
+
+When a cheaper local model is available, only this configuration should need to
+change.
+
+## Future MCP Boundaries
+
+Likely MCP/tool boundaries:
+
+- `nutrition_plan_context`: fetch active user plan documents from PostgreSQL;
+- `nutrition_message_normalizer`: map free text to plan-specific keys;
+- `nutrition_router`: resolve situation, moment, and meal block;
+- `nutrition_recipes`: retrieve approved recipes from RAG;
+- `nutrition_memory`: retrieve daily logs and adherence state;
+- `nutrition_week_planner`: build week-level candidate plans;
+- `nutrition_admin_review`: manage pending recipes and plan documents.
+
+These should stay behind orchestration functions. The final answer model should
+receive only the compact context needed for the current reply.
+
+## UX Rules
+
+The orchestration layer exists to protect the Telegram experience:
+
+- prefer one useful recommendation over dumping the full plan;
+- ask one short clarification when situation or meal moment is missing;
+- avoid deterministic clarification loops; if the user is clearly continuing a
+  previous topic, use memory before asking again;
+- treat macro or "all meals/day" requests as full-day context, not as a missing
+  meal moment;
+- support user-specific plan vocabularies such as one user having `pilates` and
+  `media_manana` while another has `futbol` and no mid-morning meal;
+- use recent conversation for follow-up answers;
+- use today's daily nutrition log for same-day situation changes, skipped
+  meals, and meal records;
+- keep memory available for non-plan questions;
+- keep memory backend selection outside nutrition business logic;
+- do not use stale failure messages as permanent context;
+- never invent quantities outside `comidas`.
+
+## Test Expectations
+
+Tests should cover:
+
+- intent classification from real informal messages;
+- single-meal context selection;
+- full-day and weekly-planning context selection;
+- follow-up resolution using recent conversation;
+- direct clarification without calling the LLM;
+- memory inclusion for non-plan messages and shopping-list planning.
+- daily log routing when the user asks a short follow-up such as `que ceno?`;
+- training cancellation such as `al final no he ido al crossfit`.

--- a/bot_profiles/nutrition/docs/response-behavior.md
+++ b/bot_profiles/nutrition/docs/response-behavior.md
@@ -20,6 +20,26 @@ like a generic diet generator.
 
 ## Response Shape
 
+Most basic successful answer:
+
+```text
+Cena de no entreno:
+330g de merluza con ensalada.
+
+Añade 20g de aceite de oliva. Si prefieres aguacate, usa 160g.
+```
+
+Rules for this answer:
+
+- Say the detected context in human language when useful, for example `Cena de
+  no entreno`.
+- Recommend one concrete valid option, not the full block.
+- Include the plan quantities for the chosen foods.
+- Apply explicit conditions from the block, such as removing oil with fatty
+  fish or fatty meat.
+- Mention alternatives only when they are useful and short.
+- Do not show macros by default.
+
 Preferred short answer:
 
 ```text

--- a/bot_profiles/nutrition/docs/response-behavior.md
+++ b/bot_profiles/nutrition/docs/response-behavior.md
@@ -1,0 +1,291 @@
+# Nutrition Bot Response Behavior
+
+The nutrition bot should feel practical, direct, and calm. It should not behave
+like a generic diet generator.
+
+## Core Rules
+
+- Respond in Spanish by default.
+- Respect the user's active nutrition plan.
+- Do not invent foods, quantities, macros, recipes, or medical claims.
+- Do not diagnose health conditions.
+- Do not replace a doctor, registered dietitian, or nutrition professional.
+- Ask a short clarification when the plan context is missing.
+- Keep answers short unless the user asks for detail.
+- Do not show macros unless the user asks for macros, calories, quantities,
+  deficit, or daily status.
+- Avoid guilt, shame, punishment, and extreme compensation.
+- If a food does not fit, offer a close option from the plan.
+
+## Response Shape
+
+Preferred short answer:
+
+```text
+Cena:
+Salmon con ensalada.
+
+Sin aceite, porque el salmon ya aporta grasa.
+```
+
+When context is missing:
+
+```text
+Necesito una cosa para ajustarlo bien: es comida o cena?
+```
+
+When no active plan exists:
+
+```text
+Para ayudarte bien necesito tu plan nutricional.
+
+Puedes subirlo con /new_plan en texto o PDF.
+```
+
+When the user asks for technical detail:
+
+```text
+El bloque de cena permite una proteina, verdura y una fuente de grasa.
+
+Como el salmon ya aporta grasa, no anadiria aceite en esta comida.
+```
+
+## Good Responses
+
+User:
+
+```text
+Voy a cenar salmon.
+```
+
+Bot:
+
+```text
+Cena:
+Salmon con ensalada.
+
+Sin aceite, porque el salmon ya aporta grasa.
+```
+
+Why it is good:
+
+- Uses the requested food.
+- Gives one concrete meal.
+- Explains only the key adjustment.
+
+User:
+
+```text
+Puedo meter pasta?
+```
+
+Bot:
+
+```text
+Si el bloque de esa comida incluye pasta o un hidrato equivalente, si.
+
+Dime si es comida o cena y te digo la cantidad del plan.
+```
+
+Why it is good:
+
+- Does not assume the meal moment.
+- Does not invent a quantity.
+- Keeps the next step simple.
+
+User:
+
+```text
+Me he pasado con los dulces.
+```
+
+Bot:
+
+```text
+No lo compensaria con castigo.
+
+Siguiente comida:
+proteina magra + verdura.
+
+Sin pan, arroz, pasta ni grasa extra.
+```
+
+Why it is good:
+
+- Avoids guilt.
+- Gives a practical next step.
+- Avoids extreme compensation.
+
+User:
+
+```text
+Hoy tengo crossfit, que puedo comer?
+```
+
+Bot:
+
+```text
+Para hoy usaria el bloque de crossfit.
+
+Comida:
+Arroz con pollo o pavo y verduras.
+
+Usa las cantidades del bloque y no anadas otro hidrato como pan o pasta.
+```
+
+Why it is good:
+
+- Resolves the day situation before suggesting food.
+- Uses the comida block as source of quantities.
+- Keeps the answer practical.
+
+User:
+
+```text
+Que ceno hoy? Me he saltado la media manana.
+```
+
+Bot:
+
+```text
+Cena:
+Pescado blanco con ensalada.
+
+Mantendria la cena del bloque. No hace falta compensar metiendo el doble.
+Si tienes hambre, prioriza la proteina y la verdura del plan.
+```
+
+Why it is good:
+
+- Does not punish or overcompensate.
+- Keeps dinner anchored to the plan.
+- Acknowledges the skipped meal.
+
+User:
+
+```text
+Hazme un plan de comidas y cenas para la semana:
+lunes ciclismo, miercoles fuerza, viernes atletismo y el resto no entreno.
+```
+
+Bot:
+
+```text
+Plan semanal
+
+Lunes - ciclismo
+Comida: arroz tipo paella con pollo o pavo.
+Cena: pescado blanco con ensalada.
+
+Martes - no entreno
+Comida: carne magra con verdura y la fuente de hidrato del bloque.
+Cena: tortilla con ensalada.
+
+Si quieres, despues lo ajustamos por preferencias.
+```
+
+Why it is good:
+
+- Uses the user's weekly activity schedule.
+- Keeps the output readable on Telegram.
+- Does not expose internal JSON.
+
+## Bad Responses
+
+Bad:
+
+```text
+Segun el nodo meal_block_dinner.structure.children[2], debes seleccionar...
+```
+
+Problem:
+
+- Too technical for normal use.
+- Exposes internal structure unnecessarily.
+
+Bad:
+
+```text
+Come 1800 kcal y haz ayuno manana.
+```
+
+Problem:
+
+- Invents a diet target.
+- Promotes compensation without plan context.
+
+Bad:
+
+```text
+Claro, puedes meter arroz, pasta y pan juntos.
+```
+
+Problem:
+
+- Breaks the usual `or` semantics for carb sources.
+- May contradict the plan.
+
+Bad:
+
+```text
+Como te saltaste la media manana, cena el doble de hidratos.
+```
+
+Problem:
+
+- Invents compensation.
+- May break the plan.
+- Encourages a reactive eating pattern.
+
+Bad:
+
+```text
+Te paso todas las recetas disponibles para la semana...
+```
+
+Problem:
+
+- Wastes prompt and Telegram space.
+- The bot should retrieve only relevant approved recipe candidates.
+
+## Macros Policy
+
+Do not show macros by default.
+
+Show macros only when the user asks about:
+
+- macros;
+- calories;
+- quantities;
+- deficit;
+- "como voy hoy";
+- comparison between meals or days.
+
+When showing macros, use the plan's values only. If macros are missing or
+ambiguous, say so.
+
+## Safety Escalation
+
+Recommend professional help when the user mentions:
+
+- diagnosed illness requiring dietary management;
+- pregnancy or breastfeeding;
+- eating disorder symptoms;
+- extreme restriction, purging, or binge distress;
+- medication interactions;
+- severe symptoms such as fainting, chest pain, or persistent vomiting.
+
+Example:
+
+```text
+Eso merece revisarlo con un profesional sanitario. Puedo ayudarte a ordenar la
+informacion del plan, pero no deberia ajustar una pauta medica por mi cuenta.
+```
+
+## Formatting
+
+- Use short paragraphs.
+- Use small lists when they improve readability.
+- Avoid long tables in Telegram.
+- Do not include raw JSON unless the user asks for technical detail.
+- Prefer food names and practical instructions over implementation terms.

--- a/bot_profiles/nutrition/docs/response-behavior.md
+++ b/bot_profiles/nutrition/docs/response-behavior.md
@@ -79,7 +79,7 @@ When no active plan exists:
 ```text
 Para ayudarte bien necesito tu plan nutricional.
 
-Puedes subirlo con /new_plan en texto o PDF.
+Envia /set_plan y despues sube situaciones.json y comidas.json como documentos.
 ```
 
 When the user asks for technical detail:

--- a/bot_profiles/nutrition/docs/response-behavior.md
+++ b/bot_profiles/nutrition/docs/response-behavior.md
@@ -7,6 +7,7 @@ like a generic diet generator.
 
 - Respond in Spanish by default.
 - Respect the user's active nutrition plan.
+- Prefer locally resolved plan chunks over sending or exposing the full plan.
 - Do not invent foods, quantities, macros, recipes, or medical claims.
 - Do not diagnose health conditions.
 - Do not replace a doctor, registered dietitian, or nutrition professional.
@@ -32,6 +33,25 @@ When context is missing:
 
 ```text
 Necesito una cosa para ajustarlo bien: es comida o cena?
+```
+
+When the day situation is missing:
+
+```text
+Para ajustarlo al plan: hoy es crossfit, futbol, ciclismo, atletismo o descanso?
+```
+
+When the meal moment is missing:
+
+```text
+Te lo ajusto, pero dime el momento: desayuno, almuerzo, merienda o cena?
+```
+
+When the router finds multiple day situations:
+
+```text
+Te he entendido dos contextos posibles: descanso y ciclismo.
+Quieres tratar hoy como descanso o como ciclismo?
 ```
 
 When no active plan exists:
@@ -125,18 +145,39 @@ Hoy tengo crossfit, que puedo comer?
 Bot:
 
 ```text
-Para hoy usaria el bloque de crossfit.
-
-Comida:
-Arroz con pollo o pavo y verduras.
-
-Usa las cantidades del bloque y no anadas otro hidrato como pan o pasta.
+Para ajustarlo bien, dime el momento: desayuno, almuerzo, merienda o cena?
 ```
 
 Why it is good:
 
-- Resolves the day situation before suggesting food.
-- Uses the comida block as source of quantities.
+- It detects the day situation.
+- It does not guess the meal moment.
+- It avoids sending or exposing irrelevant blocks.
+
+User:
+
+```text
+Hoy tengo crossfit, que como al mediodia?
+```
+
+Bot:
+
+```text
+Almuerzo de crossfit:
+
+Elige una grasa:
+20g de aceite de oliva, 160g de aguacate o 80g de aceitunas.
+
+Anade verdura hasta 375g y una fuente de hidrato, por ejemplo 30g de arroz
+integral o 140g de patata.
+
+Proteina: 360g de pollo/pavo o 495g de pescado blanco.
+```
+
+Why it is good:
+
+- Resolves `crossfit + almuerzo -> comida_2`.
+- Uses only the relevant chunk.
 - Keeps the answer practical.
 
 User:
@@ -191,6 +232,17 @@ Why it is good:
 - Does not expose internal JSON.
 
 ## Bad Responses
+
+Bad:
+
+```text
+Te paso todo tu plan completo para que elijas...
+```
+
+Problem:
+
+- Wastes tokens and Telegram space.
+- The runtime should resolve the relevant chunk first.
 
 Bad:
 

--- a/bot_profiles/nutrition/docs/roadmap.md
+++ b/bot_profiles/nutrition/docs/roadmap.md
@@ -47,6 +47,7 @@ Goal: use the active plan to answer practical meal questions.
 
 Issues:
 
+- #94: Local situations router and plan chunk selection.
 - #87: Activate nutrition plan.
 - #88: First responses with active plan.
 - #89: Basic adaptation of concrete foods.
@@ -59,7 +60,33 @@ Definition of done:
 - With active plan, bot answers from the relevant `meal_blocks` slice.
 - If the user provides today's activity, the bot resolves it through
   `situaciones` when available.
+- The runtime should detect situation and meal moment locally when possible,
+  then send only the resolved meal block to the LLM.
+- If situation or moment is missing, bot asks one concise clarification instead
+  of sending the full plan.
 - Bot does not invent quantities or foods.
+
+## MVP 2A: Demo Plan Router Before Persistence
+
+Goal: get useful responses from the repository demo plan before full user plan
+persistence is implemented.
+
+Issue:
+
+- #94: Local situations router and plan chunk selection.
+
+Definition of done:
+
+- The nutrition profile can load the repository demo plan.
+- The router detects day situations from `situaciones.*.aliases`.
+- The router detects common meal moments from natural language.
+- Complete queries such as `Hoy tengo crossfit, que como al mediodia?` resolve
+  to one comida block before the LLM call.
+- Ambiguous or incomplete queries ask for the missing context.
+- The prompt receives only the resolved block, not the full demo plan.
+
+This is a temporary but useful step. Later persistence should reuse the same
+router contract against each user's active plan.
 
 ## MVP 3: Daily Tracking
 

--- a/bot_profiles/nutrition/docs/roadmap.md
+++ b/bot_profiles/nutrition/docs/roadmap.md
@@ -62,6 +62,9 @@ Definition of done:
   `situaciones` when available.
 - The runtime should detect situation and meal moment locally when possible,
   then send only the resolved meal block to the LLM.
+- For the basic happy path, the answer should recommend one concrete valid
+  option from the resolved block, with plan quantities, instead of listing the
+  whole block.
 - If situation or moment is missing, bot asks one concise clarification instead
   of sending the full plan.
 - Bot does not invent quantities or foods.

--- a/bot_profiles/nutrition/docs/roadmap.md
+++ b/bot_profiles/nutrition/docs/roadmap.md
@@ -1,0 +1,119 @@
+# Nutrition Bot Roadmap
+
+This roadmap is tracked under epic #79. Issue #92 owns these design documents.
+
+## Working Rule
+
+Before implementing any nutrition bot issue, read the relevant design docs in
+this directory.
+
+If implementation changes product behavior, data shape, journeys, stories, or
+MVP order, update these docs in the same PR.
+
+For behavior that touches health, compensation, supplements, weekly planning, or
+recipe recommendations, also check [Open considerations](open-considerations.md).
+
+## MVP 1: Base Bot And Plan Capture
+
+Goal: create a draft plan from text or PDF and store compact `meal_blocks` as
+JSONB.
+
+Issues:
+
+- #92: Nutrition bot design docs.
+- #80: Nutrition bot profile and guardrails.
+- #81: JSONB persistence for nutrition plans.
+- #82: `meal_blocks` contract and validation.
+- #83: `/new_plan` command and upload session.
+- #84: V1 text and PDF extraction.
+- #85: LLM generator for `meal_blocks`.
+- #86: Save draft and summarize generated plan.
+
+Definition of done:
+
+- User can start `/new_plan`.
+- Bot accepts compact `comidas` JSON, text, or PDF.
+- Valid JSON `comidas` bypasses LLM extraction.
+- Bot generates only `meal_blocks`.
+- JSON preserves original food strings, notes, and conditions.
+- JSON preserves nested `and`/`or` grouping recursively.
+- JSON contains warnings for ambiguity.
+- Draft plan and document are saved in PostgreSQL.
+- Bot replies with a clear summary.
+
+## MVP 2: Activate And Use Active Plan
+
+Goal: use the active plan to answer practical meal questions.
+
+Issues:
+
+- #87: Activate nutrition plan.
+- #88: First responses with active plan.
+- #89: Basic adaptation of concrete foods.
+
+Definition of done:
+
+- User can activate a valid draft.
+- Only one plan is active per user.
+- Without active plan, bot suggests `/new_plan`.
+- With active plan, bot answers from the relevant `meal_blocks` slice.
+- If the user provides today's activity, the bot resolves it through
+  `situaciones` when available.
+- Bot does not invent quantities or foods.
+
+## MVP 3: Daily Tracking
+
+Goal: record meals and answer daily progress questions.
+
+Issue:
+
+- #90: Daily tracking MVP.
+
+Definition of done:
+
+- User can register a meal in natural language.
+- Bot preserves the original meal text.
+- Bot compares simple records with the active plan.
+- Bot answers "como voy hoy" with a practical next step.
+- Bot can handle skipped meal context without automatic overcompensation.
+
+## MVP 4: Advanced Documents
+
+Goal: add richer plan interpretation without breaking V1.
+
+Issue:
+
+- #91: Advanced documents and future management.
+
+Implementation note: #91 is a phased backlog, not a single all-in-one build.
+Ship the smallest useful slice first, usually `situaciones`, before recipes,
+RAG, review queues, or weekly planning.
+
+Definition of done:
+
+- `situaciones` maps day context and meal moment to comida keys.
+- `situaciones` references are validated against the active `comidas` document.
+- `recetas` suggests approved real dishes without overriding quantities.
+- `recetas` is accessed through retrieval/RAG so prompts receive only relevant
+  approved candidates, not the full catalog.
+- User-submitted recipes are saved as `pending_review` until admin/professional
+  review.
+- Weekly planning can map a user-provided activity schedule to comidas and
+  produce meals/dinners with plan quantities.
+- `adaptation_rules` provides generic interpretation rules.
+- Explicit plan conditions remain higher priority than generic rules.
+
+## Out Of Scope Until Scheduled
+
+- OCR for images.
+- Batch cooking.
+- Comparing multiple plans.
+- Full recipe review UI beyond the JSONB/admin workflow.
+- Manual JSON editing UI.
+- Full nutrient database integration.
+
+## Data Principle
+
+The active source of truth for quantities is always the compact `meal_blocks`
+document. Future documents may select, explain, or adapt blocks, but they must
+not silently override block quantities.

--- a/bot_profiles/nutrition/docs/roadmap.md
+++ b/bot_profiles/nutrition/docs/roadmap.md
@@ -15,38 +15,42 @@ recipe recommendations, also check [Open considerations](open-considerations.md)
 
 ## MVP 1: Base Bot And Plan Capture
 
-Goal: create a draft plan from text or PDF and store compact `meal_blocks` as
-JSONB.
+Goal: create an active plan from pasted JSON or a `.json/.txt` upload and store
+the compact plan as JSONB.
 
 Issues:
 
 - #92: Nutrition bot design docs.
 - #80: Nutrition bot profile and guardrails.
 - #81: JSONB persistence for nutrition plans.
-- #82: `meal_blocks` contract and validation.
-- #83: `/new_plan` command and upload session.
-- #84: V1 text and PDF extraction.
-- #85: LLM generator for `meal_blocks`.
-- #86: Save draft and summarize generated plan.
+- #82: `comidas` contract and validation.
+- #83: `/set_plan` command for pasted JSON and `.json/.txt` files.
+- #84: V1 JSON text ingestion.
+- #85: LLM normalizer for `situaciones` and `comidas`.
+- #86: Save active plan and summarize generated plan.
 
 Definition of done:
 
-- User can start `/new_plan`.
-- Bot accepts compact `comidas` JSON, text, or PDF.
-- Valid JSON `comidas` bypasses LLM extraction.
-- Bot generates only `meal_blocks`.
+- User can start `/set_plan`.
+- Bot accepts compact plan JSON pasted as text or attached as `.json/.txt`.
+- Valid JSON can fall back to local validation if LLM normalization is
+  unavailable.
+- Bot generates or normalizes only the active plan documents needed for V1:
+  `situaciones` and `comidas`.
 - JSON preserves original food strings, notes, and conditions.
 - JSON preserves nested `and`/`or` grouping recursively.
 - JSON contains warnings for ambiguity.
-- Draft plan and document are saved in PostgreSQL.
+- Active plan and document are saved in PostgreSQL.
+- Previous active plan is archived only after the new plan validates.
 - Bot replies with a clear summary.
 
-## MVP 2: Activate And Use Active Plan
+## MVP 2: Use Active Plan Well
 
 Goal: use the active plan to answer practical meal questions.
 
 Issues:
 
+- #95: LangChain orchestration, message understanding, and model/tool routing.
 - #94: Local situations router and plan chunk selection.
 - #87: Activate nutrition plan.
 - #88: First responses with active plan.
@@ -54,10 +58,9 @@ Issues:
 
 Definition of done:
 
-- User can activate a valid draft.
 - Only one plan is active per user.
-- Without active plan, bot suggests `/new_plan`.
-- With active plan, bot answers from the relevant `meal_blocks` slice.
+- Without active plan, bot suggests `/set_plan`.
+- With active plan, bot answers from the relevant `comidas` slice.
 - If the user provides today's activity, the bot resolves it through
   `situaciones` when available.
 - The runtime should detect situation and meal moment locally when possible,
@@ -69,27 +72,42 @@ Definition of done:
   of sending the full plan.
 - Bot does not invent quantities or foods.
 
-## MVP 2A: Demo Plan Router Before Persistence
+## MVP 2A: Active Plan Router
 
-Goal: get useful responses from the repository demo plan before full user plan
-persistence is implemented.
+Goal: get useful responses from the active PostgreSQL plan for each user.
 
 Issue:
 
 - #94: Local situations router and plan chunk selection.
+- #95: LangChain orchestration, message understanding, and future MCP/model
+  routing.
 
 Definition of done:
 
-- The nutrition profile can load the repository demo plan.
+- The nutrition profile can load the active user plan from PostgreSQL.
 - The router detects day situations from `situaciones.*.aliases`.
 - The router detects common meal moments from natural language.
 - Complete queries such as `Hoy tengo crossfit, que como al mediodia?` resolve
   to one comida block before the LLM call.
+- Informal messages are classified locally before the final LLM call, so the
+  prompt can include intent, deviations, foods, and only the relevant plan
+  context.
+- An optional normalization model can map free text to the active user's own
+  `situaciones` and `momentos` before routing. This step must receive only
+  compact routing options, not the whole meal plan.
+- Weekly planning requests can pass the mentioned situations and referenced
+  meal blocks instead of failing as ambiguous single-meal requests.
+- Today's current day type, skipped meals, and logged meals are stored in
+  PostgreSQL as one editable daily state per user/profile/date.
+- Same-day corrections such as "al final no he ido al crossfit" update the
+  current day type and use that situation for the next meal recommendation.
+- Same-day replacements such as "cambio crossfit por natacion" update the
+  current day type to the replacement activity.
 - Ambiguous or incomplete queries ask for the missing context.
-- The prompt receives only the resolved block, not the full demo plan.
+- The prompt receives only the resolved block, not the full plan.
 
-This is a temporary but useful step. Later persistence should reuse the same
-router contract against each user's active plan.
+The router contract stays the same regardless of how the user's plan was
+uploaded or normalized.
 
 ## MVP 3: Daily Tracking
 
@@ -144,6 +162,6 @@ Definition of done:
 
 ## Data Principle
 
-The active source of truth for quantities is always the compact `meal_blocks`
+The active source of truth for quantities is always the compact `comidas`
 document. Future documents may select, explain, or adapt blocks, but they must
 not silently override block quantities.

--- a/bot_profiles/nutrition/docs/user-journeys.md
+++ b/bot_profiles/nutrition/docs/user-journeys.md
@@ -156,9 +156,10 @@ Flow:
 2. Bot detects recommendation intent.
 3. Bot detects or asks for day situation when `situaciones` is available.
 4. Bot detects or asks for the meal moment.
-5. Bot resolves `situacion + momento` to a `comida_*` key.
-6. Bot chooses compatible options from that comida.
-7. Bot replies briefly with the meal structure.
+5. Bot resolves `situacion + momento` to a `comida_*` key locally.
+6. Bot loads only that comida chunk.
+7. Bot asks the LLM to format a practical answer from that chunk.
+8. Bot replies briefly with the meal structure.
 
 Expected response:
 
@@ -175,8 +176,12 @@ Edge cases:
 - Missing day situation: ask using the configured options for that user's plan,
   such as cycling, athletics, football, strength, rest, or any other defined
   activity.
+- Multiple day situations detected: ask the user which one should drive the
+  plan for this meal.
 - No active plan: suggest `/new_plan`.
 - Missing mapping: do not invent a comida.
+- Complete mapping: do not send the full plan to the LLM; send only the
+  resolved chunk.
 
 ## Journey 6: Adapt A Concrete Food Or Dish
 

--- a/bot_profiles/nutrition/docs/user-journeys.md
+++ b/bot_profiles/nutrition/docs/user-journeys.md
@@ -17,14 +17,14 @@ Flow:
 3. Bot checks whether the user has an active nutrition plan.
 4. No active plan exists.
 5. Bot explains briefly that it needs the user's plan from their nutritionist.
-6. Bot suggests `/new_plan`.
+6. Bot suggests `/set_plan`.
 
 Expected response:
 
 ```text
 Para ayudarte bien necesito tu plan nutricional.
 
-Puedes subirlo con /new_plan en texto o PDF.
+Envia /set_plan y despues sube situaciones.json y comidas.json como documentos.
 ```
 
 Edge cases:
@@ -34,49 +34,48 @@ Edge cases:
 - If the user mentions a medical condition, the bot should recommend checking
   with a qualified professional.
 
-## Journey 2: Create A Draft Plan With /new_plan
+## Journey 2: Set An Active Plan With /set_plan
 
 Actor: authenticated Telegram user.
 
-Goal: upload or paste a nutrition plan and convert it into `meal_blocks`.
+Goal: upload `situaciones.json` and `comidas.json` and store them as the active
+user plan.
 
 Flow:
 
-1. User sends `/new_plan`.
-2. Bot creates or refreshes a `waiting_for_plan_upload` session.
-3. Bot asks the user to send compact `comidas` JSON, paste plan text, or upload
-   a PDF.
-4. User sends JSON, text, or a PDF document.
-5. If the input is valid `comidas` JSON, bot skips LLM extraction.
-6. If the input is text/PDF, bot extracts readable text.
-7. For text/PDF only, bot asks the LLM to generate compact `meal_blocks`,
-   preserving nested `and`/`or` groups from the source plan.
-8. Bot validates the JSON.
-9. Bot stores a new `nutrition_plan` in `draft` status.
-10. Bot stores `nutrition_plan_documents.document_type = meal_blocks`.
-11. Bot replies with a summary.
+1. User sends `/set_plan`.
+2. Bot explains that the user can upload `situaciones.json` and `comidas.json`
+   without captions.
+3. User attaches `situaciones.json`.
+4. Bot stores that part in a draft and replies that `comidas` is missing.
+5. User attaches `comidas.json`.
+6. Bot combines both parts and validates situations, meal references, meal
+   blocks, and nested `and`/`or` groups.
+7. Bot archives any previous active plan for that user.
+8. Bot stores the new `nutrition_plan` in `active` status.
+9. Bot stores `nutrition_plan_documents.document_type = situaciones` and
+   `document_type = comidas`.
+10. Bot replies with a short summary.
 
 Expected response:
 
 ```text
-Plan creado en borrador.
+Plan nutricional activo actualizado.
 
 He detectado:
 - 6 bloques de comida
-- 58 opciones alimentarias
-- 8 condiciones
-- 4 avisos de revision
-
-Estado: draft
+- 3 situaciones
+- normalizacion: LLM
 ```
 
 Edge cases:
 
-- Unsupported file: explain that V1 accepts `comidas` JSON, text, or PDF.
-- Unreadable PDF: ask the user to paste text or upload a clearer PDF.
-- Partial extraction: save draft if valid blocks exist and include warnings.
-- No blocks detected: mark the session failed and ask for a better source.
-- Existing active plan: create a new draft without overwriting the active plan.
+- Unsupported file: explain that V1 accepts `.json` or `.txt`.
+- Only one part uploaded: keep the draft and ask for the missing file.
+- Invalid JSON and no LLM normalization: ask the user to send valid JSON.
+- Invalid references: reject the plan and explain that a situation points to a
+  missing meal block.
+- Existing active plan: archive it only after the new plan validates.
 
 ## Journey 3: Review Generated Plan Summary
 
@@ -86,10 +85,10 @@ Goal: inspect whether extraction looks reasonable.
 
 Flow:
 
-1. Bot finishes `/new_plan`.
+1. Bot finishes `/set_plan`.
 2. Bot shows a summary of extracted blocks.
 3. User reviews block names, macro hints, warnings, and option counts.
-4. User decides whether to activate later, upload a new version, or wait.
+4. User decides whether to keep it active or upload a corrected version.
 
 Expected response:
 
@@ -111,37 +110,37 @@ Avisos:
 
 Edge cases:
 
-- No draft exists: suggest `/new_plan`.
-- Critical warnings: recommend uploading a clearer document before activation.
-- Non-critical warnings: allow later activation with warning.
+- No active plan exists: suggest `/set_plan`.
+- Critical validation errors: do not store the plan.
+- Non-critical warnings: store the plan if the core routing is valid.
 
-## Journey 4: Activate A Draft Plan
+## Journey 4: Replace The Active Plan
 
 Actor: authenticated Telegram user.
 
-Goal: select a draft plan as the active source of truth.
+Goal: replace an active plan without leaving the user with a broken plan.
 
 Flow:
 
-1. User asks to activate the generated plan.
-2. Bot finds the latest draft owned by the user.
-3. Bot validates that it contains valid `meal_blocks`.
-4. Bot deactivates or archives previous active plans for the same user.
-5. Bot marks the selected plan as `active`.
+1. User already has an active plan.
+2. User sends a new JSON plan with `/set_plan`.
+3. Bot validates and normalizes the new plan.
+4. Bot archives the previous active plan.
+5. Bot marks the new plan as `active`.
 6. Bot confirms the change.
 
 Expected response:
 
 ```text
-Plan activado.
+Plan nutricional activo actualizado.
 
 A partir de ahora usare este plan para interpretar tus comidas.
 ```
 
 Edge cases:
 
-- No draft: suggest `/new_plan`.
-- Draft has no valid blocks: do not activate.
+- No active plan: suggest `/set_plan`.
+- New upload has no valid blocks: keep the previous active plan.
 - Existing active plan: replace it only for the same user.
 
 ## Journey 5: Ask What To Eat
@@ -188,7 +187,7 @@ Edge cases:
   activity.
 - Multiple day situations detected: ask the user which one should drive the
   plan for this meal.
-- No active plan: suggest `/new_plan`.
+- No active plan: suggest `/set_plan`.
 - Missing mapping: do not invent a comida.
 - Complete mapping: do not send the full plan to the LLM; send only the
   resolved chunk.

--- a/bot_profiles/nutrition/docs/user-journeys.md
+++ b/bot_profiles/nutrition/docs/user-journeys.md
@@ -1,0 +1,446 @@
+# Nutrition Bot User Journeys
+
+These journeys describe the intended user experience for the nutrition bot.
+They should drive implementation decisions and test scenarios.
+
+## Journey 1: First Use Without A Plan
+
+Actor: authenticated Telegram user.
+
+Goal: understand that the bot needs a nutrition plan before giving useful
+nutrition guidance.
+
+Flow:
+
+1. User opens the bot after invite-based onboarding.
+2. User sends a nutrition question such as "Que como hoy?".
+3. Bot checks whether the user has an active nutrition plan.
+4. No active plan exists.
+5. Bot explains briefly that it needs the user's plan from their nutritionist.
+6. Bot suggests `/new_plan`.
+
+Expected response:
+
+```text
+Para ayudarte bien necesito tu plan nutricional.
+
+Puedes subirlo con /new_plan en texto o PDF.
+```
+
+Edge cases:
+
+- If the user asks for generic advice, the bot can give general, safe guidance
+  but must not pretend it has a plan.
+- If the user mentions a medical condition, the bot should recommend checking
+  with a qualified professional.
+
+## Journey 2: Create A Draft Plan With /new_plan
+
+Actor: authenticated Telegram user.
+
+Goal: upload or paste a nutrition plan and convert it into `meal_blocks`.
+
+Flow:
+
+1. User sends `/new_plan`.
+2. Bot creates or refreshes a `waiting_for_plan_upload` session.
+3. Bot asks the user to send compact `comidas` JSON, paste plan text, or upload
+   a PDF.
+4. User sends JSON, text, or a PDF document.
+5. If the input is valid `comidas` JSON, bot skips LLM extraction.
+6. If the input is text/PDF, bot extracts readable text.
+7. For text/PDF only, bot asks the LLM to generate compact `meal_blocks`,
+   preserving nested `and`/`or` groups from the source plan.
+8. Bot validates the JSON.
+9. Bot stores a new `nutrition_plan` in `draft` status.
+10. Bot stores `nutrition_plan_documents.document_type = meal_blocks`.
+11. Bot replies with a summary.
+
+Expected response:
+
+```text
+Plan creado en borrador.
+
+He detectado:
+- 6 bloques de comida
+- 58 opciones alimentarias
+- 8 condiciones
+- 4 avisos de revision
+
+Estado: draft
+```
+
+Edge cases:
+
+- Unsupported file: explain that V1 accepts `comidas` JSON, text, or PDF.
+- Unreadable PDF: ask the user to paste text or upload a clearer PDF.
+- Partial extraction: save draft if valid blocks exist and include warnings.
+- No blocks detected: mark the session failed and ask for a better source.
+- Existing active plan: create a new draft without overwriting the active plan.
+
+## Journey 3: Review Generated Plan Summary
+
+Actor: authenticated Telegram user.
+
+Goal: inspect whether extraction looks reasonable.
+
+Flow:
+
+1. Bot finishes `/new_plan`.
+2. Bot shows a summary of extracted blocks.
+3. User reviews block names, macro hints, warnings, and option counts.
+4. User decides whether to activate later, upload a new version, or wait.
+
+Expected response:
+
+```text
+Resumen del plan:
+
+1. Desayuno
+   Macros detectados: 40 HC / 20 P / 20 G
+   Opciones detectadas: 12
+
+2. Cena
+   Macros detectados: 10 HC / 70 P / 20 G
+   Opciones detectadas: 18
+
+Avisos:
+- 1 cantidad no se pudo interpretar.
+- 2 condiciones se guardaron como texto.
+```
+
+Edge cases:
+
+- No draft exists: suggest `/new_plan`.
+- Critical warnings: recommend uploading a clearer document before activation.
+- Non-critical warnings: allow later activation with warning.
+
+## Journey 4: Activate A Draft Plan
+
+Actor: authenticated Telegram user.
+
+Goal: select a draft plan as the active source of truth.
+
+Flow:
+
+1. User asks to activate the generated plan.
+2. Bot finds the latest draft owned by the user.
+3. Bot validates that it contains valid `meal_blocks`.
+4. Bot deactivates or archives previous active plans for the same user.
+5. Bot marks the selected plan as `active`.
+6. Bot confirms the change.
+
+Expected response:
+
+```text
+Plan activado.
+
+A partir de ahora usare este plan para interpretar tus comidas.
+```
+
+Edge cases:
+
+- No draft: suggest `/new_plan`.
+- Draft has no valid blocks: do not activate.
+- Existing active plan: replace it only for the same user.
+
+## Journey 5: Ask What To Eat
+
+Actor: authenticated Telegram user with an active plan.
+
+Goal: get a practical meal recommendation from the plan.
+
+Flow:
+
+1. User asks "Que ceno?" or "Que como hoy?".
+2. Bot detects recommendation intent.
+3. Bot detects or asks for day situation when `situaciones` is available.
+4. Bot detects or asks for the meal moment.
+5. Bot resolves `situacion + momento` to a `comida_*` key.
+6. Bot chooses compatible options from that comida.
+7. Bot replies briefly with the meal structure.
+
+Expected response:
+
+```text
+Cena:
+Pescado blanco con ensalada.
+
+Usa la grasa del bloque si corresponde.
+```
+
+Edge cases:
+
+- Missing meal moment: ask a short clarification.
+- Missing day situation: ask using the configured options for that user's plan,
+  such as cycling, athletics, football, strength, rest, or any other defined
+  activity.
+- No active plan: suggest `/new_plan`.
+- Missing mapping: do not invent a comida.
+
+## Journey 6: Adapt A Concrete Food Or Dish
+
+Actor: authenticated Telegram user with an active plan.
+
+Goal: know how to fit a desired food into the plan.
+
+Flow:
+
+1. User says "Voy a cenar salmon" or "Puedo meter pasta?".
+2. Bot detects the food and meal moment.
+3. Bot loads the relevant block.
+4. Bot checks raw food strings, group names, notes, and conditions
+   conservatively.
+5. Bot applies explicit conditions when present.
+6. Bot gives a short adjustment.
+
+Expected response:
+
+```text
+Cena:
+Salmon con ensalada.
+
+Sin aceite, porque el salmon ya aporta grasa.
+```
+
+Edge cases:
+
+- Food appears in block: use the block quantity.
+- Food is a clear equivalent: adapt cautiously and say it is an approximation.
+- Food is not compatible: offer a close option from the block.
+- Fatty protein: apply oil removal or reduction if the plan says so.
+
+## Journey 7: Register A Meal
+
+Actor: authenticated Telegram user with an active plan.
+
+Goal: record what they ate.
+
+Flow:
+
+1. User says "He comido pollo con arroz y ensalada".
+2. Bot detects this is a meal log.
+3. Bot detects or asks for meal moment.
+4. Bot stores the event.
+5. Bot compares it against the expected block when possible.
+6. Bot replies with a simple assessment.
+
+Expected response:
+
+```text
+Registrado.
+
+Encaja bastante bien. Vigila no anadir otro hidrato fuerte en la siguiente comida.
+```
+
+Edge cases:
+
+- No quantities: register approximate text.
+- Missing moment: infer from time only when confidence is acceptable.
+- User corrects later: update the event instead of duplicating it.
+
+## Journey 8: Ask Daily Progress
+
+Actor: authenticated Telegram user with an active plan and meal records.
+
+Goal: understand how the day is going.
+
+Flow:
+
+1. User asks "Como voy hoy?".
+2. Bot loads today's recorded meals.
+3. Bot compares records against expected blocks.
+4. Bot summarizes the day.
+5. Bot recommends the next practical decision.
+
+Expected response:
+
+```text
+Vas bastante bien.
+
+La comida ha sido algo alta en grasa, asi que para la cena haria:
+proteina magra + verdura, sin grasa extra.
+```
+
+Edge cases:
+
+- No records: say there is not enough data yet.
+- Excess carbs: suggest a lighter next meal if compatible with plan.
+- Excess fat: suggest lean protein and vegetables.
+- Missing protein: prioritize protein next.
+
+## Journey 9: Recover From A Deviation
+
+Actor: authenticated Telegram user with an active plan.
+
+Goal: return to the plan without guilt or extreme compensation.
+
+Flow:
+
+1. User says "Me he pasado con los dulces".
+2. Bot classifies the deviation conservatively.
+3. Bot records the event when tracking exists.
+4. Bot suggests the next meal adjustment.
+5. Bot avoids punishment, shame, or extreme restriction.
+
+Expected response:
+
+```text
+No lo compensaria con castigo.
+
+Siguiente comida:
+proteina magra + verdura.
+
+Sin pan, arroz, pasta ni grasa extra.
+```
+
+Edge cases:
+
+- Possible binge or distress: recommend professional support.
+- Alcohol: suggest hydration, normal eating, and rest.
+- Repeated deviations: focus on patterns and next simple step.
+
+## Journey 10: Submit A Recipe Proposal
+
+Actor: authenticated Telegram user.
+
+Goal: propose a real recipe for future review.
+
+Flow:
+
+1. User says "Quiero anadir una receta de arroz con atun y huevo".
+2. Bot detects that this is a recipe proposal, not a meal log.
+3. Bot stores the proposal as `pending_review`.
+4. Bot preserves the raw user text and attachments when available.
+5. Bot confirms that the recipe needs admin/professional review before use.
+
+Expected response:
+
+```text
+He guardado la receta como propuesta.
+
+Un profesional tendra que revisarla antes de que el bot pueda usarla dentro del plan.
+```
+
+Edge cases:
+
+- If the user only mentions a meal they ate, do not treat it as a recipe
+  proposal unless intent is clear.
+- If required fields are unknown, keep them empty and preserve raw submission.
+- The bot must not recommend pending recipes to normal users.
+
+## Journey 11: Review A Recipe Proposal
+
+Actor: admin or nutrition professional.
+
+Goal: turn a pending recipe into an approved, rejected, edited, or archived
+catalog entry.
+
+Flow:
+
+1. Admin/professional lists pending recipes.
+2. Admin/professional reviews raw submission.
+3. Admin/professional normalizes fields such as protein, carbs, fat level,
+   compatibility, tags, and adaptation notes.
+4. Admin/professional approves, rejects, edits, or archives.
+5. Approved recipes become available for normal bot recommendations.
+
+Edge cases:
+
+- Rejected recipes keep review notes.
+- Approved recipes must have all required structured fields.
+- Only approved recipes are used by the bot outside review mode.
+
+## Journey 12: Build A Weekly Meal Plan
+
+Actor: authenticated Telegram user with active `comidas` and `situaciones`.
+
+Goal: receive a practical weekly plan for meals and dinners based on planned
+activities.
+
+Example request:
+
+```text
+Hazme un plan de comidas y cenas para la semana.
+Lunes ciclismo, miercoles fuerza, viernes atletismo y el resto no entreno.
+```
+
+Flow:
+
+1. Bot detects a weekly planning intent.
+2. Bot extracts day-by-day situations from the message.
+3. Bot maps user words to configured situation keys when confidence is high.
+4. Bot asks a clarification if an activity is not configured or ambiguous.
+5. For each day and requested moment, bot resolves `situacion + momento` to a
+   `comida_*` key.
+6. Bot loads only the selected comidas.
+7. If `recetas` RAG is available, bot retrieves approved recipe candidates per
+   day/moment.
+8. Bot returns a compact weekly table with comida/cena, quantities from
+   `comidas`, and recipe-style names when available.
+
+Expected response shape:
+
+```text
+Plan semanal
+
+Lunes - ciclismo
+Comida: arroz tipo paella con pollo o pavo.
+Usa el arroz y la proteina del bloque comida_2. No anadas pan.
+Cena: pescado blanco con ensalada y la grasa del bloque.
+
+Martes - no entreno
+Comida: carne magra con verdura y la fuente de hidrato de comida_5.
+Cena: tortilla con ensalada, ajustando el aceite del bloque.
+```
+
+Edge cases:
+
+- If the user says "algo" or an unknown activity, ask which configured situation
+  it corresponds to.
+- If a day is omitted, use the user's stated default only when explicit, such as
+  "el resto no entreno".
+- If a moment mapping is missing, show that day/moment as unresolved instead of
+  inventing a comida.
+- Do not pass all recipes or all comidas to the LLM. Resolve keys first, then
+  retrieve only needed slices/candidates.
+
+## Journey 13: Adjust After Skipping A Meal
+
+Actor: authenticated Telegram user with an active plan.
+
+Goal: decide what to eat after missing a planned meal without overcompensating.
+
+Example request:
+
+```text
+Que ceno hoy? Me he saltado la media manana.
+```
+
+Flow:
+
+1. Bot detects target moment: `cena`.
+2. Bot detects skipped moment: `media_manana` or nearest configured equivalent.
+3. Bot loads today's situation if known, or asks for it if needed.
+4. Bot resolves dinner with `situaciones`.
+5. Bot checks whether the skipped meal affects dinner instructions.
+6. Bot recommends dinner from the dinner comida and avoids inventing extra
+   compensation.
+
+Expected response:
+
+```text
+Cena:
+Pescado blanco con ensalada.
+
+Mantendria la cena del bloque. No hace falta compensar metiendo el doble.
+Si tienes hambre, prioriza la proteina y la verdura del plan.
+```
+
+Edge cases:
+
+- If the skipped meal was a snack and there is no explicit compensation rule,
+  do not move its full quantities into dinner.
+- If the user skipped several meals or reports distress, respond conservatively
+  and recommend professional guidance when appropriate.
+- If daily tracking exists, record the skipped meal as an event.

--- a/bot_profiles/nutrition/docs/user-journeys.md
+++ b/bot_profiles/nutrition/docs/user-journeys.md
@@ -148,26 +148,36 @@ Edge cases:
 
 Actor: authenticated Telegram user with an active plan.
 
-Goal: get a practical meal recommendation from the plan.
+Goal: get one practical meal recommendation from the user's active plan.
+
+This is the most basic successful use case for the bot after the user already
+has a nutrition plan loaded. The user should not need to understand `comidas`,
+macros, `situaciones`, or internal block keys.
 
 Flow:
 
-1. User asks "Que ceno?" or "Que como hoy?".
+1. User asks "Que ceno?", "Que como hoy dia de no entreno?", or "Hoy tengo
+   crossfit, que como al mediodia?".
 2. Bot detects recommendation intent.
 3. Bot detects or asks for day situation when `situaciones` is available.
 4. Bot detects or asks for the meal moment.
 5. Bot resolves `situacion + momento` to a `comida_*` key locally.
 6. Bot loads only that comida chunk.
-7. Bot asks the LLM to format a practical answer from that chunk.
-8. Bot replies briefly with the meal structure.
+7. Bot selects one valid option path through the block:
+   - for `and`, include each required group;
+   - for `or`, choose one reasonable option;
+   - preserve explicit conditions such as removing oil for fatty fish.
+8. Bot answers as a normal meal recommendation with quantities from the plan.
+9. Bot does not show macros unless the user asks for macros, calories, or
+   detailed targets.
 
 Expected response:
 
 ```text
 Cena:
-Pescado blanco con ensalada.
+330g de merluza con ensalada.
 
-Usa la grasa del bloque si corresponde.
+Añade 20g de aceite de oliva o cambia esa grasa por 160g de aguacate.
 ```
 
 Edge cases:
@@ -182,6 +192,12 @@ Edge cases:
 - Missing mapping: do not invent a comida.
 - Complete mapping: do not send the full plan to the LLM; send only the
   resolved chunk.
+- If the user asks "quiero otra opcion", choose a different valid option path
+  from the same resolved block when possible.
+- If the user asks "por que?", explain the selected groups and conditions
+  without exposing raw JSON.
+- If no reasonable concrete option can be selected automatically, show two or
+  three valid choices from the block and ask which one prefers.
 
 ## Journey 6: Adapt A Concrete Food Or Dish
 

--- a/bot_profiles/nutrition/docs/user-stories.md
+++ b/bot_profiles/nutrition/docs/user-stories.md
@@ -141,6 +141,15 @@ Acceptance criteria:
 - The bot asks for meal moment when needed.
 - When `situaciones` are available, the bot routes to the relevant comida chunk
   before calling the LLM.
+- The answer recommends one valid option path from the resolved block rather
+  than dumping all possible options.
+- The recommended option follows local `and`/`or` semantics: include all
+  required `and` groups and choose one child from each relevant `or` group.
+- The answer includes quantities from the selected block.
+- Explicit block conditions are applied or shown when they affect the selected
+  option.
+- Macros are hidden by default even when the plan contains macro codes.
+- The user can ask for another option from the same block.
 - Responses do not expose technical JSON details unless requested.
 
 Related issues: #88, #94.

--- a/bot_profiles/nutrition/docs/user-stories.md
+++ b/bot_profiles/nutrition/docs/user-stories.md
@@ -1,0 +1,284 @@
+# Nutrition Bot User Stories
+
+Stories are grouped by MVP and aligned with epic #79.
+
+## MVP 1: Plan Capture And Draft Creation
+
+### Story 1.1: Understand The Nutrition Bot Scope
+
+As a bot owner, I want a nutrition-specific profile and design docs, so that
+future changes inherit a clear product direction.
+
+Acceptance criteria:
+
+- The `nutrition` bot has versioned design docs.
+- The docs say the bot interprets user plans instead of inventing diets.
+- The docs distinguish design docs from user JSONB data.
+- Response guardrails are documented.
+
+Related issues: #80, #92.
+
+### Story 1.2: Store Nutrition Plans Per User
+
+As a user, I want my nutrition plan stored under my account, so that the bot can
+use my plan without mixing it with other users.
+
+Acceptance criteria:
+
+- Plans reference `users(id)`.
+- Plan documents are stored as JSONB.
+- V1 supports `document_type = meal_blocks`.
+- Plan states are constrained to `draft`, `active`, `failed`, and `archived`.
+
+Related issue: #81.
+
+### Story 1.3: Start A New Plan Upload
+
+As a user, I want to send `/new_plan`, so that the bot waits for my plan text or
+PDF.
+
+Acceptance criteria:
+
+- Only authenticated users can start the flow.
+- The bot creates a `waiting_for_plan_upload` session.
+- The bot tells the user to send text or PDF.
+- Re-running `/new_plan` handles an existing pending session predictably.
+
+Related issue: #83.
+
+### Story 1.4: Upload Plan Text Or PDF
+
+As a user, I want to provide compact JSON, paste text, or upload a PDF, so that
+the bot can capture my nutrition plan.
+
+Acceptance criteria:
+
+- Valid compact JSON with root `comidas` is accepted directly and does not call
+  the LLM extractor.
+- Pasted text is accepted directly.
+- PDF files are downloaded from Telegram and extracted.
+- Images and unsupported documents receive a clear V1 limitation message.
+- Extraction failures do not crash the bot.
+
+Related issue: #84.
+
+### Story 1.5: Generate Meal Blocks
+
+As a user, I want the bot to convert my plan into structured meal blocks, so
+that future answers can use the plan reliably.
+
+Acceptance criteria:
+
+- The final document is `document_type = meal_blocks`.
+- Direct `comidas` JSON bypasses LLM generation.
+- The generator does not create `situations`, `recipes`, or `adaptation_rules`
+  in V1.
+- Original food strings are preserved as leaves in the `comidas` tree.
+- Nested `and`/`or` groups from the nutritionist's plan are preserved
+  recursively.
+- Ambiguities are represented as warnings.
+
+Related issues: #82, #85.
+
+### Story 1.6: Save Draft And Show Summary
+
+As a user, I want to see what the bot extracted, so that I can decide whether
+the plan looks usable.
+
+Acceptance criteria:
+
+- A valid extraction creates a draft plan.
+- The bot stores the `meal_blocks` JSONB document.
+- The bot summarizes blocks, food options, conditions, and warnings.
+- If no blocks are detected, the flow fails clearly.
+
+Related issue: #86.
+
+## MVP 2: Active Plan Usage
+
+### Story 2.1: Activate A Draft Plan
+
+As a user, I want to activate a draft plan, so that the bot uses it as the
+source of truth.
+
+Acceptance criteria:
+
+- The bot activates only a draft owned by the user.
+- The selected plan has valid `meal_blocks`.
+- Only one plan is active per user.
+- Previous active plans are no longer active after replacement.
+
+Related issue: #87.
+
+### Story 2.2: Ask What To Eat
+
+As a user, I want to ask what to eat, so that I receive a practical answer from
+my active plan.
+
+Acceptance criteria:
+
+- Without an active plan, the bot suggests `/new_plan`.
+- With an active plan, the bot uses `meal_blocks`.
+- The bot asks for meal moment when needed.
+- Responses do not expose technical JSON details unless requested.
+
+Related issue: #88.
+
+### Story 2.3: Adapt A Concrete Food
+
+As a user, I want to ask whether I can eat a concrete food, so that the bot
+adapts it to my plan.
+
+Acceptance criteria:
+
+- Matching uses raw food strings, group names, notes, and conditions
+  conservatively.
+- If the food appears in the block, the bot uses the block quantity.
+- If a condition applies, the bot explains the key adjustment.
+- If compatibility is unclear, the bot asks or offers a plan option.
+
+Related issue: #89.
+
+### Story 2.4: Ask What To Eat For A Specific Activity Day
+
+As a user, I want to say what activity I have today, so that the bot can select
+the correct comida before suggesting food.
+
+Acceptance criteria:
+
+- The bot maps user activity words to configured `situaciones` keys.
+- The bot resolves `situacion + momento` to a `comida_*` key.
+- If the activity or moment is ambiguous, the bot asks using configured options.
+- The bot answers with quantities from the resolved comida.
+
+Related issues: #88, #91.
+
+## MVP 3: Daily Tracking
+
+### Story 3.1: Register A Meal
+
+As a user, I want to tell the bot what I ate, so that it can track my day.
+
+Acceptance criteria:
+
+- The bot stores meal records by user and day.
+- The original user text is preserved.
+- The bot detects or asks for meal moment.
+- The bot can compare the record against the active plan at a basic level.
+
+Related issue: #90.
+
+### Story 3.2: Ask How The Day Is Going
+
+As a user, I want to ask how I am doing today, so that I can decide what to eat
+next.
+
+Acceptance criteria:
+
+- The bot loads today's meal records.
+- The bot summarizes alignment with the active plan.
+- The bot gives one practical next-step recommendation.
+- The bot avoids shame, punishment, and extreme compensation.
+
+Related issue: #90.
+
+### Story 3.3: Adjust After A Skipped Meal
+
+As a user, I want to tell the bot that I skipped a meal, so that the next meal
+recommendation stays practical and does not overcompensate.
+
+Acceptance criteria:
+
+- The bot detects skipped meal context such as "me he saltado la media manana".
+- The bot records the skipped meal when daily tracking exists.
+- The bot keeps the next recommendation anchored to the selected comida.
+- The bot does not automatically move all skipped quantities into the next meal.
+- If the plan has explicit compensation notes, those notes take priority.
+
+Related issues: #88, #90.
+
+## MVP 4: Advanced Documents
+
+### Story 4.1: Use Situations
+
+As a user, I want the bot to know whether today is a training or rest day, so
+that it can choose the right block.
+
+Acceptance criteria:
+
+- `situaciones` exists as a JSONB document type or supported content shape.
+- Situations map day context and meal moment to `comida_*` keys.
+- Situation keys are plan data, not hardcoded sports.
+- Every referenced comida key exists in the active `comidas` document.
+- Supplementation is preserved but not repeated in every meal answer.
+- Missing situation context triggers a short clarification.
+- Missing meal moment triggers a short clarification or a later time-based
+  suggestion with user correction.
+- Missing mappings do not invent comidas.
+
+Related issue: #91.
+
+### Story 4.2: Use Recipes
+
+As a user, I want real meal suggestions, so that the plan feels practical.
+
+Acceptance criteria:
+
+- `recetas` exists as a JSONB document type or future row-per-recipe storage.
+- Recipes suggest dishes but do not override `meal_blocks` quantities.
+- Recipe compatibility is scoped by meal moment and compact plan context.
+- The bot uses only recipes with `status = approved`.
+- The bot retrieves recipes through search/RAG and does not pass the full
+  catalog to the LLM.
+- Only a small set of approved candidates is added to prompt context.
+- Recipes can be filtered by moment, carb level, protein type, restrictions,
+  and preferences.
+
+Related issue: #91.
+
+### Story 4.3: Submit Recipe For Review
+
+As a user, I want to propose a recipe I usually eat, so that a professional can
+review whether it should be added to the catalog.
+
+Acceptance criteria:
+
+- User-submitted recipes are stored as `pending_review`.
+- The bot confirms that a professional must review the recipe before use.
+- The bot never uses pending recipes for normal recommendations.
+- Admin/professional users can approve, reject, edit, or archive recipes.
+- Approved recipes include required structured fields and `status = approved`.
+
+Related issue: #91.
+
+### Story 4.4: Build A Weekly Meal Plan
+
+As a user, I want to give the bot my weekly activity schedule, so that it can
+generate a practical plan for meals and dinners.
+
+Acceptance criteria:
+
+- The bot accepts day-by-day activity input in natural language.
+- The bot maps each day to configured `situaciones` keys.
+- Explicit defaults such as "el resto no entreno" are applied to omitted days.
+- For each requested moment, the bot resolves a `comida_*` key before answering.
+- The weekly plan uses quantities from `comidas`.
+- If recipe RAG is available, only approved candidates are retrieved per
+  day/moment.
+- Missing mappings or unknown activities trigger clarification instead of
+  invented meals.
+
+Related issue: #91.
+
+### Story 4.5: Use Adaptation Rules
+
+As a user, I want the bot to adjust meals consistently, so that equivalent
+foods do not break the plan.
+
+Acceptance criteria:
+
+- `adaptation_rules` exists as a JSONB document type.
+- Rules document macro interpretation and conservative substitutions.
+- Explicit plan conditions still take priority.
+
+Related issue: #91.

--- a/bot_profiles/nutrition/docs/user-stories.md
+++ b/bot_profiles/nutrition/docs/user-stories.md
@@ -2,7 +2,7 @@
 
 Stories are grouped by MVP and aligned with epic #79.
 
-## MVP 1: Plan Capture And Draft Creation
+## MVP 1: Plan Capture And Active Plan Creation
 
 ### Story 1.1: Understand The Nutrition Bot Scope
 
@@ -27,36 +27,40 @@ Acceptance criteria:
 
 - Plans reference `users(id)`.
 - Plan documents are stored as JSONB.
-- V1 supports `document_type = meal_blocks`.
-- Plan states are constrained to `draft`, `active`, `failed`, and `archived`.
+- V1 supports `document_type = situaciones` and `document_type = comidas`.
+- Implemented plan states are constrained to `active` and `archived`.
 
 Related issue: #81.
 
 ### Story 1.3: Start A New Plan Upload
 
-As a user, I want to send `/new_plan`, so that the bot waits for my plan text or
-PDF.
+As a user, I want to send `/set_plan` with my plan files, so that the bot stores
+my `situaciones` and `comidas` under my account.
 
 Acceptance criteria:
 
 - Only authenticated users can start the flow.
-- The bot creates a `waiting_for_plan_upload` session.
-- The bot tells the user to send text or PDF.
-- Re-running `/new_plan` handles an existing pending session predictably.
+- The bot accepts `situaciones.json` and `comidas.json` documents without
+  requiring captions, in either order.
+- If only one required file has arrived, the bot keeps a draft and asks for the
+  missing part.
+- The bot accepts pasted JSON after `/set_plan` for small test payloads.
+- Re-running `/set_plan` replaces the active plan only after validation passes.
 
 Related issue: #83.
 
-### Story 1.4: Upload Plan Text Or PDF
+### Story 1.4: Upload Plan JSON
 
-As a user, I want to provide compact JSON, paste text, or upload a PDF, so that
-the bot can capture my nutrition plan.
+As a user, I want to provide compact JSON as text or a file, so that the bot can
+capture my nutrition plan.
 
 Acceptance criteria:
 
-- Valid compact JSON with root `comidas` is accepted directly and does not call
-  the LLM extractor.
-- Pasted text is accepted directly.
-- PDF files are downloaded from Telegram and extracted.
+- Pasted JSON is accepted.
+- `.json` and `.txt` files are downloaded from Telegram and decoded as UTF-8.
+- The configured normalizer model cleans and normalizes the JSON.
+- Already-valid JSON can be accepted through local validation if the LLM is
+  unavailable.
 - Images and unsupported documents receive a clear V1 limitation message.
 - Extraction failures do not crash the bot.
 
@@ -69,10 +73,10 @@ that future answers can use the plan reliably.
 
 Acceptance criteria:
 
-- The final document is `document_type = meal_blocks`.
-- Direct `comidas` JSON bypasses LLM generation.
-- The generator does not create `situations`, `recipes`, or `adaptation_rules`
-  in V1.
+- The final active plan stores separate `situaciones` and `comidas` documents.
+- The normalizer outputs `situaciones` and `comidas`; it may preserve
+  `reglas_adaptacion` and `recetas` when provided.
+- The generator does not create recipes or adaptation rules in V1.
 - Original food strings are preserved as leaves in the `comidas` tree.
 - Nested `and`/`or` groups from the nutritionist's plan are preserved
   recursively.
@@ -80,19 +84,33 @@ Acceptance criteria:
 
 Related issues: #82, #85.
 
-### Story 1.6: Save Draft And Show Summary
+### Story 1.6: Save Active Plan And Show Summary
 
 As a user, I want to see what the bot extracted, so that I can decide whether
 the plan looks usable.
 
 Acceptance criteria:
 
-- A valid extraction creates a draft plan.
-- The bot stores the `meal_blocks` JSONB document.
+- A valid extraction creates an active plan.
+- The bot stores `situaciones` and `comidas` JSONB documents.
+- Previous active plans for the same user are archived.
 - The bot summarizes blocks, food options, conditions, and warnings.
 - If no blocks are detected, the flow fails clearly.
 
 Related issue: #86.
+
+### Story 1.7: Review Active Plan
+
+As a user, I want to review the plan stored for me, so that I can check whether
+the uploaded files were interpreted correctly.
+
+Acceptance criteria:
+
+- `/get_plan` returns a short active-plan summary.
+- `/get_plan situaciones` exports the stored `situaciones` JSON document.
+- `/get_plan comidas` exports the stored `comidas` JSON document.
+- `/get_plan all` exports a combined review JSON.
+- Without an active plan, the bot suggests using `/set_plan`.
 
 ## MVP 2: Active Plan Usage
 
@@ -115,15 +133,14 @@ Acceptance criteria:
 
 Related issue: #94.
 
-### Story 2.1: Activate A Draft Plan
+### Story 2.1: Replace Active Plan
 
-As a user, I want to activate a draft plan, so that the bot uses it as the
-source of truth.
+As a user, I want to replace my active plan safely, so that the bot uses the
+new source of truth only when it is valid.
 
 Acceptance criteria:
 
-- The bot activates only a draft owned by the user.
-- The selected plan has valid `meal_blocks`.
+- The bot validates the uploaded plan before changing the active plan.
 - Only one plan is active per user.
 - Previous active plans are no longer active after replacement.
 
@@ -136,8 +153,8 @@ my active plan.
 
 Acceptance criteria:
 
-- Without an active plan, the bot suggests `/new_plan`.
-- With an active plan, the bot uses `meal_blocks`.
+- Without an active plan, the bot suggests `/set_plan`.
+- With an active plan, the bot uses the selected `comidas` block.
 - The bot asks for meal moment when needed.
 - When `situaciones` are available, the bot routes to the relevant comida chunk
   before calling the LLM.
@@ -257,7 +274,7 @@ As a user, I want real meal suggestions, so that the plan feels practical.
 Acceptance criteria:
 
 - `recetas` exists as a JSONB document type or future row-per-recipe storage.
-- Recipes suggest dishes but do not override `meal_blocks` quantities.
+- Recipes suggest dishes but do not override `comidas` quantities.
 - Recipe compatibility is scoped by meal moment and compact plan context.
 - The bot uses only recipes with `status = approved`.
 - The bot retrieves recipes through search/RAG and does not pass the full

--- a/bot_profiles/nutrition/docs/user-stories.md
+++ b/bot_profiles/nutrition/docs/user-stories.md
@@ -96,6 +96,25 @@ Related issue: #86.
 
 ## MVP 2: Active Plan Usage
 
+### Story 2.0: Route Natural Language To A Plan Chunk
+
+As a user, I want to describe my day naturally, so that the bot can select the
+right comida without sending the full plan to the LLM.
+
+Acceptance criteria:
+
+- The bot detects situation keys from configured `situaciones.*.aliases`.
+- The bot detects common meal moments such as desayuno, almuerzo, merienda, and
+  cena.
+- The bot resolves `situacion + momento` to a `comida_*` key before the LLM
+  call.
+- If either value is missing, the bot asks one concise clarification.
+- If multiple situations match, the bot asks the user to choose.
+- When resolution succeeds, the LLM receives only the resolved comida chunk and
+  not the full plan.
+
+Related issue: #94.
+
 ### Story 2.1: Activate A Draft Plan
 
 As a user, I want to activate a draft plan, so that the bot uses it as the
@@ -120,9 +139,11 @@ Acceptance criteria:
 - Without an active plan, the bot suggests `/new_plan`.
 - With an active plan, the bot uses `meal_blocks`.
 - The bot asks for meal moment when needed.
+- When `situaciones` are available, the bot routes to the relevant comida chunk
+  before calling the LLM.
 - Responses do not expose technical JSON details unless requested.
 
-Related issue: #88.
+Related issues: #88, #94.
 
 ### Story 2.3: Adapt A Concrete Food
 
@@ -148,10 +169,12 @@ Acceptance criteria:
 
 - The bot maps user activity words to configured `situaciones` keys.
 - The bot resolves `situacion + momento` to a `comida_*` key.
+- The bot uses `aliases` from the plan instead of hardcoding only one set of
+  sports.
 - If the activity or moment is ambiguous, the bot asks using configured options.
 - The bot answers with quantities from the resolved comida.
 
-Related issues: #88, #91.
+Related issues: #88, #91, #94.
 
 ## MVP 3: Daily Tracking
 

--- a/bot_profiles/nutrition/profile.json
+++ b/bot_profiles/nutrition/profile.json
@@ -15,8 +15,8 @@
   ],
   "disclaimer_text": "Este bot ayuda a interpretar un plan nutricional aportado por el usuario. No sustituye a un nutricionista, medico u otro profesional sanitario.",
   "default_language": "es",
-  "llm_provider": "ollama",
-  "llm_model": "gemma3:4b",
+  "llm_provider": "nvidia",
+  "llm_model": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
   "memory_enabled": true,
   "analytics_enabled": false
 }

--- a/bot_profiles/nutrition/profile.json
+++ b/bot_profiles/nutrition/profile.json
@@ -6,6 +6,7 @@
   "context_files": [
     "demo_plan.json"
   ],
+  "nutrition_plan_file": "demo_plan.json",
   "domain_rules": [
     "Responde en espanol por defecto con tono claro, directo y practico.",
     "Ayuda a interpretar y aplicar el plan nutricional del usuario; no inventes dietas completas desde cero.",

--- a/bot_profiles/nutrition/profile.json
+++ b/bot_profiles/nutrition/profile.json
@@ -1,0 +1,22 @@
+{
+  "bot_profile_id": "nutrition",
+  "bot_display_name": "Bot Nutricionista",
+  "bot_description": "Perfil nutricionista para ayudar a aplicar planes nutricionales estructurados desde Telegram.",
+  "system_prompt_file": "system_prompt.md",
+  "domain_rules": [
+    "Responde en espanol por defecto con tono claro, directo y practico.",
+    "Ayuda a interpretar y aplicar el plan nutricional del usuario; no inventes dietas completas desde cero.",
+    "Las cantidades, opciones y ajustes concretos deben salir del plan disponible; si no hay plan o falta contexto, pide aclaracion.",
+    "No diagnostiques ni trates condiciones medicas; deriva a un profesional ante embarazo, lactancia, patologias, medicacion, sintomas agudos o senales de TCA.",
+    "No muestres macros, calorias ni calculos detallados por defecto salvo que el usuario los pida.",
+    "No recomiendes compensaciones agresivas por comidas saltadas, excesos o desviaciones del plan.",
+    "Si una comida no encaja, ofrece una alternativa cercana del plan o pide mas contexto.",
+    "No expongas JSON, datos internos ni detalles tecnicos salvo que el usuario los pida."
+  ],
+  "disclaimer_text": "Este bot ayuda a interpretar un plan nutricional aportado por el usuario. No sustituye a un nutricionista, medico u otro profesional sanitario.",
+  "default_language": "es",
+  "llm_provider": "ollama",
+  "llm_model": "gemma3:4b",
+  "memory_enabled": true,
+  "analytics_enabled": false
+}

--- a/bot_profiles/nutrition/profile.json
+++ b/bot_profiles/nutrition/profile.json
@@ -3,6 +3,9 @@
   "bot_display_name": "Bot Nutricionista",
   "bot_description": "Perfil nutricionista para ayudar a aplicar planes nutricionales estructurados desde Telegram.",
   "system_prompt_file": "system_prompt.md",
+  "context_files": [
+    "demo_plan.json"
+  ],
   "domain_rules": [
     "Responde en espanol por defecto con tono claro, directo y practico.",
     "Ayuda a interpretar y aplicar el plan nutricional del usuario; no inventes dietas completas desde cero.",

--- a/bot_profiles/nutrition/profile.json
+++ b/bot_profiles/nutrition/profile.json
@@ -3,7 +3,6 @@
   "bot_display_name": "Bot Nutricionista",
   "bot_description": "Perfil nutricionista para ayudar a aplicar planes nutricionales estructurados desde Telegram.",
   "system_prompt_file": "system_prompt.md",
-  "nutrition_plan_file": "demo_plan.json",
   "domain_rules": [
     "Responde en espanol por defecto con tono claro, directo y practico.",
     "Ayuda a interpretar y aplicar el plan nutricional del usuario; no inventes dietas completas desde cero.",
@@ -19,5 +18,6 @@
   "llm_provider": "nvidia",
   "llm_model": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
   "memory_enabled": true,
+  "memory_backend": "langchain_postgres",
   "analytics_enabled": false
 }

--- a/bot_profiles/nutrition/profile.json
+++ b/bot_profiles/nutrition/profile.json
@@ -3,9 +3,6 @@
   "bot_display_name": "Bot Nutricionista",
   "bot_description": "Perfil nutricionista para ayudar a aplicar planes nutricionales estructurados desde Telegram.",
   "system_prompt_file": "system_prompt.md",
-  "context_files": [
-    "demo_plan.json"
-  ],
   "nutrition_plan_file": "demo_plan.json",
   "domain_rules": [
     "Responde en espanol por defecto con tono claro, directo y practico.",

--- a/bot_profiles/nutrition/system_prompt.md
+++ b/bot_profiles/nutrition/system_prompt.md
@@ -1,3 +1,5 @@
+/no_think
+
 Eres un bot nutricionista conversacional integrado en Telegram.
 
 Tu objetivo es ayudar al usuario a seguir un plan nutricional ya definido,
@@ -46,6 +48,12 @@ Comidas saltadas, desviaciones y memoria:
   agresiva. Ajusta con prudencia: continuar con la siguiente comida prevista,
   priorizar proteina/verdura si procede, y evitar doblar cantidades salvo que el
   plan lo indique.
+- Si el prompt incluye contexto de memoria o conversacion reciente, tratalo como
+  memoria disponible para esta respuesta.
+- Si el usuario pregunta que dijo, pregunto o comento antes, responde usando la
+  conversacion reciente incluida en el prompt.
+- No digas que no tienes memoria si el contexto de memoria contiene la
+  informacion.
 - Si la memoria reciente contiene un fallo repetido, una preferencia o una
   restriccion, tenlo en cuenta, pero no conviertas un mensaje antiguo en una
   coletilla permanente.
@@ -63,9 +71,21 @@ Seguridad:
 
 Estilo de respuesta:
 - Responde en espanol salvo que el usuario use otro idioma.
-- Se directo, natural y util.
+- Se directo, natural y util. En preguntas de "que como/ceno", no expliques el
+  plan: da la recomendacion.
 - No muestres JSON, razonamiento interno ni estructura tecnica salvo que el
   usuario lo pida.
 - No muestres macros o calorias por defecto. Si el usuario los pide, dales solo
   si estan en el plan o si aclaras que son estimaciones.
 - Para Telegram, usa mensajes cortos, con listas simples solo cuando ayuden.
+- Evita encabezados Markdown largos, tablas y listas anidadas.
+- Si necesitas destacar algo, usa una unica negrita corta con `**texto**`.
+- No empieces con "basandome en el plan", "segun el contexto" ni frases
+  similares.
+- No vuelques todas las opciones disponibles. Elige una opcion valida y menciona
+  como pedir otra alternativa.
+- Formato recomendado:
+  **Cena de no entreno**
+  330g de merluza con ensalada.
+  Añade 20g de aceite de oliva.
+  Si prefieres otra opcion, dimelo y te doy una alternativa del bloque.

--- a/bot_profiles/nutrition/system_prompt.md
+++ b/bot_profiles/nutrition/system_prompt.md
@@ -1,0 +1,64 @@
+Eres un bot nutricionista conversacional integrado en Telegram.
+
+Tu objetivo es ayudar al usuario a seguir un plan nutricional ya definido,
+explicandolo de forma practica, clara y accionable. No eres un medico ni un
+nutricionista colegiado sustituto; actuas como asistente para interpretar el
+plan que el usuario aporta.
+
+Principio operativo principal:
+- Si existe un plan nutricional en el contexto de la conversacion o en memoria,
+  usalo como fuente principal.
+- Si no existe plan disponible, no finjas que lo hay. Pide al usuario que te
+  comparta el plan, el bloque de comida o la informacion necesaria antes de dar
+  cantidades concretas.
+- Puedes dar orientacion general y prudente cuando no haya plan, pero debes
+  dejar claro que no es una pauta personalizada.
+
+Modelo mental del producto:
+- Las situaciones del dia deciden que bloque de comida toca.
+- Los bloques de comida definen alimentos, opciones, cantidades y condiciones.
+- Las recetas, cuando existan, solo daran forma culinaria al bloque; nunca
+  sustituyen sus cantidades.
+- Las reglas de adaptacion ayudan a ajustar platos al bloque, sin inventar
+  dietas nuevas.
+
+Cuando el usuario pregunte que comer:
+1. Identifica el momento de comida si esta claro: desayuno, almuerzo, merienda,
+   cena u otro momento definido por el plan.
+2. Identifica el tipo de dia si esta claro: descanso, entrenamiento, crossfit,
+   futbol, ciclismo, atletismo u otra actividad configurada.
+3. Si falta el momento o el tipo de dia y es necesario para responder bien,
+   pregunta una sola aclaracion breve.
+4. Si tienes un bloque aplicable, responde con las opciones y cantidades del
+   bloque. Si hay condiciones tipo "and" u "or", explicalas en lenguaje natural.
+5. Si el usuario pide cambiar un alimento, comprueba si encaja con las opciones
+   del bloque. Si no encaja, propone una alternativa cercana del propio plan.
+
+Comidas saltadas, desviaciones y memoria:
+- Si el usuario se ha saltado una comida, no recomiendes compensar de forma
+  agresiva. Ajusta con prudencia: continuar con la siguiente comida prevista,
+  priorizar proteina/verdura si procede, y evitar doblar cantidades salvo que el
+  plan lo indique.
+- Si la memoria reciente contiene un fallo repetido, una preferencia o una
+  restriccion, tenlo en cuenta, pero no conviertas un mensaje antiguo en una
+  coletilla permanente.
+- Si una respuesta anterior fue lenta, erronea o incompleta, no repitas ese
+  aviso en mensajes posteriores salvo que el usuario pregunte por ello.
+
+Seguridad:
+- No diagnostiques, no trates patologias y no ajustes medicacion.
+- Ante sintomas agudos, trastornos de conducta alimentaria, embarazo,
+  lactancia, diabetes, enfermedad renal, enfermedad cardiaca, medicacion
+  relevante o cualquier caso clinico, recomienda revisar el plan con un
+  profesional sanitario.
+- No promuevas ayunos extremos, purgas, restricciones agresivas, deshidratacion
+  ni conductas de riesgo.
+
+Estilo de respuesta:
+- Responde en espanol salvo que el usuario use otro idioma.
+- Se directo, natural y util.
+- No muestres JSON, razonamiento interno ni estructura tecnica salvo que el
+  usuario lo pida.
+- No muestres macros o calorias por defecto. Si el usuario los pide, dales solo
+  si estan en el plan o si aclaras que son estimaciones.
+- Para Telegram, usa mensajes cortos, con listas simples solo cuando ayuden.

--- a/bot_profiles/nutrition/system_prompt.md
+++ b/bot_profiles/nutrition/system_prompt.md
@@ -8,6 +8,9 @@ plan que el usuario aporta.
 Principio operativo principal:
 - Si existe un plan nutricional en el contexto de la conversacion o en memoria,
   usalo como fuente principal.
+- Si hay documentos de contexto del perfil con un plan nutricional, tratalos
+  como el plan activo por defecto mientras no exista un plan de usuario mas
+  especifico.
 - Si no existe plan disponible, no finjas que lo hay. Pide al usuario que te
   comparta el plan, el bloque de comida o la informacion necesaria antes de dar
   cantidades concretas.
@@ -17,6 +20,10 @@ Principio operativo principal:
 Modelo mental del producto:
 - Las situaciones del dia deciden que bloque de comida toca.
 - Los bloques de comida definen alimentos, opciones, cantidades y condiciones.
+- Si el plan contiene `situaciones`, usa `situaciones` como router:
+  tipo de dia + momento -> clave de comida.
+- Si una situacion contiene `aliases`, puedes usarlos para reconocer formas
+  naturales de la actividad, por ejemplo bici/ciclismo o correr/atletismo.
 - Las recetas, cuando existan, solo daran forma culinaria al bloque; nunca
   sustituyen sus cantidades.
 - Las reglas de adaptacion ayudan a ajustar platos al bloque, sin inventar

--- a/bot_profiles/nutrition/system_prompt.md
+++ b/bot_profiles/nutrition/system_prompt.md
@@ -1,91 +1,153 @@
 /no_think
 
-Eres un bot nutricionista conversacional integrado en Telegram.
+# System Prompt Nutricion
 
-Tu objetivo es ayudar al usuario a seguir un plan nutricional ya definido,
-explicandolo de forma practica, clara y accionable. No eres un medico ni un
-nutricionista colegiado sustituto; actuas como asistente para interpretar el
-plan que el usuario aporta.
+## Contexto
 
-Principio operativo principal:
-- Si existe un plan nutricional en el contexto de la conversacion o en memoria,
-  usalo como fuente principal.
-- Si hay documentos de contexto del perfil con un plan nutricional, tratalos
-  como el plan activo por defecto mientras no exista un plan de usuario mas
-  especifico.
-- Si no existe plan disponible, no finjas que lo hay. Pide al usuario que te
-  comparta el plan, el bloque de comida o la informacion necesaria antes de dar
-  cantidades concretas.
-- Puedes dar orientacion general y prudente cuando no haya plan, pero debes
-  dejar claro que no es una pauta personalizada.
+Eres un asistente nutricional conversacional integrado en Telegram.
 
-Modelo mental del producto:
-- Las situaciones del dia deciden que bloque de comida toca.
-- Los bloques de comida definen alimentos, opciones, cantidades y condiciones.
-- Si el plan contiene `situaciones`, usa `situaciones` como router:
-  tipo de dia + momento -> clave de comida.
-- Si una situacion contiene `aliases`, puedes usarlos para reconocer formas
-  naturales de la actividad, por ejemplo bici/ciclismo o correr/atletismo.
-- Las recetas, cuando existan, solo daran forma culinaria al bloque; nunca
-  sustituyen sus cantidades.
-- Las reglas de adaptacion ayudan a ajustar platos al bloque, sin inventar
-  dietas nuevas.
+Ayudas al usuario a seguir un plan estructurado basado en situaciones del dia y
+bloques de comidas.
 
-Cuando el usuario pregunte que comer:
-1. Identifica el momento de comida si esta claro: desayuno, almuerzo, merienda,
-   cena u otro momento definido por el plan.
-2. Identifica el tipo de dia si esta claro: descanso, entrenamiento, crossfit,
-   futbol, ciclismo, atletismo u otra actividad configurada.
-3. Si falta el momento o el tipo de dia y es necesario para responder bien,
-   pregunta una sola aclaracion breve.
-4. Si tienes un bloque aplicable, responde con las opciones y cantidades del
-   bloque. Si hay condiciones tipo "and" u "or", explicalas en lenguaje natural.
-5. Si el usuario pide cambiar un alimento, comprueba si encaja con las opciones
-   del bloque. Si no encaja, propone una alternativa cercana del propio plan.
+Tu funcion no es crear dietas nuevas, sino adaptar y aplicar correctamente el
+plan existente a la vida real del usuario.
 
-Comidas saltadas, desviaciones y memoria:
-- Si el usuario se ha saltado una comida, no recomiendes compensar de forma
-  agresiva. Ajusta con prudencia: continuar con la siguiente comida prevista,
-  priorizar proteina/verdura si procede, y evitar doblar cantidades salvo que el
-  plan lo indique.
-- Si el prompt incluye contexto de memoria o conversacion reciente, tratalo como
-  memoria disponible para esta respuesta.
-- Si el usuario pregunta que dijo, pregunto o comento antes, responde usando la
-  conversacion reciente incluida en el prompt.
-- No digas que no tienes memoria si el contexto de memoria contiene la
-  informacion.
-- Si la memoria reciente contiene un fallo repetido, una preferencia o una
-  restriccion, tenlo en cuenta, pero no conviertas un mensaje antiguo en una
-  coletilla permanente.
+No sustituyes a un nutricionista, medico u otro profesional sanitario.
+
+## Objetivo
+
+- ayudar al usuario a cumplir su plan nutricional
+- facilitar decisiones rapidas
+- mantener adherencia en el dia a dia
+- resolver dudas practicas sin abrumar
+
+## Fuente de verdad
+
+El plan activo del usuario manda.
+
+Usa esta jerarquia:
+
+1. `situaciones` decide que bloque toca segun tipo de dia y momento.
+2. `comidas` define alimentos, cantidades, macros del plan, condiciones y
+   grupos `and`/`or`.
+3. `reglas_adaptacion`, si existen, guian como convertir platos reales al
+   bloque.
+4. `recetas`, si existen, solo proponen platos reales compatibles; nunca
+   sustituyen las cantidades de `comidas`.
+
+Si no hay plan activo, no finjas que lo hay. Pide al usuario que lo suba con
+`/set_plan` antes de dar cantidades concretas.
+
+## Como responder cuando pregunta que comer
+
+1. Detecta el tipo de dia: crossfit, futbol, ciclismo, atletismo, descanso,
+   pilates u otra situacion definida por el plan del usuario.
+2. Detecta el momento: desayuno, almuerzo, comida, merienda, cena, pre entreno,
+   post entreno u otro momento definido por el plan.
+3. Si falta un dato imprescindible, pregunta una sola aclaracion breve.
+4. Si tienes situacion y momento, usa `situaciones[situacion].momentos[momento]`
+   para obtener la comida correspondiente.
+5. Responde usando solo ese bloque de `comidas`.
+6. En grupos `and`, combina todos los elementos requeridos.
+7. En grupos `or`, elige una opcion compatible y simple por defecto.
+
+## Formato
+
+Por defecto, si pide comida y cena:
+
+Comida:
+[plato con cantidades]
+
+Cena:
+[plato con cantidades]
+
+Si solo pide una comida:
+
+Cena:
+[plato con cantidades]
+
+Si hay adaptacion:
+
+Cena:
+Salmon con ensalada.
+
+He quitado el aceite porque el salmon ya aporta grasa.
+
+## Nivel de detalle
+
+- no expliques macros salvo que se pidan
+- no expliques el razonamiento completo
+- explica solo decisiones clave
+- no muestres JSON ni claves internas salvo que el usuario lo pida
+- no vuelques todas las opciones del bloque
+- da una unica recomendacion clara por defecto
+
+## Comportamiento en vida real
+
+El objetivo principal es que el usuario mantenga adherencia al plan.
+
+- prioriza soluciones faciles de ejecutar
+- si hay varias opciones validas, elige la mas simple
+- evita respuestas rigidas o excesivamente restrictivas
+- intenta adaptar lo que el usuario propone antes de rechazarlo
+- si una opcion no es ideal pero es razonable, ajustala en lugar de descartarla
+- si no encaja, ofrece una alternativa cercana del plan
+
+El usuario puede comer fuera, no tener ingredientes, desviarse del plan, tener
+prisa o haberse saltado una comida.
+
+En esos casos:
+
+- no juzgues
+- no recomiendes compensaciones agresivas
+- no dobles cantidades salvo que el plan lo indique
+- reconduce con prudencia hacia la siguiente comida
+
+## Reglas de adaptacion importantes
+
+- `comidas` manda sobre cualquier receta.
+- No inventes cantidades fuera del bloque si el bloque tiene cantidad concreta.
+- No sumes hidratos de varias fuentes si el bloque pide elegir una.
+- No sumes aceite cuando la proteina o receta ya aporta grasa relevante y las
+  reglas indican reducirlo o quitarlo.
+- Pescado azul, carne grasa o recetas grasas suelen requerir reducir o eliminar
+  aceite externo.
+- Carne magra, pescado blanco, claras o marisco suelen mantener la grasa del
+  bloque.
+- En cenas, prioriza opciones ligeras y evita hidratos altos salvo peticion
+  explicita del usuario.
+- En almuerzos, adapta arroz, pasta, patata, boniato, legumbres o pan a la
+  cantidad del bloque.
+
+## Memoria y contexto
+
+Si el prompt incluye memoria o conversacion reciente, usala como contexto
+disponible.
+
+- No digas que no tienes memoria si el contexto contiene informacion util.
+- Usa la conversacion reciente para resolver seguimientos como "y para cenar?",
+  "eso", "lo de antes" o correcciones del usuario.
 - Si una respuesta anterior fue lenta, erronea o incompleta, no repitas ese
-  aviso en mensajes posteriores salvo que el usuario pregunte por ello.
+  aviso salvo que el usuario pregunte por ello.
 
-Seguridad:
-- No diagnostiques, no trates patologias y no ajustes medicacion.
-- Ante sintomas agudos, trastornos de conducta alimentaria, embarazo,
-  lactancia, diabetes, enfermedad renal, enfermedad cardiaca, medicacion
-  relevante o cualquier caso clinico, recomienda revisar el plan con un
-  profesional sanitario.
-- No promuevas ayunos extremos, purgas, restricciones agresivas, deshidratacion
-  ni conductas de riesgo.
+## Seguridad
 
-Estilo de respuesta:
-- Responde en espanol salvo que el usuario use otro idioma.
-- Se directo, natural y util. En preguntas de "que como/ceno", no expliques el
-  plan: da la recomendacion.
-- No muestres JSON, razonamiento interno ni estructura tecnica salvo que el
-  usuario lo pida.
-- No muestres macros o calorias por defecto. Si el usuario los pide, dales solo
-  si estan en el plan o si aclaras que son estimaciones.
-- Para Telegram, usa mensajes cortos, con listas simples solo cuando ayuden.
-- Evita encabezados Markdown largos, tablas y listas anidadas.
-- Si necesitas destacar algo, usa una unica negrita corta con `**texto**`.
-- No empieces con "basandome en el plan", "segun el contexto" ni frases
-  similares.
-- No vuelques todas las opciones disponibles. Elige una opcion valida y menciona
-  como pedir otra alternativa.
-- Formato recomendado:
-  **Cena de no entreno**
-  330g de merluza con ensalada.
-  Añade 20g de aceite de oliva.
-  Si prefieres otra opcion, dimelo y te doy una alternativa del bloque.
+- No diagnostiques ni trates patologias.
+- No ajustes medicacion.
+- Ante sintomas agudos, TCA, embarazo, lactancia, diabetes, enfermedad renal,
+  enfermedad cardiaca, medicacion relevante o cualquier caso clinico, recomienda
+  revisar el plan con un profesional sanitario.
+- No promuevas ayunos extremos, purgas, restricciones agresivas,
+  deshidratacion ni conductas de riesgo.
+
+## Estilo
+
+- responde en espanol por defecto
+- claro
+- directo
+- practico
+- cercano pero profesional
+- sin tecnicismos innecesarios
+- sin sonar restrictivo ni rigido
+- mensajes cortos que rendericen bien en Telegram
+- evita tablas, listas largas y Markdown complejo

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,9 @@
+services:
+  botforge:
+    environment:
+      PYTHONPATH: /app/src
+    volumes:
+      - ./src:/app/src:ro
+      - ./bot_profiles:/app/bot_profiles:ro
+      - ./migrations:/app/migrations:ro
+      - ./debug_conversations:/home/botforge/debug_conversations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       OLLAMA_HOST: http://ollama:11434
       BOT_PROFILE: ${BOT_PROFILE:-default_dev}
       BOT_PROFILES_DIR: ${BOT_PROFILES_DIR:-bot_profiles}
+      DEBUG_CONVERSATION_LOG_DIR: ${DEBUG_CONVERSATION_LOG_DIR:-/home/botforge/debug_conversations}
     depends_on:
       postgres:
         condition: service_healthy

--- a/migrations/versions/20260524_0009_add_langchain_chat_memory.py
+++ b/migrations/versions/20260524_0009_add_langchain_chat_memory.py
@@ -1,0 +1,70 @@
+"""add langchain postgres chat memory tables
+
+Revision ID: 20260524_0009
+Revises: 20260519_0008
+Create Date: 2026-05-24
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260524_0009"
+down_revision: str | Sequence[str] | None = "20260519_0008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create LangChain's Postgres chat-history table plus user mapping."""
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS langchain_chat_history (
+            id SERIAL PRIMARY KEY,
+            session_id UUID NOT NULL,
+            message JSONB NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_langchain_chat_history_session_id
+        ON langchain_chat_history (session_id)
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_langchain_chat_history_session_id_id
+        ON langchain_chat_history (session_id, id)
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS langchain_chat_sessions (
+            id BIGSERIAL PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            bot_profile_id TEXT NOT NULL,
+            session_id UUID NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE (user_id, bot_profile_id),
+            UNIQUE (session_id)
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_langchain_chat_sessions_user_profile
+        ON langchain_chat_sessions (user_id, bot_profile_id)
+        """
+    )
+
+
+def downgrade() -> None:
+    """Remove LangChain chat memory tables."""
+    op.execute("DROP INDEX IF EXISTS ix_langchain_chat_sessions_user_profile")
+    op.execute("DROP TABLE IF EXISTS langchain_chat_sessions")
+    op.execute("DROP INDEX IF EXISTS idx_langchain_chat_history_session_id_id")
+    op.execute("DROP INDEX IF EXISTS idx_langchain_chat_history_session_id")
+    op.execute("DROP TABLE IF EXISTS langchain_chat_history")

--- a/migrations/versions/20260524_0009_add_langchain_chat_memory.py
+++ b/migrations/versions/20260524_0009_add_langchain_chat_memory.py
@@ -35,12 +35,6 @@ def upgrade() -> None:
     )
     op.execute(
         """
-        CREATE INDEX IF NOT EXISTS idx_langchain_chat_history_session_id_id
-        ON langchain_chat_history (session_id, id)
-        """
-    )
-    op.execute(
-        """
         CREATE TABLE IF NOT EXISTS langchain_chat_sessions (
             id BIGSERIAL PRIMARY KEY,
             user_id INTEGER NOT NULL REFERENCES users(id),
@@ -65,6 +59,5 @@ def downgrade() -> None:
     """Remove LangChain chat memory tables."""
     op.execute("DROP INDEX IF EXISTS ix_langchain_chat_sessions_user_profile")
     op.execute("DROP TABLE IF EXISTS langchain_chat_sessions")
-    op.execute("DROP INDEX IF EXISTS idx_langchain_chat_history_session_id_id")
     op.execute("DROP INDEX IF EXISTS idx_langchain_chat_history_session_id")
     op.execute("DROP TABLE IF EXISTS langchain_chat_history")

--- a/migrations/versions/20260524_0010_create_nutrition_daily_logs.py
+++ b/migrations/versions/20260524_0010_create_nutrition_daily_logs.py
@@ -1,0 +1,50 @@
+"""create nutrition daily logs
+
+Revision ID: 20260524_0010
+Revises: 20260524_0009
+Create Date: 2026-05-24
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260524_0010"
+down_revision: str | Sequence[str] | None = "20260524_0009"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Store one editable nutrition day state per user/profile/date."""
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS nutrition_daily_logs (
+            id BIGSERIAL PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            bot_profile_id TEXT NOT NULL,
+            log_date DATE NOT NULL,
+            plan_id TEXT NULL,
+            situation_key TEXT NULL,
+            situation_updated_at TIMESTAMPTZ NULL,
+            meals JSONB NOT NULL DEFAULT '{}'::jsonb,
+            notes JSONB NOT NULL DEFAULT '[]'::jsonb,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT nutrition_daily_logs_user_profile_date_unique
+                UNIQUE (user_id, bot_profile_id, log_date)
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_nutrition_daily_logs_user_profile_date
+        ON nutrition_daily_logs (user_id, bot_profile_id, log_date DESC)
+        """
+    )
+
+
+def downgrade() -> None:
+    """Remove nutrition daily log storage."""
+    op.execute("DROP INDEX IF EXISTS ix_nutrition_daily_logs_user_profile_date")
+    op.execute("DROP TABLE IF EXISTS nutrition_daily_logs")

--- a/migrations/versions/20260524_0011_add_langchain_history_window_index.py
+++ b/migrations/versions/20260524_0011_add_langchain_history_window_index.py
@@ -1,0 +1,30 @@
+"""add langchain chat history window index
+
+Revision ID: 20260524_0011
+Revises: 20260524_0010
+Create Date: 2026-05-24
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260524_0011"
+down_revision: str | Sequence[str] | None = "20260524_0010"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Support bounded recent-message and compaction-window reads."""
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_langchain_chat_history_session_id_id
+        ON langchain_chat_history (session_id, id)
+        """
+    )
+
+
+def downgrade() -> None:
+    """Remove bounded-window read index."""
+    op.execute("DROP INDEX IF EXISTS idx_langchain_chat_history_session_id_id")

--- a/migrations/versions/20260524_0012_create_nutrition_plans.py
+++ b/migrations/versions/20260524_0012_create_nutrition_plans.py
@@ -1,0 +1,74 @@
+"""create nutrition plan storage
+
+Revision ID: 20260524_0012
+Revises: 20260524_0011
+Create Date: 2026-05-24
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260524_0012"
+down_revision: str | Sequence[str] | None = "20260524_0011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Store active nutrition plans and their normalized JSON documents."""
+    op.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS nutrition_plans (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            status TEXT NOT NULL,
+            source_filename TEXT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CHECK (status IN ('draft', 'active', 'failed', 'archived'))
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS ux_nutrition_plans_one_active_per_user
+        ON nutrition_plans (user_id)
+        WHERE status = 'active'
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_nutrition_plans_user_status_updated
+        ON nutrition_plans (user_id, status, updated_at DESC)
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS nutrition_plan_documents (
+            id BIGSERIAL PRIMARY KEY,
+            plan_id UUID NOT NULL REFERENCES nutrition_plans(id) ON DELETE CASCADE,
+            document_type TEXT NOT NULL,
+            content JSONB NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CHECK (document_type IN ('meal_plan'))
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS ux_nutrition_plan_documents_plan_type
+        ON nutrition_plan_documents (plan_id, document_type)
+        """
+    )
+
+
+def downgrade() -> None:
+    """Remove nutrition plan storage."""
+    op.execute("DROP INDEX IF EXISTS ux_nutrition_plan_documents_plan_type")
+    op.execute("DROP TABLE IF EXISTS nutrition_plan_documents")
+    op.execute("DROP INDEX IF EXISTS ix_nutrition_plans_user_status_updated")
+    op.execute("DROP INDEX IF EXISTS ux_nutrition_plans_one_active_per_user")
+    op.execute("DROP TABLE IF EXISTS nutrition_plans")

--- a/migrations/versions/20260524_0013_split_nutrition_plan_documents.py
+++ b/migrations/versions/20260524_0013_split_nutrition_plan_documents.py
@@ -1,0 +1,57 @@
+"""split nutrition plan documents by source JSON
+
+Revision ID: 20260524_0013
+Revises: 20260524_0012
+Create Date: 2026-05-24
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260524_0013"
+down_revision: str | Sequence[str] | None = "20260524_0012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Allow active plans to store situaciones/comidas as separate JSONB docs."""
+    op.execute(
+        """
+        ALTER TABLE nutrition_plan_documents
+        DROP CONSTRAINT IF EXISTS nutrition_plan_documents_document_type_check
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE nutrition_plan_documents
+        ADD CONSTRAINT nutrition_plan_documents_document_type_check
+        CHECK (
+            document_type IN (
+                'meal_plan',
+                'situaciones',
+                'comidas',
+                'reglas_adaptacion',
+                'recetas'
+            )
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    """Return to the original single meal_plan document type."""
+    op.execute(
+        """
+        ALTER TABLE nutrition_plan_documents
+        DROP CONSTRAINT IF EXISTS nutrition_plan_documents_document_type_check
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE nutrition_plan_documents
+        ADD CONSTRAINT nutrition_plan_documents_document_type_check
+        CHECK (document_type IN ('meal_plan'))
+        """
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "psycopg[binary]>=3.2.0",
     "bcrypt>=4.1.0",
     "alembic>=1.13.0",
+    "certifi>=2024.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dependencies = [
     "bcrypt>=4.1.0",
     "alembic>=1.13.0",
     "certifi>=2024.0.0",
+    "langchain-core>=0.3.0,<2.0",
+    "langchain-postgres>=0.0.17,<0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/forge_bot/bot_profile.py
+++ b/src/forge_bot/bot_profile.py
@@ -42,6 +42,7 @@ class BotProfile:
     memory_enabled: bool
     analytics_enabled: bool
     context_documents: tuple[BotProfileContextDocument, ...] = ()
+    nutrition_plan_path: Path | None = None
 
 
 def load_active_bot_profile(
@@ -107,6 +108,11 @@ def load_bot_profile(
         memory_enabled=_required_bool(data, "memory_enabled"),
         analytics_enabled=_required_bool(data, "analytics_enabled"),
         context_documents=_load_context_documents(data, profile_root),
+        nutrition_plan_path=_optional_profile_file(
+            data,
+            profile_root,
+            "nutrition_plan_file",
+        ),
     )
 
 
@@ -251,5 +257,24 @@ def _resolve_profile_file(profile_root: Path, relative_path: str) -> Path:
     ):
         raise BotProfileError(
             "Bot profile context files must stay inside the profile folder."
+        )
+    return resolved
+
+
+def _optional_profile_file(
+    data: Mapping[str, Any],
+    profile_root: Path,
+    field: str,
+) -> Path | None:
+    value = data.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise BotProfileError(f"Bot profile field '{field}' must be a string.")
+
+    resolved = _resolve_profile_file(profile_root, value.strip())
+    if not resolved.is_file():
+        raise BotProfileError(
+            f"Bot profile file configured by '{field}' was not found at {resolved}."
         )
     return resolved

--- a/src/forge_bot/bot_profile.py
+++ b/src/forge_bot/bot_profile.py
@@ -262,9 +262,7 @@ def _load_context_documents(
                 f"Bot profile context file '{item.strip()}' is too large "
                 f"({len(content)} chars; max {MAX_CONTEXT_DOCUMENT_CHARS})."
             )
-        documents.append(
-            BotProfileContextDocument(name=item.strip(), content=content)
-        )
+        documents.append(BotProfileContextDocument(name=item.strip(), content=content))
     return tuple(documents)
 
 

--- a/src/forge_bot/bot_profile.py
+++ b/src/forge_bot/bot_profile.py
@@ -7,10 +7,19 @@ from pathlib import Path
 from typing import Any
 
 PROFILE_FILE_NAME = "profile.json"
+MAX_CONTEXT_DOCUMENT_CHARS = 120_000
 
 
 class BotProfileError(RuntimeError):
     """Raised when a bot profile cannot be loaded or validated."""
+
+
+@dataclass(frozen=True)
+class BotProfileContextDocument:
+    """Read-only context bundled with one bot profile."""
+
+    name: str
+    content: str
 
 
 @dataclass(frozen=True)
@@ -32,6 +41,7 @@ class BotProfile:
     llm_model: str
     memory_enabled: bool
     analytics_enabled: bool
+    context_documents: tuple[BotProfileContextDocument, ...] = ()
 
 
 def load_active_bot_profile(
@@ -96,6 +106,7 @@ def load_bot_profile(
         llm_model=_required_text(data, "llm_model"),
         memory_enabled=_required_bool(data, "memory_enabled"),
         analytics_enabled=_required_bool(data, "analytics_enabled"),
+        context_documents=_load_context_documents(data, profile_root),
     )
 
 
@@ -183,3 +194,62 @@ def _load_system_prompt(
             f"System prompt file for bot profile '{profile_id}' must not be empty."
         )
     return prompt
+
+
+def _load_context_documents(
+    data: Mapping[str, Any],
+    profile_root: Path,
+) -> tuple[BotProfileContextDocument, ...]:
+    """Load optional profile context files declared in profile.json."""
+    value = data.get("context_files", [])
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise BotProfileError(
+            "Bot profile field 'context_files' must be a list of relative paths."
+        )
+
+    documents: list[BotProfileContextDocument] = []
+    for index, item in enumerate(value, start=1):
+        if not isinstance(item, str) or not item.strip():
+            raise BotProfileError(
+                "Bot profile field 'context_files' must contain only non-empty "
+                f"strings; item {index} is invalid."
+            )
+        context_path = _resolve_profile_file(profile_root, item.strip())
+        if not context_path.is_file():
+            raise BotProfileError(
+                f"Bot profile context file was not found at {context_path}."
+            )
+
+        content = context_path.read_text(encoding="utf-8").strip()
+        if not content:
+            raise BotProfileError(
+                f"Bot profile context file '{item.strip()}' must not be empty."
+            )
+        if len(content) > MAX_CONTEXT_DOCUMENT_CHARS:
+            raise BotProfileError(
+                f"Bot profile context file '{item.strip()}' is too large "
+                f"({len(content)} chars; max {MAX_CONTEXT_DOCUMENT_CHARS})."
+            )
+        documents.append(
+            BotProfileContextDocument(name=item.strip(), content=content)
+        )
+    return tuple(documents)
+
+
+def _resolve_profile_file(profile_root: Path, relative_path: str) -> Path:
+    """Resolve a profile file while preventing accidental path traversal."""
+    path = Path(relative_path)
+    if path.is_absolute():
+        raise BotProfileError("Bot profile context files must use relative paths.")
+
+    profile_root_resolved = profile_root.resolve()
+    resolved = (profile_root / path).resolve()
+    if resolved != profile_root_resolved and profile_root_resolved not in (
+        resolved.parents
+    ):
+        raise BotProfileError(
+            "Bot profile context files must stay inside the profile folder."
+        )
+    return resolved

--- a/src/forge_bot/bot_profile.py
+++ b/src/forge_bot/bot_profile.py
@@ -8,6 +8,7 @@ from typing import Any
 
 PROFILE_FILE_NAME = "profile.json"
 MAX_CONTEXT_DOCUMENT_CHARS = 120_000
+SUPPORTED_MEMORY_BACKENDS = frozenset({"postgres", "langchain_postgres"})
 
 
 class BotProfileError(RuntimeError):
@@ -40,6 +41,7 @@ class BotProfile:
     llm_provider: str
     llm_model: str
     memory_enabled: bool
+    memory_backend: str
     analytics_enabled: bool
     context_documents: tuple[BotProfileContextDocument, ...] = ()
     nutrition_plan_path: Path | None = None
@@ -106,6 +108,7 @@ def load_bot_profile(
         llm_provider=_required_text(data, "llm_provider"),
         llm_model=_required_text(data, "llm_model"),
         memory_enabled=_required_bool(data, "memory_enabled"),
+        memory_backend=_memory_backend(data),
         analytics_enabled=_required_bool(data, "analytics_enabled"),
         context_documents=_load_context_documents(data, profile_root),
         nutrition_plan_path=_optional_profile_file(
@@ -141,6 +144,27 @@ def _required_text(data: Mapping[str, Any], field: str) -> str:
             f"Bot profile field '{field}' must be a non-empty string."
         )
     return value.strip()
+
+
+def _optional_text(data: Mapping[str, Any], field: str, *, default: str) -> str:
+    value = data.get(field)
+    if value is None:
+        return default
+    if not isinstance(value, str) or not value.strip():
+        raise BotProfileError(
+            f"Bot profile field '{field}' must be a non-empty string when set."
+        )
+    return value.strip()
+
+
+def _memory_backend(data: Mapping[str, Any]) -> str:
+    backend = _optional_text(data, "memory_backend", default="postgres").lower()
+    if backend not in SUPPORTED_MEMORY_BACKENDS:
+        options = ", ".join(sorted(SUPPORTED_MEMORY_BACKENDS))
+        raise BotProfileError(
+            f"Bot profile field 'memory_backend' must be one of: {options}."
+        )
+    return backend
 
 
 def _required_bool(data: Mapping[str, Any], field: str) -> bool:

--- a/src/forge_bot/commands/admin_memory.py
+++ b/src/forge_bot/commands/admin_memory.py
@@ -1,0 +1,477 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from forge_bot.config import get_settings
+from forge_bot.database import conect_db
+
+from .auth_guard import admin_required
+
+ADMIN_USERS_USAGE = "/admin_users [limit]"
+ADMIN_MEMORY_USAGE = (
+    "/admin_memory <user_id|tg:telegram_id|email:value|username:value> [profile_id]"
+)
+MAX_TELEGRAM_MESSAGE_CHARS = 3800
+DEFAULT_USER_LIMIT = 20
+MAX_USER_LIMIT = 50
+RECENT_MESSAGE_LIMIT = 8
+DAILY_LOG_LIMIT = 3
+
+
+@admin_required
+async def admin_users(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """List users with identifiers that can be passed to /admin_memory."""
+    if not update.message:
+        return
+
+    limit = _parse_limit(context.args or ())
+    if limit is None:
+        await update.message.reply_text(f"Usage:\n{ADMIN_USERS_USAGE}")
+        return
+
+    users = list_admin_users(limit=limit)
+    if users is None:
+        await update.message.reply_text("Could not load users right now.")
+        return
+    if not users:
+        await update.message.reply_text("No users found.")
+        return
+
+    lines = ["Users", ""]
+    for user in users:
+        lines.append(
+            " ".join(
+                part
+                for part in (
+                    f"id={user.get('id')}",
+                    f"tg={user.get('telegram_id')}",
+                    f"role={user.get('role')}",
+                    f"username={user.get('username')}",
+                    f"email={user.get('email')}" if user.get("email") else "",
+                )
+                if part
+            )
+        )
+    lines.extend(("", f"Use: {ADMIN_MEMORY_USAGE}"))
+    await _reply_chunks(update, "\n".join(lines))
+
+
+@admin_required
+async def admin_memory(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Return a sectioned memory snapshot for one user."""
+    if not update.message:
+        return
+
+    args = [arg.strip() for arg in (context.args or []) if arg.strip()]
+    if not args or len(args) > 2:
+        await update.message.reply_text(f"Usage:\n{ADMIN_MEMORY_USAGE}")
+        return
+
+    profile_id = args[1] if len(args) == 2 else get_settings().bot_profile
+    report = build_admin_memory_report(args[0], profile_id=profile_id)
+    await _reply_chunks(update, report)
+
+
+def list_admin_users(*, limit: int) -> list[Mapping[str, Any]] | None:
+    connection = conect_db()
+    if connection is None:
+        return None
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT id, telegram_id, username, email, role, created_at, deleted_at
+                FROM users
+                ORDER BY id DESC
+                LIMIT %s
+                """,
+                (limit,),
+            )
+            return list(cursor.fetchall())
+    finally:
+        connection.close()
+
+
+def build_admin_memory_report(identifier: str, *, profile_id: str) -> str:
+    user = resolve_admin_user(identifier)
+    if user is None:
+        return (
+            "User not found.\n\n"
+            f"Usage:\n{ADMIN_MEMORY_USAGE}\n\n"
+            "Examples:\n/admin_memory 7\n/admin_memory tg:123456\n"
+            "/admin_memory email:person@example.com nutrition"
+        )
+
+    snapshot = load_user_memory_snapshot(user_id=int(user["id"]), profile_id=profile_id)
+    if snapshot is None:
+        return "Could not load user memory right now."
+
+    return _format_memory_report(user=user, profile_id=profile_id, snapshot=snapshot)
+
+
+def resolve_admin_user(identifier: str) -> Mapping[str, Any] | None:
+    field, value = _parse_user_identifier(identifier)
+    numeric_value = (
+        _parse_int_identifier(value) if field in {"id", "telegram_id"} else None
+    )
+    if field in {"id", "telegram_id"} and numeric_value is None:
+        return None
+    connection = conect_db()
+    if connection is None:
+        return None
+    try:
+        with connection.cursor() as cursor:
+            if field == "id":
+                cursor.execute(
+                    """
+                    SELECT id, telegram_id, username, email, role, created_at,
+                           deleted_at
+                    FROM users
+                    WHERE id = %s
+                    """,
+                    (numeric_value,),
+                )
+            elif field == "telegram_id":
+                cursor.execute(
+                    """
+                    SELECT id, telegram_id, username, email, role, created_at,
+                           deleted_at
+                    FROM users
+                    WHERE telegram_id = %s
+                    """,
+                    (numeric_value,),
+                )
+            elif field == "email":
+                cursor.execute(
+                    """
+                    SELECT id, telegram_id, username, email, role, created_at,
+                           deleted_at
+                    FROM users
+                    WHERE lower(email) = lower(%s)
+                    """,
+                    (value,),
+                )
+            else:
+                cursor.execute(
+                    """
+                    SELECT id, telegram_id, username, email, role, created_at,
+                           deleted_at
+                    FROM users
+                    WHERE username = %s
+                    """,
+                    (value,),
+                )
+            row = cursor.fetchone()
+            return row if isinstance(row, Mapping) else None
+    finally:
+        connection.close()
+
+
+def _parse_int_identifier(value: str) -> int | None:
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def load_user_memory_snapshot(
+    *,
+    user_id: int,
+    profile_id: str,
+) -> dict[str, Any] | None:
+    connection = conect_db()
+    if connection is None:
+        return None
+    try:
+        with connection.cursor() as cursor:
+            return {
+                "daily_logs": _fetch_daily_logs(cursor, user_id, profile_id),
+                "compact_memory": _fetch_compact_memory(cursor, user_id, profile_id),
+                "langchain_messages": _fetch_langchain_messages(
+                    cursor,
+                    user_id,
+                    profile_id,
+                ),
+                "legacy_messages": _fetch_legacy_messages(cursor, user_id, profile_id),
+                "db_active_plan": _fetch_db_active_plan(cursor, user_id),
+            }
+    finally:
+        connection.close()
+
+
+def _fetch_daily_logs(
+    cursor: Any,
+    user_id: int,
+    profile_id: str,
+) -> list[Mapping[str, Any]]:
+    cursor.execute(
+        """
+        SELECT log_date, situation_key, meals, notes, updated_at
+        FROM nutrition_daily_logs
+        WHERE user_id = %s
+          AND bot_profile_id = %s
+        ORDER BY log_date DESC
+        LIMIT %s
+        """,
+        (user_id, profile_id, DAILY_LOG_LIMIT),
+    )
+    return list(cursor.fetchall())
+
+
+def _fetch_compact_memory(
+    cursor: Any,
+    user_id: int,
+    profile_id: str,
+) -> Mapping[str, Any] | None:
+    cursor.execute(
+        """
+        SELECT summary, source_message_count, compaction_version, updated_at
+        FROM user_memory_summaries
+        WHERE user_id = %s
+          AND bot_profile_id = %s
+          AND deleted_at IS NULL
+        """,
+        (user_id, profile_id),
+    )
+    row = cursor.fetchone()
+    return row if isinstance(row, Mapping) else None
+
+
+def _fetch_langchain_messages(
+    cursor: Any,
+    user_id: int,
+    profile_id: str,
+) -> list[Mapping[str, Any]]:
+    cursor.execute(
+        """
+        SELECT h.created_at, h.message
+        FROM langchain_chat_sessions s
+        JOIN langchain_chat_history h ON h.session_id = s.session_id
+        WHERE s.user_id = %s
+          AND s.bot_profile_id = %s
+        ORDER BY h.created_at DESC, h.id DESC
+        LIMIT %s
+        """,
+        (user_id, profile_id, RECENT_MESSAGE_LIMIT),
+    )
+    rows = list(cursor.fetchall())
+    rows.reverse()
+    return rows
+
+
+def _fetch_legacy_messages(
+    cursor: Any,
+    user_id: int,
+    profile_id: str,
+) -> list[Mapping[str, Any]]:
+    cursor.execute(
+        """
+        SELECT role, content, created_at
+        FROM conversation_messages
+        WHERE user_id = %s
+          AND bot_profile_id = %s
+          AND deleted_at IS NULL
+        ORDER BY created_at DESC, id DESC
+        LIMIT %s
+        """,
+        (user_id, profile_id, RECENT_MESSAGE_LIMIT),
+    )
+    rows = list(cursor.fetchall())
+    rows.reverse()
+    return rows
+
+
+def _fetch_db_active_plan(cursor: Any, user_id: int) -> Mapping[str, Any] | None:
+    cursor.execute("SELECT to_regclass('nutrition_plans') AS table_name")
+    table_row = cursor.fetchone()
+    if not table_row or table_row.get("table_name") is None:
+        return None
+    cursor.execute(
+        """
+        SELECT id, status, created_at, updated_at
+        FROM nutrition_plans
+        WHERE user_id = %s
+        ORDER BY CASE WHEN status = 'active' THEN 0 ELSE 1 END,
+                 updated_at DESC NULLS LAST,
+                 created_at DESC NULLS LAST
+        LIMIT 1
+        """,
+        (user_id,),
+    )
+    row = cursor.fetchone()
+    return row if isinstance(row, Mapping) else None
+
+
+def _format_memory_report(
+    *,
+    user: Mapping[str, Any],
+    profile_id: str,
+    snapshot: Mapping[str, Any],
+) -> str:
+    sections = [
+        "User memory",
+        _format_user(user, profile_id),
+        _format_db_active_plan(snapshot.get("db_active_plan")),
+        _format_daily_logs(snapshot.get("daily_logs")),
+        _format_compact_memory(snapshot.get("compact_memory")),
+        _format_messages(
+            "LangChain recent messages",
+            snapshot.get("langchain_messages"),
+        ),
+        _format_messages("Legacy recent messages", snapshot.get("legacy_messages")),
+    ]
+    return "\n\n".join(section for section in sections if section)
+
+
+def _format_user(user: Mapping[str, Any], profile_id: str) -> str:
+    return "\n".join(
+        (
+            f"Profile: {profile_id}",
+            f"User id: {user.get('id')}",
+            f"Telegram id: {user.get('telegram_id')}",
+            f"Username: {user.get('username')}",
+            f"Email: {user.get('email') or '-'}",
+            f"Role: {user.get('role')}",
+        )
+    )
+
+
+def _format_db_active_plan(value: object) -> str:
+    if not isinstance(value, Mapping) or not value:
+        return "DB active plan: not available yet"
+    return "\n".join(
+        (
+            "DB active plan:",
+            f"- id: {value.get('id')}",
+            f"- status: {value.get('status')}",
+            f"- updated_at: {value.get('updated_at')}",
+        )
+    )
+
+
+def _format_daily_logs(value: object) -> str:
+    logs = value if isinstance(value, list) else []
+    if not logs:
+        return "Daily logs: none"
+    sections = ["Daily logs:"]
+    for log in logs:
+        if not isinstance(log, Mapping):
+            continue
+        sections.append(
+            "\n".join(
+                (
+                    f"- date: {log.get('log_date')}",
+                    f"  tipo_dia: {log.get('situation_key') or '-'}",
+                    f"  meals: {_compact_json(log.get('meals'))}",
+                    f"  notes: {_compact_json(log.get('notes'))}",
+                )
+            )
+        )
+    return "\n".join(sections)
+
+
+def _format_compact_memory(value: object) -> str:
+    if not isinstance(value, Mapping) or not value:
+        return "Compact memory: none"
+    return "\n".join(
+        (
+            "Compact memory:",
+            f"- source_message_count: {value.get('source_message_count')}",
+            f"- updated_at: {value.get('updated_at')}",
+            f"- summary: {_short(value.get('summary'), 1200)}",
+        )
+    )
+
+
+def _format_messages(title: str, value: object) -> str:
+    messages = value if isinstance(value, list) else []
+    if not messages:
+        return f"{title}: none"
+    lines = [f"{title}:"]
+    for row in messages:
+        if not isinstance(row, Mapping):
+            continue
+        role, content = _message_role_content(row)
+        lines.append(f"- {role}: {_short(content, 260)}")
+    return "\n".join(lines)
+
+
+def _message_role_content(row: Mapping[str, Any]) -> tuple[str, str]:
+    if "message" not in row:
+        return str(row.get("role") or "unknown"), str(row.get("content") or "")
+    message = row.get("message")
+    if not isinstance(message, Mapping):
+        return "unknown", str(message or "")
+    message_type = str(message.get("type") or "")
+    role = "assistant" if message_type in {"ai", "assistant"} else "user"
+    data = message.get("data")
+    if isinstance(data, Mapping):
+        content = data.get("content")
+    else:
+        content = message.get("content")
+    return role, str(content or "")
+
+
+def _parse_user_identifier(identifier: str) -> tuple[str, str]:
+    value = identifier.strip()
+    lowered = value.lower()
+    if lowered.startswith(("tg:", "telegram:")):
+        return "telegram_id", value.split(":", 1)[1].strip()
+    if lowered.startswith("email:"):
+        return "email", value.split(":", 1)[1].strip()
+    if lowered.startswith("username:"):
+        return "username", value.split(":", 1)[1].strip()
+    if lowered.startswith("id:"):
+        return "id", value.split(":", 1)[1].strip()
+    return "id", value
+
+
+def _parse_limit(args: Sequence[str]) -> int | None:
+    if not args:
+        return DEFAULT_USER_LIMIT
+    if len(args) > 1:
+        return None
+    try:
+        limit = int(args[0])
+    except ValueError:
+        return None
+    if limit < 1:
+        return None
+    return min(limit, MAX_USER_LIMIT)
+
+
+async def _reply_chunks(update: Update, text: str) -> None:
+    if not update.message:
+        return
+    for chunk in _chunks(text, MAX_TELEGRAM_MESSAGE_CHARS):
+        await update.message.reply_text(chunk)
+
+
+def _chunks(text: str, max_chars: int) -> Iterable[str]:
+    remaining = text
+    while len(remaining) > max_chars:
+        split_at = remaining.rfind("\n\n", 0, max_chars)
+        if split_at <= 0:
+            split_at = max_chars
+        yield remaining[:split_at].strip()
+        remaining = remaining[split_at:].strip()
+    if remaining:
+        yield remaining
+
+
+def _compact_json(value: object) -> str:
+    if value in (None, {}, []):
+        return "-"
+    return _short(json.dumps(value, ensure_ascii=False, sort_keys=True), 900)
+
+
+def _short(value: object, max_chars: int) -> str:
+    text = str(value or "")
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 3].rstrip() + "..."

--- a/src/forge_bot/commands/auth.py
+++ b/src/forge_bot/commands/auth.py
@@ -4,6 +4,7 @@ from telegram.ext import ContextTypes
 from forge_bot.database import redeem_invite_token, status_user
 from forge_bot.messages import build_message
 
+from .auth_guard import require_linked_user
 from .policy import policy_action_keyboard, policy_prompt
 
 INVITE_PROMPT = build_message(
@@ -72,6 +73,7 @@ async def _reply_to_invite_redemption(
     await update.message.reply_text(message)
 
 
+@require_linked_user
 async def status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not update.message or not update.effective_user:
         return

--- a/src/forge_bot/commands/auth_guard.py
+++ b/src/forge_bot/commands/auth_guard.py
@@ -43,6 +43,23 @@ def require_login(func: Handler) -> Handler:
     return wrapper
 
 
+def require_linked_user(func: Handler) -> Handler:
+    """Restrict a handler to Telegram users already linked to BotForge."""
+
+    @wraps(func)
+    async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if not update.effective_user or not update.message:
+            return
+
+        user_id = update.effective_user.id
+        if not await _require_linked_user(update, user_id, INVITE_REQUIRED_MESSAGE):
+            return
+
+        await func(update, context)
+
+    return wrapper
+
+
 def admin_required(func: Handler) -> Handler:
     """Restrict a Telegram command handler to logged-in admin users."""
 

--- a/src/forge_bot/commands/get_plan.py
+++ b/src/forge_bot/commands/get_plan.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from typing import Any
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from forge_bot.commands.auth_guard import require_login
+from forge_bot.database import get_user_by_telegram_id
+from forge_bot.messages import build_message
+from forge_bot.nutrition.plan import parse_nutrition_plan
+from forge_bot.nutrition.plan_store import (
+    NUTRITION_PLAN_MEALS_DOCUMENT_TYPE,
+    NUTRITION_PLAN_SITUATIONS_DOCUMENT_TYPE,
+    load_active_nutrition_plan_documents,
+)
+
+EXPORT_OPTIONS = frozenset(
+    {
+        "all",
+        "todo",
+        "combined",
+        "combinado",
+        "situaciones",
+        "comidas",
+    }
+)
+
+
+@require_login
+async def get_plan(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Show or export the authenticated user's active nutrition plan."""
+    if not update.message or not update.effective_user:
+        return
+
+    user = get_user_by_telegram_id(update.effective_user.id)
+    if not user or user.get("id") is None:
+        await update.message.reply_text("No puedo localizar tu usuario interno ahora.")
+        return
+
+    active_documents = load_active_nutrition_plan_documents(user_id=int(user["id"]))
+    if active_documents is None:
+        await update.message.reply_text(
+            "Todavia no tienes un plan nutricional activo. Sube situaciones y "
+            "comidas con /set_plan."
+        )
+        return
+
+    option = _export_option(context.args or [])
+    if option is None:
+        await update.message.reply_text(_summary_message(active_documents.combined))
+        return
+
+    content, filename = _export_payload(active_documents.documents, option)
+    if content is None:
+        await update.message.reply_text("No tengo ese documento en tu plan activo.")
+        return
+
+    await update.message.reply_document(
+        document=_json_file(content),
+        filename=filename,
+    )
+
+
+def _export_option(args: list[str]) -> str | None:
+    if not args:
+        return None
+    option = args[0].strip().lower()
+    return option if option in EXPORT_OPTIONS else None
+
+
+def _summary_message(combined: Any) -> str:
+    plan = parse_nutrition_plan(combined)
+    situation_lines = []
+    for situation_key, situation in plan.situations.items():
+        moments = situation.get("momentos")
+        moment_count = len(moments) if isinstance(moments, dict) else 0
+        situation_lines.append(f"- {situation_key}: {moment_count} momentos")
+
+    summary = build_message(
+        "Plan nutricional activo",
+        details=(
+            ("Plan", plan.plan_id),
+            ("Situaciones", str(len(plan.situations))),
+            ("Comidas", str(len(plan.meals))),
+            ("Revisar", "/get_plan situaciones | /get_plan comidas | /get_plan all"),
+        ),
+    )
+    if situation_lines:
+        summary = f"{summary}\n\nSituaciones:\n" + "\n".join(situation_lines[:12])
+    return summary
+
+
+def _export_payload(
+    documents: Any,
+    option: str,
+) -> tuple[Any | None, str]:
+    if option in {"situaciones"}:
+        return (
+            documents.get(NUTRITION_PLAN_SITUATIONS_DOCUMENT_TYPE),
+            "situaciones.json",
+        )
+    if option in {"comidas"}:
+        return documents.get(NUTRITION_PLAN_MEALS_DOCUMENT_TYPE), "comidas.json"
+    return _combined_payload(documents), "plan_nutricional.json"
+
+
+def _combined_payload(documents: Any) -> dict[str, Any] | None:
+    situations = documents.get(NUTRITION_PLAN_SITUATIONS_DOCUMENT_TYPE)
+    meals = documents.get(NUTRITION_PLAN_MEALS_DOCUMENT_TYPE)
+    if not isinstance(situations, dict) or not isinstance(meals, dict):
+        return None
+
+    combined: dict[str, Any] = {}
+    plan_id = situations.get("plan_id") or meals.get("plan_id")
+    if isinstance(plan_id, str) and plan_id.strip():
+        combined["plan_id"] = plan_id.strip()
+    if isinstance(situations.get("situaciones"), dict):
+        combined["situaciones"] = situations["situaciones"]
+    if isinstance(meals.get("comidas"), dict):
+        combined["comidas"] = meals["comidas"]
+    for optional_key in ("reglas_adaptacion", "recetas"):
+        optional = documents.get(optional_key)
+        if isinstance(optional, dict) and optional_key in optional:
+            combined[optional_key] = optional[optional_key]
+    return combined
+
+
+def _json_file(content: Any) -> BytesIO:
+    payload = json.dumps(content, ensure_ascii=False, indent=2).encode("utf-8")
+    file_obj = BytesIO(payload)
+    file_obj.name = "plan.json"
+    return file_obj

--- a/src/forge_bot/commands/greet.py
+++ b/src/forge_bot/commands/greet.py
@@ -1,7 +1,10 @@
 from telegram import Update
 from telegram.ext import ContextTypes
 
+from .auth_guard import require_login
 
+
+@require_login
 async def greet(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not update.message or not update.effective_user:
         return

--- a/src/forge_bot/commands/help.py
+++ b/src/forge_bot/commands/help.py
@@ -24,11 +24,16 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "/decline_policy - Decline the current policy.\n"
         "/privacy - Review stored data and controls.\n"
         "/memory_clear - Clear personalization memory.\n"
-        "/delete_my_data - Start data deletion."
+        "/delete_my_data - Start data deletion.\n"
+        "/set_plan - Upload your nutrition plan JSON files.\n"
+        "/get_plan - Review or export your active nutrition plan."
     )
     if admin:
         help_text += (
             "\n\nAdmin commands\n"
+            "/admin_users [limit] - List user identifiers for admin tools.\n"
+            "/admin_memory <user_id|tg:telegram_id|email:value|username:value> "
+            "[profile_id] - Inspect memory sections for a user.\n"
             "/invite <role> <email> - Create a single-use invite link.\n"
             "/campaign_invite <role> <expires_at> <max_uses> - Create a "
             "reusable campaign invite link."

--- a/src/forge_bot/commands/help.py
+++ b/src/forge_bot/commands/help.py
@@ -4,7 +4,10 @@ from telegram.ext import ContextTypes
 from forge_bot.database import is_admin
 from forge_bot.messages import build_message
 
+from .auth_guard import require_login
 
+
+@require_login
 async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not update.message or not update.effective_user:
         return

--- a/src/forge_bot/commands/ping.py
+++ b/src/forge_bot/commands/ping.py
@@ -3,7 +3,10 @@ import time as time_module
 from telegram import Update
 from telegram.ext import ContextTypes
 
+from .auth_guard import require_login
 
+
+@require_login
 async def ping(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not update.message:
         return

--- a/src/forge_bot/commands/policy.py
+++ b/src/forge_bot/commands/policy.py
@@ -15,6 +15,8 @@ from forge_bot.database import (
 )
 from forge_bot.messages import build_message
 
+from .auth_guard import require_linked_user
+
 logger = logging.getLogger(__name__)
 
 IDENTITY_UNAVAILABLE_MESSAGE = (
@@ -101,6 +103,7 @@ def policy_prompt() -> str:
     )
 
 
+@require_linked_user
 async def policy(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not update.message:
         return
@@ -128,6 +131,7 @@ async def policy(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await update.message.reply_text(text, reply_markup=policy_action_keyboard())
 
 
+@require_linked_user
 async def accept_policy(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not update.message or not update.effective_user:
         return
@@ -136,6 +140,7 @@ async def accept_policy(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     await update.message.reply_text(_accept_policy_message(status))
 
 
+@require_linked_user
 async def decline_policy(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not update.message or not update.effective_user:
         return

--- a/src/forge_bot/commands/privacy.py
+++ b/src/forge_bot/commands/privacy.py
@@ -10,6 +10,8 @@ from forge_bot.database import (
 )
 from forge_bot.messages import usage_message
 
+from .auth_guard import require_linked_user
+
 PRIVACY_TEXT = (
     "BotForge data controls\n\n"
     "BotForge stores your Telegram identity after invite redemption, policy "
@@ -36,6 +38,7 @@ DELETE_EXPLANATION = (
 )
 
 
+@require_linked_user
 async def privacy(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Explain stored data categories and available controls."""
     if not update.message:
@@ -44,6 +47,7 @@ async def privacy(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await update.message.reply_text(PRIVACY_TEXT)
 
 
+@require_linked_user
 async def memory_clear(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Clear personalization memory for the linked Telegram user."""
     if not update.message or not update.effective_user:
@@ -61,6 +65,7 @@ async def memory_clear(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     )
 
 
+@require_linked_user
 async def delete_my_data(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Request or confirm broader beta deletion for the linked Telegram user."""
     if not update.message or not update.effective_user:

--- a/src/forge_bot/commands/set_plan.py
+++ b/src/forge_bot/commands/set_plan.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import logging
+
+from telegram import Document, Update
+from telegram.ext import ContextTypes
+
+from forge_bot import engine
+from forge_bot.bot_profile import BotProfileError
+from forge_bot.commands.auth_guard import require_login
+from forge_bot.database import get_user_by_telegram_id
+from forge_bot.messages import build_message
+from forge_bot.nutrition.normalizer import parse_json_object
+from forge_bot.nutrition.plan import NutritionPlanError
+from forge_bot.nutrition.plan_normalizer import normalize_uploaded_plan
+from forge_bot.nutrition.plan_store import (
+    NUTRITION_PLAN_MEALS_DOCUMENT_TYPE,
+    NUTRITION_PLAN_SITUATIONS_DOCUMENT_TYPE,
+    NutritionPlanStoreError,
+    save_active_nutrition_plan,
+    save_nutrition_plan_part,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_PLAN_UPLOAD_BYTES = 300_000
+SUPPORTED_MIME_TYPES = frozenset(
+    {
+        "application/json",
+        "text/plain",
+        "application/octet-stream",
+    }
+)
+
+
+@require_login
+async def set_plan(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Store a user's active nutrition plan from pasted JSON or an attached file."""
+    if not update.message or not update.effective_user:
+        return
+
+    message = update.message
+    raw_text: str | None = None
+    source_filename: str | None = None
+    if message.document is not None:
+        document_result = await _read_plan_document(message.document)
+        if isinstance(document_result, str):
+            raw_text = document_result
+            source_filename = message.document.file_name
+        else:
+            await message.reply_text(document_result["message"])
+            return
+    else:
+        raw_text = _command_text(message.text or "", context.args or [])
+
+    if not raw_text or not raw_text.strip():
+        await message.reply_text(
+            build_message(
+                "Listo para cargar tu plan.",
+                details=(
+                    (
+                        "Paso 1",
+                        "Envia situaciones.json como documento.",
+                    ),
+                    (
+                        "Paso 2",
+                        "Envia comidas.json como documento.",
+                    ),
+                    (
+                        "Nota",
+                        "Desde movil no hace falta caption en los ficheros.",
+                    ),
+                ),
+            )
+        )
+        return
+
+    user = get_user_by_telegram_id(update.effective_user.id)
+    if not user or user.get("id") is None:
+        await message.reply_text("No puedo localizar tu usuario interno ahora mismo.")
+        return
+
+    try:
+        profile = engine.load_default_profile()
+        if profile.bot_profile_id != "nutrition":
+            await message.reply_text(
+                "Este comando solo esta disponible con el perfil nutrition."
+            )
+            return
+        partial_payload = _partial_plan_payload(raw_text)
+        if partial_payload is not None:
+            partial = save_nutrition_plan_part(
+                user_id=int(user["id"]),
+                document_type=partial_payload[0],
+                content=partial_payload[1],
+                source_filename=source_filename,
+            )
+            if not partial.activated:
+                await message.reply_text(
+                    build_message(
+                        "Parte del plan guardada.",
+                        details=(
+                            ("Recibido", partial.document_type),
+                            (
+                                "Falta",
+                                ", ".join(partial.missing_document_types),
+                            ),
+                        ),
+                    )
+                )
+                return
+            plan = partial.activated_plan
+            if plan is None:
+                await message.reply_text("No he podido activar el plan ahora mismo.")
+                return
+            source = "validacion local"
+        else:
+            normalizer = engine.build_nutrition_normalizer(profile)
+            normalized = await normalize_uploaded_plan(
+                raw_text=raw_text,
+                client=normalizer[0] if normalizer is not None else None,
+                model=normalizer[1] if normalizer is not None else None,
+            )
+            saved = save_active_nutrition_plan(
+                user_id=int(user["id"]),
+                plan_data=normalized.content,
+                source_filename=source_filename,
+            )
+            plan = saved.plan
+            source = "LLM" if normalized.normalized_by_llm else "validacion local"
+    except (NutritionPlanError, NutritionPlanStoreError, BotProfileError) as exc:
+        await message.reply_text(
+            build_message(
+                "No he podido guardar el plan.",
+                details=(("Motivo", str(exc)),),
+            )
+        )
+        return
+    except Exception:
+        logger.exception(
+            "set_plan_failed telegram_user_id=%s",
+            update.effective_user.id,
+        )
+        await message.reply_text("No he podido guardar el plan ahora mismo.")
+        return
+
+    await message.reply_text(
+        build_message(
+            "Plan nutricional activo actualizado.",
+            details=(
+                ("Plan", plan.plan_id),
+                ("Situaciones", str(len(plan.situations))),
+                ("Comidas", str(len(plan.meals))),
+                ("Normalizacion", source),
+            ),
+        )
+    )
+
+
+async def _read_plan_document(document: Document) -> str | dict[str, str]:
+    filename = document.file_name or "plan"
+    if not _is_supported_document(document):
+        return {
+            "message": (
+                "Sube un fichero .json o .txt con situaciones o comidas."
+            )
+        }
+    if document.file_size and document.file_size > MAX_PLAN_UPLOAD_BYTES:
+        return {
+            "message": (
+                "El fichero es demasiado grande para esta primera version. "
+                f"Maximo: {MAX_PLAN_UPLOAD_BYTES // 1000} KB."
+            )
+        }
+
+    telegram_file = await document.get_file()
+    content = await telegram_file.download_as_bytearray()
+    if len(content) > MAX_PLAN_UPLOAD_BYTES:
+        return {
+            "message": (
+                "El fichero es demasiado grande para esta primera version. "
+                f"Maximo: {MAX_PLAN_UPLOAD_BYTES // 1000} KB."
+            )
+        }
+    try:
+        return bytes(content).decode("utf-8")
+    except UnicodeDecodeError:
+        return {"message": f"No puedo leer {filename} como texto UTF-8."}
+
+
+def _is_supported_document(document: Document) -> bool:
+    filename = (document.file_name or "").lower()
+    mime_type = document.mime_type or ""
+    return filename.endswith((".json", ".txt")) or mime_type in SUPPORTED_MIME_TYPES
+
+
+def _command_text(text: str, args: list[str]) -> str:
+    if args:
+        return " ".join(args)
+    if text.startswith("/set_plan"):
+        return text.removeprefix("/set_plan").strip()
+    return text.strip()
+
+
+def _partial_plan_payload(raw_text: str) -> tuple[str, dict[str, object]] | None:
+    payload = parse_json_object(raw_text)
+    if not isinstance(payload, dict):
+        return None
+
+    has_situations = isinstance(payload.get("situaciones"), dict)
+    has_meals = isinstance(payload.get("comidas"), dict)
+    if has_situations and has_meals:
+        return None
+    if has_situations:
+        return (
+            NUTRITION_PLAN_SITUATIONS_DOCUMENT_TYPE,
+            {
+                key: value
+                for key, value in payload.items()
+                if key in {"plan_id", "situaciones"}
+            },
+        )
+    if has_meals:
+        return (
+            NUTRITION_PLAN_MEALS_DOCUMENT_TYPE,
+            {
+                key: value
+                for key, value in payload.items()
+                if key in {"plan_id", "comidas"}
+            },
+        )
+    return None

--- a/src/forge_bot/commands/set_plan.py
+++ b/src/forge_bot/commands/set_plan.py
@@ -217,7 +217,7 @@ def _partial_plan_payload(raw_text: str) -> tuple[str, dict[str, object]] | None
             {
                 key: value
                 for key, value in payload.items()
-                if key in {"plan_id", "situaciones"}
+                if key in {"plan_id", "momentos", "situaciones"}
             },
         )
     if has_meals:

--- a/src/forge_bot/commands/set_plan.py
+++ b/src/forge_bot/commands/set_plan.py
@@ -160,11 +160,7 @@ async def set_plan(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 async def _read_plan_document(document: Document) -> str | dict[str, str]:
     filename = document.file_name or "plan"
     if not _is_supported_document(document):
-        return {
-            "message": (
-                "Sube un fichero .json o .txt con situaciones o comidas."
-            )
-        }
+        return {"message": ("Sube un fichero .json o .txt con situaciones o comidas.")}
     if document.file_size and document.file_size > MAX_PLAN_UPLOAD_BYTES:
         return {
             "message": (

--- a/src/forge_bot/commands/time.py
+++ b/src/forge_bot/commands/time.py
@@ -3,7 +3,10 @@ from datetime import datetime
 from telegram import Update
 from telegram.ext import ContextTypes
 
+from .auth_guard import require_login
 
+
+@require_login
 async def time(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not update.message:
         return

--- a/src/forge_bot/commands/unknown.py
+++ b/src/forge_bot/commands/unknown.py
@@ -1,7 +1,10 @@
 from telegram import Update
 from telegram.ext import ContextTypes
 
+from .auth_guard import require_login
 
+
+@require_login
 async def unknown_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not update.message:
         return

--- a/src/forge_bot/config.py
+++ b/src/forge_bot/config.py
@@ -9,11 +9,11 @@ from dotenv import load_dotenv
 DEFAULT_DB_PORT = 5432
 DEFAULT_OLLAMA_HOST = "http://localhost:11434"
 DEFAULT_OLLAMA_MODEL = "gemma3:4b"
-DEFAULT_LLM_PRIMARY_PROVIDER = "ollama"
+DEFAULT_LLM_PRIMARY_PROVIDER = "profile"
 DEFAULT_LLM_FALLBACK_PROVIDER = "nvidia"
 DEFAULT_LLM_FALLBACK_QUEUE_WAIT_SECONDS = 100
 DEFAULT_NVIDIA_BASE_URL = "https://integrate.api.nvidia.com/v1"
-DEFAULT_NVIDIA_MODEL = "nvidia/llama-3.1-nemotron-nano-8b-v1"
+DEFAULT_NVIDIA_MODEL = "nvidia/llama-3.3-nemotron-super-49b-v1.5"
 DEFAULT_BOT_PROFILE = "default_dev"
 DEFAULT_BOT_PROFILES_DIR = "bot_profiles"
 DEFAULT_BOT_POLICY_VERSION = "2026-05-08"

--- a/src/forge_bot/config.py
+++ b/src/forge_bot/config.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from os import environ
 from urllib.parse import quote
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from dotenv import load_dotenv
 
@@ -14,6 +15,8 @@ DEFAULT_LLM_FALLBACK_PROVIDER = "nvidia"
 DEFAULT_LLM_FALLBACK_QUEUE_WAIT_SECONDS = 100
 DEFAULT_NVIDIA_BASE_URL = "https://integrate.api.nvidia.com/v1"
 DEFAULT_NVIDIA_MODEL = "nvidia/llama-3.3-nemotron-super-49b-v1.5"
+DEFAULT_NUTRITION_NORMALIZER_PROVIDER = "nvidia"
+DEFAULT_NUTRITION_NORMALIZER_MODEL = DEFAULT_NVIDIA_MODEL
 DEFAULT_BOT_PROFILE = "default_dev"
 DEFAULT_BOT_PROFILES_DIR = "bot_profiles"
 DEFAULT_BOT_POLICY_VERSION = "2026-05-08"
@@ -23,7 +26,7 @@ DEFAULT_CAMPAIGN_INVITE_MAX_USES_LIMIT = 1000
 DEFAULT_MESSAGE_PROCESSING_STALE_MINUTES = 30
 DEFAULT_MESSAGE_EXPIRATION_HOURS = 24
 DEFAULT_MESSAGE_MAX_RETRIES = 1
-DEFAULT_AI_TIMEOUT_SECONDS = 60
+DEFAULT_AI_TIMEOUT_SECONDS = 300
 DEFAULT_AI_MAX_RESPONSE_CHARS = 4000
 DEFAULT_MAX_MESSAGE_CHARS = 4000
 DEFAULT_USER_MESSAGES_PER_MINUTE = 6
@@ -37,7 +40,9 @@ DEFAULT_MEMORY_COMPACTION_TRIGGER_MESSAGES = 6
 DEFAULT_MEMORY_COMPACTION_SOURCE_MESSAGES = 5
 DEFAULT_MEMORY_MAX_MESSAGE_CHARS = 4000
 DEFAULT_MEMORY_COMPACTED_MAX_CHARS = 2000
+DEFAULT_DEBUG_CONVERSATION_LOG_DIR = "debug_conversations"
 DEFAULT_BOTFORGE_ENV = "development"
+DEFAULT_BOT_TIMEZONE = "Europe/Madrid"
 PRODUCTION_ENVS = frozenset({"prod", "production"})
 DEVELOPMENT_DB_PASSWORD = "botforge_dev_password"
 PLACEHOLDER_TELEGRAM_TOKEN = "<telegram_bot_token>"
@@ -147,6 +152,8 @@ class Settings(DatabaseSettings):
     nvidia_api_key: str = ""
     nvidia_base_url: str = DEFAULT_NVIDIA_BASE_URL
     nvidia_model: str = DEFAULT_NVIDIA_MODEL
+    nutrition_normalizer_provider: str = DEFAULT_NUTRITION_NORMALIZER_PROVIDER
+    nutrition_normalizer_model: str = DEFAULT_NUTRITION_NORMALIZER_MODEL
     bot_profile: str = DEFAULT_BOT_PROFILE
     bot_profiles_dir: str = DEFAULT_BOT_PROFILES_DIR
     bot_policy_version: str = DEFAULT_BOT_POLICY_VERSION
@@ -172,9 +179,12 @@ class Settings(DatabaseSettings):
     memory_compaction_source_messages: int = DEFAULT_MEMORY_COMPACTION_SOURCE_MESSAGES
     memory_max_message_chars: int = DEFAULT_MEMORY_MAX_MESSAGE_CHARS
     memory_compacted_max_chars: int = DEFAULT_MEMORY_COMPACTED_MAX_CHARS
+    debug_conversation_log_enabled: bool = False
+    debug_conversation_log_dir: str = DEFAULT_DEBUG_CONVERSATION_LOG_DIR
     analytics_consent_enabled: bool = False
     training_consent_enabled: bool = False
     botforge_env: str = DEFAULT_BOTFORGE_ENV
+    bot_timezone: str = DEFAULT_BOT_TIMEZONE
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] = environ) -> "Settings":
@@ -197,6 +207,16 @@ class Settings(DatabaseSettings):
             botforge_env,
             telegram_token=required["TELEGRAM_TOKEN"],
             db_password=required["DB_PASSWORD"],
+        )
+        debug_conversation_log_enabled = _parse_bool(
+            env.get("DEBUG_CONVERSATION_LOG_ENABLED")
+        )
+        _validate_debug_logging(
+            botforge_env,
+            enabled=debug_conversation_log_enabled,
+            allow_production=_parse_bool(
+                env.get("DEBUG_CONVERSATION_LOG_ALLOW_PRODUCTION")
+            ),
         )
 
         return cls(
@@ -224,6 +244,14 @@ class Settings(DatabaseSettings):
                 _clean(env.get("NVIDIA_BASE_URL")) or DEFAULT_NVIDIA_BASE_URL
             ),
             nvidia_model=_clean(env.get("NVIDIA_MODEL")) or DEFAULT_NVIDIA_MODEL,
+            nutrition_normalizer_provider=(
+                _clean(env.get("NUTRITION_NORMALIZER_PROVIDER"))
+                or DEFAULT_NUTRITION_NORMALIZER_PROVIDER
+            ).lower(),
+            nutrition_normalizer_model=(
+                _clean(env.get("NUTRITION_NORMALIZER_MODEL"))
+                or DEFAULT_NUTRITION_NORMALIZER_MODEL
+            ),
             bot_profile=_clean(env.get("BOT_PROFILE")) or DEFAULT_BOT_PROFILE,
             bot_profiles_dir=(
                 _clean(env.get("BOT_PROFILES_DIR")) or DEFAULT_BOT_PROFILES_DIR
@@ -316,6 +344,11 @@ class Settings(DatabaseSettings):
                 env.get("MEMORY_COMPACTED_MAX_CHARS"),
                 DEFAULT_MEMORY_COMPACTED_MAX_CHARS,
             ),
+            debug_conversation_log_enabled=debug_conversation_log_enabled,
+            debug_conversation_log_dir=(
+                _clean(env.get("DEBUG_CONVERSATION_LOG_DIR"))
+                or DEFAULT_DEBUG_CONVERSATION_LOG_DIR
+            ),
             analytics_consent_enabled=_parse_bool(
                 env.get("BOT_ANALYTICS_CONSENT_ENABLED")
             ),
@@ -323,6 +356,7 @@ class Settings(DatabaseSettings):
                 env.get("BOT_TRAINING_CONSENT_ENABLED")
             ),
             botforge_env=botforge_env,
+            bot_timezone=_parse_timezone(env.get("BOT_TIMEZONE")),
         )
 
 
@@ -421,6 +455,18 @@ def _parse_bool_default(value: str | None, *, default: bool) -> bool:
     return cleaned.lower() in {"1", "true", "yes", "on"}
 
 
+def _parse_timezone(value: str | None) -> str:
+    """Parse and validate the default application timezone."""
+    cleaned = _clean(value) or DEFAULT_BOT_TIMEZONE
+    try:
+        ZoneInfo(cleaned)
+    except ZoneInfoNotFoundError as exc:
+        raise SettingsError(
+            f"BOT_TIMEZONE is not a valid IANA timezone: {cleaned}"
+        ) from exc
+    return cleaned
+
+
 def _validate_production_secrets(
     botforge_env: str,
     *,
@@ -442,6 +488,21 @@ def _validate_production_secrets(
         raise SettingsError(
             f"Production configuration cannot use development secrets: {details}."
         )
+
+
+def _validate_debug_logging(
+    botforge_env: str,
+    *,
+    enabled: bool,
+    allow_production: bool,
+) -> None:
+    """Keep raw conversation file logging out of production by default."""
+    if not enabled or botforge_env not in PRODUCTION_ENVS or allow_production:
+        return
+    raise SettingsError(
+        "DEBUG_CONVERSATION_LOG_ENABLED cannot be true in production unless "
+        "DEBUG_CONVERSATION_LOG_ALLOW_PRODUCTION=true is set explicitly."
+    )
 
 
 @lru_cache

--- a/src/forge_bot/database.py
+++ b/src/forge_bot/database.py
@@ -898,6 +898,27 @@ def _clear_user_memory_records(cursor: Any, *, user_id: int) -> tuple[int, int]:
     )
     conversation_memory = int(cursor.rowcount or 0)
     cursor.execute(
+        """
+        DELETE FROM langchain_chat_history
+        WHERE session_id IN (
+            SELECT session_id
+            FROM langchain_chat_sessions
+            WHERE user_id = %s
+        )
+        """,
+        (user_id,),
+    )
+    conversation_memory += int(cursor.rowcount or 0)
+    cursor.execute(
+        "DELETE FROM langchain_chat_sessions WHERE user_id = %s",
+        (user_id,),
+    )
+    cursor.execute(
+        "DELETE FROM nutrition_daily_logs WHERE user_id = %s",
+        (user_id,),
+    )
+    conversation_memory += int(cursor.rowcount or 0)
+    cursor.execute(
         "DELETE FROM user_memory_summaries WHERE user_id = %s",
         (user_id,),
     )

--- a/src/forge_bot/debug_conversation_log.py
+++ b/src/forge_bot/debug_conversation_log.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .config import Settings, get_settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DebugConversationTurn:
+    """One user/assistant exchange written only when debug logging is enabled."""
+
+    bot_profile_id: str
+    user_message: str
+    assistant_message: str
+    internal_user_id: int | None = None
+    telegram_user_id: int | None = None
+    telegram_chat_id: int | None = None
+    telegram_message_id: int | None = None
+    inbound_message_id: int | None = None
+    request_id: str | None = None
+    created_at: datetime | None = None
+
+
+def append_debug_conversation_turn(
+    turn: DebugConversationTurn,
+    *,
+    settings: Settings | None = None,
+) -> bool:
+    """Append one conversation turn to a per-user text file in debug mode."""
+    active_settings = settings or get_settings()
+    if not active_settings.debug_conversation_log_enabled:
+        return False
+
+    try:
+        path = _conversation_log_path(
+            directory=Path(active_settings.debug_conversation_log_dir),
+            bot_profile_id=turn.bot_profile_id,
+            user_key=_user_key(turn),
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as file:
+            file.write(_format_turn(turn))
+        return True
+    except OSError:
+        logger.exception(
+            "debug_conversation_log_write_failed user_id=%s telegram_user_id=%s "
+            "bot_profile_id=%s",
+            turn.internal_user_id,
+            turn.telegram_user_id,
+            turn.bot_profile_id,
+        )
+        return False
+
+
+def _conversation_log_path(
+    *,
+    directory: Path,
+    bot_profile_id: str,
+    user_key: str,
+) -> Path:
+    profile_dir = _safe_path_part(bot_profile_id)
+    return directory / profile_dir / f"{_safe_path_part(user_key)}.txt"
+
+
+def _format_turn(turn: DebugConversationTurn) -> str:
+    created_at = turn.created_at or datetime.now(timezone.utc)
+    timestamp = created_at.astimezone(timezone.utc).isoformat()
+    metadata = {
+        "at": timestamp,
+        "bot_profile_id": turn.bot_profile_id,
+        "internal_user_id": turn.internal_user_id,
+        "telegram_user_id": turn.telegram_user_id,
+        "telegram_chat_id": turn.telegram_chat_id,
+        "telegram_message_id": turn.telegram_message_id,
+        "inbound_message_id": turn.inbound_message_id,
+        "request_id": turn.request_id,
+    }
+    metadata_lines = "\n".join(
+        f"{key}: {value}" for key, value in metadata.items() if value is not None
+    )
+    return (
+        "\n"
+        "================================================================================\n"
+        f"{metadata_lines}\n\n"
+        "[USER]\n"
+        f"{turn.user_message.rstrip()}\n\n"
+        "[ASSISTANT]\n"
+        f"{turn.assistant_message.rstrip()}\n"
+    )
+
+
+def _user_key(turn: DebugConversationTurn) -> str:
+    if turn.internal_user_id is not None:
+        return f"user_{turn.internal_user_id}"
+    if turn.telegram_user_id is not None:
+        return f"telegram_{turn.telegram_user_id}"
+    return "unknown_user"
+
+
+def _safe_path_part(value: str) -> str:
+    cleaned = re.sub(r"[^a-zA-Z0-9_.-]+", "_", value.strip())
+    return cleaned.strip("._") or "unknown"

--- a/src/forge_bot/engine.py
+++ b/src/forge_bot/engine.py
@@ -43,16 +43,22 @@ class ProviderConfigurationError(RuntimeError):
 class GeneratedAnswer(str):
     """String response with optional post-success side effects."""
 
+    debug_log: bool
     post_success_actions: tuple[object, ...]
+    store_in_memory: bool
 
     def __new__(
         cls,
         value: str,
         *,
+        debug_log: bool = True,
         post_success_actions: Sequence[object] = (),
+        store_in_memory: bool = True,
     ) -> "GeneratedAnswer":
         instance = str.__new__(cls, value)
+        instance.debug_log = debug_log
         instance.post_success_actions = tuple(post_success_actions)
+        instance.store_in_memory = store_in_memory
         return instance
 
 
@@ -326,7 +332,7 @@ async def answer(
             settings.ai_timeout_seconds,
             len(msg),
         )
-        return AI_TIMEOUT_FALLBACK
+        return _operational_fallback(AI_TIMEOUT_FALLBACK)
     except ProviderConfigurationError:
         logger.exception(
             "llm_provider_configuration_failed request_id=%s provider_reason=%s "
@@ -335,7 +341,7 @@ async def answer(
             fallback_reason,
             len(msg),
         )
-        return AI_ERROR_FALLBACK
+        return _operational_fallback(AI_ERROR_FALLBACK)
     except Exception:
         provider_name = _provider_name(provider)
         if provider_name != _fallback_provider_name():
@@ -348,7 +354,7 @@ async def answer(
                 reason="primary_error",
             )
             if fallback_answer is not None:
-                return GeneratedAnswer(fallback_answer)
+                return _fallback_generated_answer(fallback_answer)
 
         logger.exception(
             "llm_chat_failed request_id=%s provider=%s model=%s message_chars=%s",
@@ -357,7 +363,7 @@ async def answer(
             _logged_model(active_profile.llm_model, provider_name),
             len(msg),
         )
-        return AI_ERROR_FALLBACK
+        return _operational_fallback(AI_ERROR_FALLBACK)
 
     provider_name = _provider_name(provider)
     return GeneratedAnswer(
@@ -480,7 +486,7 @@ async def answer_stream(
             settings.ai_timeout_seconds,
             len(msg),
         )
-        return AI_TIMEOUT_FALLBACK
+        return _operational_fallback(AI_TIMEOUT_FALLBACK)
     except ProviderConfigurationError:
         logger.exception(
             "llm_provider_configuration_failed request_id=%s provider_reason=%s "
@@ -489,7 +495,7 @@ async def answer_stream(
             fallback_reason,
             len(msg),
         )
-        return AI_ERROR_FALLBACK
+        return _operational_fallback(AI_ERROR_FALLBACK)
     except Exception:
         provider_name = _provider_name(provider)
         logger.exception(
@@ -511,9 +517,9 @@ async def answer_stream(
                     "No he podido completar la respuesta, pero esto es lo que "
                     "llevaba preparado."
                 ),
-                post_success_actions=nutrition_prompt.post_success_actions,
+                store_in_memory=False,
             )
-        return AI_ERROR_FALLBACK
+        return _operational_fallback(AI_ERROR_FALLBACK)
 
     content = "".join(raw_parts)
     provider_name = _provider_name(provider)
@@ -537,6 +543,16 @@ def finalize_successful_answer(answer: str) -> None:
                 action()
         except Exception:
             logger.exception("post_success_answer_action_failed")
+
+
+def answer_should_be_debug_logged(answer: str) -> bool:
+    """Return whether this answer belongs in the debug conversation transcript."""
+    return bool(getattr(answer, "debug_log", True))
+
+
+def answer_should_be_stored_in_memory(answer: str) -> bool:
+    """Return whether this answer should become reusable user memory."""
+    return bool(getattr(answer, "store_in_memory", True))
 
 
 async def summarize_memory(
@@ -878,6 +894,16 @@ async def _answer_with_fallback(
         model=_logged_model(model, provider.name),
         max_chars=max_chars,
     )
+
+
+def _fallback_generated_answer(answer: str) -> GeneratedAnswer:
+    if answer in {AI_TIMEOUT_FALLBACK, AI_ERROR_FALLBACK}:
+        return _operational_fallback(answer)
+    return GeneratedAnswer(answer)
+
+
+def _operational_fallback(answer: str) -> GeneratedAnswer:
+    return GeneratedAnswer(answer, debug_log=False, store_in_memory=False)
 
 
 async def _chat_with_timeout(

--- a/src/forge_bot/engine.py
+++ b/src/forge_bot/engine.py
@@ -7,27 +7,28 @@ import ssl
 import time
 import urllib.error
 import urllib.request
-from collections.abc import Iterable, Sequence
-from dataclasses import replace
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Sequence
+from datetime import datetime
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
+from zoneinfo import ZoneInfo
 
 import certifi
 import ollama
 
 from .bot_profile import BotProfile, load_active_bot_profile
 from .config import get_settings
-from .nutrition.plan import NutritionPlan, NutritionPlanError, load_nutrition_plan_file
-from .nutrition.router import MealResolution, resolve_meal_context
+from .nutrition.orchestrator import prepare_nutrition_prompt_async
 from .prompting import ChatMessage, assemble_prompt_messages
 
 logger = logging.getLogger(__name__)
 
 AI_TIMEOUT_FALLBACK = (
-    "The AI response is taking longer than expected. Please try again in a moment."
+    "No he podido cerrar la respuesta tras varios minutos. No la reenvies de "
+    "momento; prueba con una version mas corta si necesitas resolverlo ya."
 )
 AI_ERROR_FALLBACK = (
-    "The AI service is temporarily unavailable. Please try again in a moment."
+    "El servicio de IA no esta disponible ahora mismo. Prueba de nuevo en un momento."
 )
 FALLBACK_DISABLED_VALUES = {"", "none", "disabled", "off"}
 PROFILE_PRIMARY_PROVIDER_VALUES = {"", "profile"}
@@ -37,6 +38,22 @@ AI_TIMEOUT_ERRORS = (TimeoutError, asyncio.TimeoutError)
 
 class ProviderConfigurationError(RuntimeError):
     """Raised when a selected LLM provider is not configured for use."""
+
+
+class GeneratedAnswer(str):
+    """String response with optional post-success side effects."""
+
+    post_success_actions: tuple[object, ...]
+
+    def __new__(
+        cls,
+        value: str,
+        *,
+        post_success_actions: Sequence[object] = (),
+    ) -> "GeneratedAnswer":
+        instance = str.__new__(cls, value)
+        instance.post_success_actions = tuple(post_success_actions)
+        return instance
 
 
 class OllamaProvider:
@@ -87,16 +104,50 @@ class NvidiaNimProvider:
         self._ssl_context = ssl.create_default_context(cafile=certifi.where())
 
     async def chat(self, *, model: str, messages: list[ChatMessage]) -> str:
-        del model
+        request_model = _nvidia_model_for_request(model, self._model)
         return await asyncio.wait_for(
-            asyncio.to_thread(self._chat, messages),
+            asyncio.to_thread(self._chat, messages, request_model),
             timeout=self._timeout_seconds,
         )
 
-    def _chat(self, messages: list[ChatMessage]) -> str:
+    async def stream_chat(
+        self,
+        *,
+        model: str,
+        messages: list[ChatMessage],
+    ) -> AsyncIterator[str]:
+        request_model = _nvidia_model_for_request(model, self._model)
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[str | BaseException | None] = asyncio.Queue()
+
+        def worker() -> None:
+            try:
+                for chunk in self._stream_chat(messages, request_model):
+                    loop.call_soon_threadsafe(queue.put_nowait, chunk)
+            except BaseException as exc:
+                loop.call_soon_threadsafe(queue.put_nowait, exc)
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, None)
+
+        worker_task = asyncio.create_task(asyncio.to_thread(worker))
+        try:
+            while True:
+                item = await asyncio.wait_for(
+                    queue.get(),
+                    timeout=self._timeout_seconds,
+                )
+                if item is None:
+                    break
+                if isinstance(item, BaseException):
+                    raise item
+                yield item
+        finally:
+            await worker_task
+
+    def _chat(self, messages: list[ChatMessage], model: str) -> str:
         body = json.dumps(
             {
-                "model": self._model,
+                "model": model,
                 "messages": messages,
             }
         ).encode("utf-8")
@@ -134,6 +185,49 @@ class NvidiaNimProvider:
             ) from exc
         return str(content or "")
 
+    def _stream_chat(self, messages: list[ChatMessage], model: str) -> Iterator[str]:
+        body = json.dumps(
+            {
+                "model": model,
+                "messages": messages,
+                "stream": True,
+            }
+        ).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self._base_url}/chat/completions",
+            data=body,
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+                "Accept": "text/event-stream",
+            },
+        )
+
+        try:
+            # The base URL is normalized by _validated_https_base_url().
+            with urllib.request.urlopen(  # nosec B310
+                request,
+                timeout=self._timeout_seconds,
+                context=self._ssl_context,
+            ) as response:
+                for raw_line in response:
+                    line = raw_line.decode("utf-8").strip()
+                    if not line.startswith("data:"):
+                        continue
+                    data = line.removeprefix("data:").strip()
+                    if data == "[DONE]":
+                        break
+                    chunk = _nvidia_stream_delta(data)
+                    if chunk:
+                        yield chunk
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"NVIDIA NIM streaming request failed with HTTP {exc.code}."
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError("NVIDIA NIM streaming request failed.") from exc
+
 
 async def answer(
     user: str,
@@ -143,6 +237,7 @@ async def answer(
     queue_wait_seconds: float = 0.0,
     compacted_user_memory: str | None = None,
     recent_conversation_messages: list[ChatMessage] | None = None,
+    internal_user_id: int | None = None,
 ) -> str:
     """Send a profile-aware prompt to the configured LLM provider.
 
@@ -154,32 +249,45 @@ async def answer(
         queue_wait_seconds: Seconds between message receipt and processing start.
         compacted_user_memory: Durable summary for this user/profile.
         recent_conversation_messages: Recent raw messages for this user/profile.
+        internal_user_id: Internal database user id for profile-specific state.
 
     Returns:
         The assistant response text produced by Ollama.
     """
     settings = get_settings()
     active_profile = _resolve_profile(profile)
-    prompt_profile, runtime_instructions, direct_answer = _prepare_profile_prompt(
+    normalizer = _build_nutrition_normalizer(active_profile)
+    now = _current_datetime(settings.bot_timezone)
+    nutrition_prompt = await prepare_nutrition_prompt_async(
         active_profile,
         msg,
-        recent_conversation_messages or [],
+        compacted_user_memory=compacted_user_memory,
+        recent_conversation_messages=recent_conversation_messages or [],
+        normalizer_client=normalizer[0] if normalizer is not None else None,
+        normalizer_model=normalizer[1] if normalizer is not None else None,
+        internal_user_id=internal_user_id,
+        current_date=now.date(),
     )
-    if direct_answer is not None:
-        return direct_answer
-    include_memory = not (
-        active_profile.bot_profile_id == "nutrition" and runtime_instructions
-    )
+    if nutrition_prompt.direct_answer is not None:
+        return GeneratedAnswer(
+            nutrition_prompt.direct_answer,
+            post_success_actions=nutrition_prompt.post_success_actions,
+        )
 
     messages = assemble_prompt_messages(
-        prompt_profile,
+        nutrition_prompt.prompt_profile,
         current_user_message=msg,
         user_display_name=user,
-        compacted_user_memory=compacted_user_memory if include_memory else None,
-        recent_conversation_messages=(
-            recent_conversation_messages or [] if include_memory else []
+        compacted_user_memory=(
+            compacted_user_memory if nutrition_prompt.include_memory else None
         ),
-        runtime_safety_instructions=runtime_instructions,
+        recent_conversation_messages=(
+            recent_conversation_messages or []
+            if nutrition_prompt.include_memory
+            else []
+        ),
+        runtime_safety_instructions=nutrition_prompt.runtime_instructions,
+        now=now,
     )
     request_id_text = request_id or "unknown"
     fallback_reason = _fallback_reason(
@@ -240,7 +348,7 @@ async def answer(
                 reason="primary_error",
             )
             if fallback_answer is not None:
-                return fallback_answer
+                return GeneratedAnswer(fallback_answer)
 
         logger.exception(
             "llm_chat_failed request_id=%s provider=%s model=%s message_chars=%s",
@@ -252,12 +360,183 @@ async def answer(
         return AI_ERROR_FALLBACK
 
     provider_name = _provider_name(provider)
-    return _trim_response(
-        content,
-        provider=provider_name,
-        model=_logged_model(active_profile.llm_model, provider_name),
-        max_chars=settings.ai_max_response_chars,
+    return GeneratedAnswer(
+        _trim_response(
+            content,
+            provider=provider_name,
+            model=_logged_model(active_profile.llm_model, provider_name),
+            max_chars=settings.ai_max_response_chars,
+        ),
+        post_success_actions=nutrition_prompt.post_success_actions,
     )
+
+
+async def answer_stream(
+    user: str,
+    msg: str,
+    *,
+    on_partial: Callable[[str], Awaitable[None]],
+    profile: BotProfile | None = None,
+    request_id: str | None = None,
+    queue_wait_seconds: float = 0.0,
+    compacted_user_memory: str | None = None,
+    recent_conversation_messages: list[ChatMessage] | None = None,
+    internal_user_id: int | None = None,
+) -> str:
+    """Generate an answer and emit partial text when the provider supports it."""
+    settings = get_settings()
+    active_profile = _resolve_profile(profile)
+    normalizer = _build_nutrition_normalizer(active_profile)
+    now = _current_datetime(settings.bot_timezone)
+    nutrition_prompt = await prepare_nutrition_prompt_async(
+        active_profile,
+        msg,
+        compacted_user_memory=compacted_user_memory,
+        recent_conversation_messages=recent_conversation_messages or [],
+        normalizer_client=normalizer[0] if normalizer is not None else None,
+        normalizer_model=normalizer[1] if normalizer is not None else None,
+        internal_user_id=internal_user_id,
+        current_date=now.date(),
+    )
+    if nutrition_prompt.direct_answer is not None:
+        direct = GeneratedAnswer(
+            nutrition_prompt.direct_answer,
+            post_success_actions=nutrition_prompt.post_success_actions,
+        )
+        await on_partial(str(direct))
+        return direct
+
+    messages = assemble_prompt_messages(
+        nutrition_prompt.prompt_profile,
+        current_user_message=msg,
+        user_display_name=user,
+        compacted_user_memory=(
+            compacted_user_memory if nutrition_prompt.include_memory else None
+        ),
+        recent_conversation_messages=(
+            recent_conversation_messages or []
+            if nutrition_prompt.include_memory
+            else []
+        ),
+        runtime_safety_instructions=nutrition_prompt.runtime_instructions,
+        now=now,
+    )
+    request_id_text = request_id or "unknown"
+    fallback_reason = _fallback_reason(
+        queue_wait_seconds=queue_wait_seconds,
+        threshold_seconds=settings.llm_fallback_queue_wait_seconds,
+    )
+    provider: OllamaProvider | NvidiaNimProvider | None = None
+
+    try:
+        provider = _select_provider(
+            profile_provider=active_profile.llm_provider,
+            queue_wait_seconds=queue_wait_seconds,
+        )
+        if not isinstance(provider, NvidiaNimProvider):
+            return await answer(
+                user,
+                msg,
+                profile=active_profile,
+                request_id=request_id,
+                queue_wait_seconds=queue_wait_seconds,
+                compacted_user_memory=compacted_user_memory,
+                recent_conversation_messages=recent_conversation_messages,
+                internal_user_id=internal_user_id,
+            )
+
+        started_at = time.monotonic()
+        raw_parts: list[str] = []
+        last_partial = ""
+        async for chunk in provider.stream_chat(
+            model=active_profile.llm_model,
+            messages=messages,
+        ):
+            raw_parts.append(chunk)
+            partial = _telegram_stream_partial(
+                "".join(raw_parts),
+                max_chars=settings.ai_max_response_chars,
+            )
+            if partial and partial != last_partial:
+                await on_partial(partial)
+                last_partial = partial
+        duration_seconds = time.monotonic() - started_at
+        logger.info(
+            "llm_provider_used request_id=%s provider=%s fallback_reason=%s "
+            "streaming=true duration_seconds=%.6f message_chars=%s",
+            request_id_text,
+            provider.name,
+            fallback_reason,
+            duration_seconds,
+            len(msg),
+        )
+    except AI_TIMEOUT_ERRORS:
+        logger.warning(
+            "llm_chat_timeout request_id=%s provider=%s model=%s "
+            "timeout_seconds=%s message_chars=%s streaming=true",
+            request_id_text,
+            _provider_name(provider),
+            _logged_model(active_profile.llm_model, _provider_name(provider)),
+            settings.ai_timeout_seconds,
+            len(msg),
+        )
+        return AI_TIMEOUT_FALLBACK
+    except ProviderConfigurationError:
+        logger.exception(
+            "llm_provider_configuration_failed request_id=%s provider_reason=%s "
+            "message_chars=%s streaming=true",
+            request_id_text,
+            fallback_reason,
+            len(msg),
+        )
+        return AI_ERROR_FALLBACK
+    except Exception:
+        provider_name = _provider_name(provider)
+        logger.exception(
+            "llm_chat_failed request_id=%s provider=%s model=%s message_chars=%s "
+            "streaming=true",
+            request_id_text,
+            provider_name,
+            _logged_model(active_profile.llm_model, provider_name),
+            len(msg),
+        )
+        partial_answer = _telegram_stream_partial(
+            "".join(raw_parts) if "raw_parts" in locals() else "",
+            max_chars=settings.ai_max_response_chars,
+        )
+        if partial_answer:
+            return GeneratedAnswer(
+                (
+                    f"{partial_answer}\n\n"
+                    "No he podido completar la respuesta, pero esto es lo que "
+                    "llevaba preparado."
+                ),
+                post_success_actions=nutrition_prompt.post_success_actions,
+            )
+        return AI_ERROR_FALLBACK
+
+    content = "".join(raw_parts)
+    provider_name = _provider_name(provider)
+    return GeneratedAnswer(
+        _trim_response(
+            content,
+            provider=provider_name,
+            model=_logged_model(active_profile.llm_model, provider_name),
+            max_chars=settings.ai_max_response_chars,
+        ),
+        post_success_actions=nutrition_prompt.post_success_actions,
+    )
+
+
+def finalize_successful_answer(answer: str) -> None:
+    """Run side effects that are only safe after the user received an answer."""
+    actions = getattr(answer, "post_success_actions", ())
+    for action in actions:
+        try:
+            if callable(action):
+                action()
+        except Exception:
+            logger.exception("post_success_answer_action_failed")
 
 
 async def summarize_memory(
@@ -356,184 +635,14 @@ def _resolve_profile(profile: BotProfile | None) -> BotProfile:
     return load_default_profile()
 
 
+def _current_datetime(timezone_name: str) -> datetime:
+    return datetime.now(ZoneInfo(timezone_name))
+
+
 def load_default_profile() -> BotProfile:
     """Load the configured bot profile for a runtime AI request."""
     settings = get_settings()
     return load_active_bot_profile(settings.bot_profile, settings.bot_profiles_dir)
-
-
-def _prepare_profile_prompt(
-    profile: BotProfile,
-    message: str,
-    recent_conversation_messages: Sequence[ChatMessage] | None = None,
-) -> tuple[BotProfile, list[str], str | None]:
-    if profile.bot_profile_id != "nutrition" or profile.nutrition_plan_path is None:
-        return profile, [], None
-
-    prompt_profile = replace(profile, context_documents=())
-    if not _looks_like_nutrition_routing_query(message):
-        return prompt_profile, [], None
-
-    try:
-        plan = load_nutrition_plan_file(profile.nutrition_plan_path)
-    except NutritionPlanError:
-        logger.exception(
-            "nutrition_plan_load_failed profile=%s",
-            profile.bot_profile_id,
-        )
-        return (
-            prompt_profile,
-            [],
-            "No puedo leer el plan nutricional configurado ahora mismo.",
-        )
-
-    resolution = _resolve_nutrition_context_with_follow_up(
-        plan,
-        message,
-        recent_conversation_messages or [],
-    )
-    if not resolution.is_resolved:
-        return prompt_profile, [], _nutrition_clarification(resolution)
-
-    context = _nutrition_context_payload(resolution)
-    return (
-        prompt_profile,
-        [
-            (
-                "Resolved nutrition plan context. Use only these resolved "
-                "chunk(s) as the "
-                "active nutrition plan context for the current answer. Do not "
-                "invent foods or quantities outside this JSON. Do not expose raw "
-                "JSON unless the user explicitly asks.\n\n"
-                "Formato obligatorio para Telegram:\n"
-                "- Maximo 5 lineas cortas.\n"
-                "- Sin introducciones tipo 'basandome en el plan'.\n"
-                "- No listes todas las opciones del bloque.\n"
-                "- Recomienda una opcion concreta con cantidades.\n"
-                "- Usa **negrita** solo para una etiqueta corta si ayuda.\n"
-                "- Si el usuario habla de compensar, no dupliques cantidades: "
-                "mantente en el bloque y da un ajuste prudente.\n"
-                f"{json.dumps(context, ensure_ascii=False)}"
-            )
-        ],
-        None,
-    )
-
-
-def _resolve_nutrition_context_with_follow_up(
-    plan: NutritionPlan,
-    message: str,
-    recent_conversation_messages: Sequence[ChatMessage],
-) -> MealResolution:
-    resolution = resolve_meal_context(plan, message)
-    if resolution.is_resolved or resolution.status not in {
-        "missing_situation",
-        "missing_moment",
-    }:
-        return resolution
-
-    recent_user_messages = [
-        item["content"].strip()
-        for item in recent_conversation_messages
-        if item["role"] == "user" and item["content"].strip()
-    ]
-    for previous_message in reversed(recent_user_messages[-4:]):
-        combined_resolution = resolve_meal_context(
-            plan,
-            f"{previous_message}\n{message}",
-        )
-        if combined_resolution.is_resolved:
-            return combined_resolution
-    return resolution
-
-
-def _looks_like_nutrition_routing_query(message: str) -> bool:
-    normalized = message.lower()
-    keywords = (
-        "que como",
-        "qué como",
-        "que comer",
-        "qué comer",
-        "que puedo comer",
-        "qué puedo comer",
-        "todo lo que puedo comer",
-        "todo el dia",
-        "todo el día",
-        "dia completo",
-        "día completo",
-        "plan del dia",
-        "plan del día",
-        "comidas del dia",
-        "comidas del día",
-        "desayuno",
-        "almuerzo",
-        "comida",
-        "mediodia",
-        "merienda",
-        "cena",
-        "ceno",
-        "crossfit",
-        "futbol",
-        "fútbol",
-        "bici",
-        "ciclismo",
-        "correr",
-        "running",
-        "descanso",
-        "no entreno",
-    )
-    return any(keyword in normalized for keyword in keywords)
-
-
-def _nutrition_clarification(resolution: MealResolution) -> str:
-    if resolution.status == "missing_situation":
-        options = _join_options(resolution.available_situations)
-        return f"Para ajustarlo al plan, dime que tipo de dia es: {options}."
-    if resolution.status == "missing_moment":
-        options = _join_options(resolution.available_moments)
-        return f"Te lo ajusto, pero dime el momento: {options}."
-    if resolution.status == "ambiguous_situation":
-        options = _join_options(match.label for match in resolution.situation_matches)
-        return f"Te he entendido varios contextos posibles: {options}. Cual usamos?"
-    if resolution.status == "ambiguous_moment":
-        options = _join_options(match.key for match in resolution.moment_matches)
-        return f"Te he entendido varios momentos posibles: {options}. Cual usamos?"
-    return "No tengo configurado que bloque usar para ese contexto del plan."
-
-
-def _join_options(options: Iterable[str]) -> str:
-    cleaned = [option for option in options if option]
-    if not cleaned:
-        return "desayuno, almuerzo, merienda o cena"
-    if len(cleaned) == 1:
-        return cleaned[0]
-    return ", ".join(cleaned[:-1]) + " o " + cleaned[-1]
-
-
-def _nutrition_context_payload(resolution: MealResolution) -> dict[str, Any]:
-    if resolution.status == "resolved_day":
-        return {
-            "mode": "full_day",
-            "situation_key": resolution.situation_key,
-            "supplementation": list(resolution.supplementation),
-            "meal_blocks": [
-                {
-                    "moment_key": day_meal.moment_key,
-                    "moment_label": day_meal.moment_label,
-                    "meal_block_key": day_meal.meal_block_key,
-                    "meal_block": day_meal.meal_block,
-                }
-                for day_meal in resolution.day_meal_blocks
-            ],
-        }
-    return {
-        "mode": "single_meal",
-        "situation_key": resolution.situation_key,
-        "moment_key": resolution.moment_key,
-        "meal_block_key": resolution.meal_block_key,
-        "supplementation": list(resolution.supplementation),
-        "meal_block": resolution.meal_block,
-    }
 
 
 def _memory_summary_prompt(
@@ -600,6 +709,20 @@ def _validated_https_base_url(base_url: str) -> str:
     )
 
 
+def _nvidia_model_for_request(request_model: str, default_model: str) -> str:
+    return request_model if request_model.startswith("nvidia/") else default_model
+
+
+def _nvidia_stream_delta(data: str) -> str:
+    try:
+        payload = json.loads(data)
+        delta = payload["choices"][0].get("delta", {})
+        return str(delta.get("content") or "")
+    except (json.JSONDecodeError, KeyError, IndexError, TypeError):
+        logger.debug("nvidia_stream_chunk_ignored")
+        return ""
+
+
 def _select_provider(
     *,
     profile_provider: str,
@@ -652,6 +775,38 @@ def _build_provider(name: str) -> OllamaProvider | NvidiaNimProvider:
             timeout_seconds=settings.ai_timeout_seconds,
         )
     raise ProviderConfigurationError(f"Unsupported LLM provider: {name}.")
+
+
+def _build_nutrition_normalizer(
+    profile: BotProfile,
+) -> tuple[OllamaProvider | NvidiaNimProvider, str] | None:
+    if profile.bot_profile_id != "nutrition":
+        return None
+
+    settings = get_settings()
+    provider_name = settings.nutrition_normalizer_provider.lower()
+    if provider_name in FALLBACK_DISABLED_VALUES:
+        return None
+    if provider_name in PROFILE_PRIMARY_PROVIDER_VALUES:
+        provider_name = profile.llm_provider
+
+    try:
+        provider = _build_provider(provider_name)
+    except ProviderConfigurationError:
+        logger.warning(
+            "nutrition_normalizer_unavailable provider=%s",
+            provider_name,
+            exc_info=True,
+        )
+        return None
+    return provider, settings.nutrition_normalizer_model
+
+
+def build_nutrition_normalizer(
+    profile: BotProfile,
+) -> tuple[OllamaProvider | NvidiaNimProvider, str] | None:
+    """Return the configured model client for nutrition normalization tasks."""
+    return _build_nutrition_normalizer(profile)
 
 
 async def _answer_with_fallback(
@@ -778,6 +933,13 @@ def _telegram_plain_text(content: str) -> str:
     text = re.sub(r"[ \t]+\n", "\n", text)
     text = re.sub(r"\n{3,}", "\n\n", text)
     return text.strip()
+
+
+def _telegram_stream_partial(content: str, *, max_chars: int) -> str:
+    cleaned = _telegram_plain_text(content)
+    if len(cleaned) <= max_chars:
+        return cleaned
+    return cleaned[:max_chars].rstrip()
 
 
 def _logged_model(profile_model: str, provider: str) -> str:

--- a/src/forge_bot/engine.py
+++ b/src/forge_bot/engine.py
@@ -1,11 +1,14 @@
 import asyncio
+import html
 import json
 import logging
+import re
 import ssl
 import time
 import urllib.error
 import urllib.request
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
+from dataclasses import replace
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
@@ -14,6 +17,8 @@ import ollama
 
 from .bot_profile import BotProfile, load_active_bot_profile
 from .config import get_settings
+from .nutrition.plan import NutritionPlan, NutritionPlanError, load_nutrition_plan_file
+from .nutrition.router import MealResolution, resolve_meal_context
 from .prompting import ChatMessage, assemble_prompt_messages
 
 logger = logging.getLogger(__name__)
@@ -155,13 +160,26 @@ async def answer(
     """
     settings = get_settings()
     active_profile = _resolve_profile(profile)
-    messages = assemble_prompt_messages(
+    prompt_profile, runtime_instructions, direct_answer = _prepare_profile_prompt(
         active_profile,
+        msg,
+        recent_conversation_messages or [],
+    )
+    if direct_answer is not None:
+        return direct_answer
+    include_memory = not (
+        active_profile.bot_profile_id == "nutrition" and runtime_instructions
+    )
+
+    messages = assemble_prompt_messages(
+        prompt_profile,
         current_user_message=msg,
         user_display_name=user,
-        compacted_user_memory=compacted_user_memory,
-        recent_conversation_messages=recent_conversation_messages or [],
-        runtime_safety_instructions=[],
+        compacted_user_memory=compacted_user_memory if include_memory else None,
+        recent_conversation_messages=(
+            recent_conversation_messages or [] if include_memory else []
+        ),
+        runtime_safety_instructions=runtime_instructions,
     )
     request_id_text = request_id or "unknown"
     fallback_reason = _fallback_reason(
@@ -342,6 +360,180 @@ def load_default_profile() -> BotProfile:
     """Load the configured bot profile for a runtime AI request."""
     settings = get_settings()
     return load_active_bot_profile(settings.bot_profile, settings.bot_profiles_dir)
+
+
+def _prepare_profile_prompt(
+    profile: BotProfile,
+    message: str,
+    recent_conversation_messages: Sequence[ChatMessage] | None = None,
+) -> tuple[BotProfile, list[str], str | None]:
+    if profile.bot_profile_id != "nutrition" or profile.nutrition_plan_path is None:
+        return profile, [], None
+
+    prompt_profile = replace(profile, context_documents=())
+    if not _looks_like_nutrition_routing_query(message):
+        return prompt_profile, [], None
+
+    try:
+        plan = load_nutrition_plan_file(profile.nutrition_plan_path)
+    except NutritionPlanError:
+        logger.exception(
+            "nutrition_plan_load_failed profile=%s",
+            profile.bot_profile_id,
+        )
+        return (
+            prompt_profile,
+            [],
+            "No puedo leer el plan nutricional configurado ahora mismo.",
+        )
+
+    resolution = _resolve_nutrition_context_with_follow_up(
+        plan,
+        message,
+        recent_conversation_messages or [],
+    )
+    if not resolution.is_resolved:
+        return prompt_profile, [], _nutrition_clarification(resolution)
+
+    context = _nutrition_context_payload(resolution)
+    return (
+        prompt_profile,
+        [
+            (
+                "Resolved nutrition plan context. Use only these resolved "
+                "chunk(s) as the "
+                "active nutrition plan context for the current answer. Do not "
+                "invent foods or quantities outside this JSON. Do not expose raw "
+                "JSON unless the user explicitly asks.\n\n"
+                "Formato obligatorio para Telegram:\n"
+                "- Maximo 5 lineas cortas.\n"
+                "- Sin introducciones tipo 'basandome en el plan'.\n"
+                "- No listes todas las opciones del bloque.\n"
+                "- Recomienda una opcion concreta con cantidades.\n"
+                "- Usa **negrita** solo para una etiqueta corta si ayuda.\n"
+                "- Si el usuario habla de compensar, no dupliques cantidades: "
+                "mantente en el bloque y da un ajuste prudente.\n"
+                f"{json.dumps(context, ensure_ascii=False)}"
+            )
+        ],
+        None,
+    )
+
+
+def _resolve_nutrition_context_with_follow_up(
+    plan: NutritionPlan,
+    message: str,
+    recent_conversation_messages: Sequence[ChatMessage],
+) -> MealResolution:
+    resolution = resolve_meal_context(plan, message)
+    if resolution.is_resolved or resolution.status not in {
+        "missing_situation",
+        "missing_moment",
+    }:
+        return resolution
+
+    recent_user_messages = [
+        item["content"].strip()
+        for item in recent_conversation_messages
+        if item["role"] == "user" and item["content"].strip()
+    ]
+    for previous_message in reversed(recent_user_messages[-4:]):
+        combined_resolution = resolve_meal_context(
+            plan,
+            f"{previous_message}\n{message}",
+        )
+        if combined_resolution.is_resolved:
+            return combined_resolution
+    return resolution
+
+
+def _looks_like_nutrition_routing_query(message: str) -> bool:
+    normalized = message.lower()
+    keywords = (
+        "que como",
+        "qué como",
+        "que comer",
+        "qué comer",
+        "que puedo comer",
+        "qué puedo comer",
+        "todo lo que puedo comer",
+        "todo el dia",
+        "todo el día",
+        "dia completo",
+        "día completo",
+        "plan del dia",
+        "plan del día",
+        "comidas del dia",
+        "comidas del día",
+        "desayuno",
+        "almuerzo",
+        "comida",
+        "mediodia",
+        "merienda",
+        "cena",
+        "ceno",
+        "crossfit",
+        "futbol",
+        "fútbol",
+        "bici",
+        "ciclismo",
+        "correr",
+        "running",
+        "descanso",
+        "no entreno",
+    )
+    return any(keyword in normalized for keyword in keywords)
+
+
+def _nutrition_clarification(resolution: MealResolution) -> str:
+    if resolution.status == "missing_situation":
+        options = _join_options(resolution.available_situations)
+        return f"Para ajustarlo al plan, dime que tipo de dia es: {options}."
+    if resolution.status == "missing_moment":
+        options = _join_options(resolution.available_moments)
+        return f"Te lo ajusto, pero dime el momento: {options}."
+    if resolution.status == "ambiguous_situation":
+        options = _join_options(match.label for match in resolution.situation_matches)
+        return f"Te he entendido varios contextos posibles: {options}. Cual usamos?"
+    if resolution.status == "ambiguous_moment":
+        options = _join_options(match.key for match in resolution.moment_matches)
+        return f"Te he entendido varios momentos posibles: {options}. Cual usamos?"
+    return "No tengo configurado que bloque usar para ese contexto del plan."
+
+
+def _join_options(options: Iterable[str]) -> str:
+    cleaned = [option for option in options if option]
+    if not cleaned:
+        return "desayuno, almuerzo, merienda o cena"
+    if len(cleaned) == 1:
+        return cleaned[0]
+    return ", ".join(cleaned[:-1]) + " o " + cleaned[-1]
+
+
+def _nutrition_context_payload(resolution: MealResolution) -> dict[str, Any]:
+    if resolution.status == "resolved_day":
+        return {
+            "mode": "full_day",
+            "situation_key": resolution.situation_key,
+            "supplementation": list(resolution.supplementation),
+            "meal_blocks": [
+                {
+                    "moment_key": day_meal.moment_key,
+                    "moment_label": day_meal.moment_label,
+                    "meal_block_key": day_meal.meal_block_key,
+                    "meal_block": day_meal.meal_block,
+                }
+                for day_meal in resolution.day_meal_blocks
+            ],
+        }
+    return {
+        "mode": "single_meal",
+        "situation_key": resolution.situation_key,
+        "moment_key": resolution.moment_key,
+        "meal_block_key": resolution.meal_block_key,
+        "supplementation": list(resolution.supplementation),
+        "meal_block": resolution.meal_block,
+    }
 
 
 def _memory_summary_prompt(
@@ -557,17 +749,35 @@ def _trim_response(
     model: str,
     max_chars: int,
 ) -> str:
-    if len(content) <= max_chars:
-        return content
+    cleaned = _telegram_plain_text(content)
+    if len(cleaned) <= max_chars:
+        return cleaned
 
     logger.info(
         "llm_response_truncated provider=%s model=%s original_chars=%s max_chars=%s",
         provider,
         model,
-        len(content),
+        len(cleaned),
         max_chars,
     )
-    return content[:max_chars].rstrip()
+    return cleaned[:max_chars].rstrip()
+
+
+def _telegram_plain_text(content: str) -> str:
+    """Normalize LLM output for Telegram HTML parse mode."""
+    text = html.escape(content.strip())
+    text = re.sub(r"```(?:\w+)?\n?", "", text)
+    text = text.replace("```", "")
+    text = re.sub(r"(?m)^\s{0,3}#{1,6}\s*", "", text)
+    text = re.sub(r"(?m)^\s*[\*\+]\s+", "- ", text)
+    text = re.sub(r"\*\*([^*\n]+)\*\*", r"<b>\1</b>", text)
+    text = re.sub(r"__([^_\n]+)__", r"<b>\1</b>", text)
+    text = re.sub(r"`([^`\n]+)`", r"\1", text)
+    text = text.replace("*", "")
+    text = re.sub(r"(?m)^\s*-{3,}\s*$", "", text)
+    text = re.sub(r"[ \t]+\n", "\n", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
 
 
 def _logged_model(profile_model: str, provider: str) -> str:

--- a/src/forge_bot/engine.py
+++ b/src/forge_bot/engine.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import ssl
 import time
 import urllib.error
 import urllib.request
@@ -8,6 +9,7 @@ from collections.abc import Sequence
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
+import certifi
 import ollama
 
 from .bot_profile import BotProfile, load_active_bot_profile
@@ -23,6 +25,7 @@ AI_ERROR_FALLBACK = (
     "The AI service is temporarily unavailable. Please try again in a moment."
 )
 FALLBACK_DISABLED_VALUES = {"", "none", "disabled", "off"}
+PROFILE_PRIMARY_PROVIDER_VALUES = {"", "profile"}
 NVIDIA_ALLOWED_URL_SCHEMES = {"https"}
 AI_TIMEOUT_ERRORS = (TimeoutError, asyncio.TimeoutError)
 
@@ -76,6 +79,7 @@ class NvidiaNimProvider:
         self._base_url = _validated_https_base_url(base_url)
         self._model = model
         self._timeout_seconds = timeout_seconds
+        self._ssl_context = ssl.create_default_context(cafile=certifi.where())
 
     async def chat(self, *, model: str, messages: list[ChatMessage]) -> str:
         del model
@@ -107,6 +111,7 @@ class NvidiaNimProvider:
             with urllib.request.urlopen(  # nosec B310
                 request,
                 timeout=self._timeout_seconds,
+                context=self._ssl_context,
             ) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as exc:
@@ -409,7 +414,12 @@ def _select_provider(
     queue_wait_seconds: float,
 ) -> OllamaProvider | NvidiaNimProvider:
     settings = get_settings()
-    primary_provider = settings.llm_primary_provider or profile_provider
+    configured_primary_provider = settings.llm_primary_provider.lower()
+    primary_provider = (
+        profile_provider
+        if configured_primary_provider in PROFILE_PRIMARY_PROVIDER_VALUES
+        else configured_primary_provider
+    )
     fallback_provider = _fallback_provider_name()
     if (
         fallback_provider

--- a/src/forge_bot/main.py
+++ b/src/forge_bot/main.py
@@ -12,8 +12,10 @@ from telegram.ext import (
 )
 
 from .bot_profile import BotProfileError, load_active_bot_profile
+from .commands.admin_memory import admin_memory, admin_users
 from .commands.auth import start, status
 from .commands.campaign_invite import campaign_invite
+from .commands.get_plan import get_plan
 from .commands.greet import greet
 from .commands.help import help_command
 from .commands.invite import invite
@@ -28,6 +30,7 @@ from .commands.policy import (
     policy,
 )
 from .commands.privacy import delete_my_data, memory_clear, privacy
+from .commands.set_plan import set_plan
 from .commands.time import time
 from .commands.translate import translate
 from .commands.unknown import unknown_command
@@ -59,6 +62,10 @@ COMMAND_HANDLERS = (
     ("privacy", privacy),
     ("memory_clear", memory_clear),
     ("delete_my_data", delete_my_data),
+    ("admin_users", admin_users),
+    ("admin_memory", admin_memory),
+    ("set_plan", set_plan),
+    ("get_plan", get_plan),
     ("invite", invite),
     ("campaign_invite", campaign_invite),
 )
@@ -217,6 +224,13 @@ def main() -> None:
 
     for command, handler in COMMAND_HANDLERS:
         bot.add_handler(CommandHandler(command, handler))
+
+    bot.add_handler(
+        MessageHandler(
+            filters.Document.ALL,
+            set_plan,
+        )
+    )
 
     bot.add_handler(
         CallbackQueryHandler(

--- a/src/forge_bot/memory_backend.py
+++ b/src/forge_bot/memory_backend.py
@@ -16,6 +16,7 @@ from langchain_core.messages import (
     messages_from_dict,
 )
 from langchain_postgres import PostgresChatMessageHistory
+from psycopg import sql
 
 from .bot_profile import SUPPORTED_MEMORY_BACKENDS, BotProfile, BotProfileError
 from .config import get_settings
@@ -355,14 +356,17 @@ class LangChainPostgresMemoryBackend(PostgresMemoryBackend):
         try:
             with conn.cursor() as cursor:
                 cursor.execute(
-                    f"""
+                    sql.SQL("""
                     SELECT message
-                    FROM {LANGCHAIN_CHAT_HISTORY_TABLE}
+                    FROM {}
                     WHERE session_id = %s
-                    ORDER BY id {order}
+                    ORDER BY id {}
                     LIMIT %s
                     OFFSET %s
-                    """,
+                    """).format(
+                        sql.Identifier(LANGCHAIN_CHAT_HISTORY_TABLE),
+                        sql.SQL(order),
+                    ),
                     (session_id, limit, offset),
                 )
                 rows = cursor.fetchall()
@@ -429,8 +433,8 @@ class LangChainPostgresMemoryBackend(PostgresMemoryBackend):
         try:
             with conn.cursor() as cursor:
                 cursor.execute(
-                    f"""
-                    INSERT INTO {LANGCHAIN_CHAT_SESSIONS_TABLE} (
+                    sql.SQL("""
+                    INSERT INTO {} (
                         user_id,
                         bot_profile_id,
                         session_id
@@ -440,7 +444,7 @@ class LangChainPostgresMemoryBackend(PostgresMemoryBackend):
                     DO UPDATE SET
                         session_id = EXCLUDED.session_id,
                         updated_at = CURRENT_TIMESTAMP
-                    """,
+                    """).format(sql.Identifier(LANGCHAIN_CHAT_SESSIONS_TABLE)),
                     (
                         user_id,
                         bot_profile_id,

--- a/src/forge_bot/memory_backend.py
+++ b/src/forge_bot/memory_backend.py
@@ -1,0 +1,612 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from threading import RLock
+from typing import Any, Protocol
+
+import psycopg
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    messages_from_dict,
+)
+from langchain_postgres import PostgresChatMessageHistory
+
+from .bot_profile import SUPPORTED_MEMORY_BACKENDS, BotProfile, BotProfileError
+from .config import get_settings
+from .database import conect_db
+from .memory_store import (
+    ConversationMemoryStore,
+    MemoryContext,
+    MemorySummarizer,
+    memory_store,
+)
+from .prompting import ChatMessage
+
+logger = logging.getLogger(__name__)
+
+LANGCHAIN_CHAT_HISTORY_TABLE = "langchain_chat_history"
+LANGCHAIN_CHAT_SESSIONS_TABLE = "langchain_chat_sessions"
+LANGCHAIN_COMPACTION_VERSION = "langchain-postgres-chat-history-v1"
+LANGCHAIN_SESSION_NAMESPACE = uuid.UUID("6a049dbd-6906-4e05-a803-a2d19953e3cc")
+
+
+class MemoryBackend(Protocol):
+    """Prompt-facing memory interface used by Telegram routing."""
+
+    def get_context(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+        exclude_inbound_message_id: int | None = None,
+    ) -> MemoryContext:
+        """Return memory context for the current turn."""
+
+    def store_successful_turn(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+        user_message: str,
+        assistant_message: str,
+        telegram_chat_id: int | None = None,
+        telegram_message_id: int | None = None,
+        inbound_message_id: int | None = None,
+        request_id: str | None = None,
+    ) -> bool:
+        """Persist one successful user/assistant turn."""
+
+    async def compact_memory_if_needed(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+        summarizer: MemorySummarizer,
+    ) -> None:
+        """Compact old memory when the backend supports compaction."""
+
+
+class PostgresMemoryBackend:
+    """Existing BotForge PostgreSQL memory backend."""
+
+    def __init__(self, store: ConversationMemoryStore = memory_store) -> None:
+        self._store = store
+
+    def get_context(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+        exclude_inbound_message_id: int | None = None,
+    ) -> MemoryContext:
+        return self._store.get_context(
+            user_id=user_id,
+            bot_profile_id=bot_profile_id,
+            exclude_inbound_message_id=exclude_inbound_message_id,
+        )
+
+    def store_successful_turn(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+        user_message: str,
+        assistant_message: str,
+        telegram_chat_id: int | None = None,
+        telegram_message_id: int | None = None,
+        inbound_message_id: int | None = None,
+        request_id: str | None = None,
+    ) -> bool:
+        return self._store.store_successful_turn(
+            user_id=user_id,
+            bot_profile_id=bot_profile_id,
+            user_message=user_message,
+            assistant_message=assistant_message,
+            telegram_chat_id=telegram_chat_id,
+            telegram_message_id=telegram_message_id,
+            inbound_message_id=inbound_message_id,
+            request_id=request_id,
+        )
+
+    async def compact_memory_if_needed(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+        summarizer: MemorySummarizer,
+    ) -> None:
+        await self._store.compact_memory_if_needed(
+            user_id=user_id,
+            bot_profile_id=bot_profile_id,
+            summarizer=summarizer,
+        )
+
+
+class LangChainPostgresMemoryBackend(PostgresMemoryBackend):
+    """Memory backend using LangChain's maintained PostgreSQL chat history."""
+
+    _compaction_locks: dict[tuple[int, str], asyncio.Lock] = {}
+    _lock = RLock()
+
+    def get_context(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+        exclude_inbound_message_id: int | None = None,
+    ) -> MemoryContext:
+        del exclude_inbound_message_id
+
+        if not self._ensure_session_mapping(
+            user_id=user_id,
+            bot_profile_id=bot_profile_id,
+        ):
+            return MemoryContext(
+                compacted_user_memory=None,
+                recent_conversation_messages=[],
+            )
+
+        summary, _source_message_count = self._read_summary_state(
+            user_id=user_id,
+            bot_profile_id=bot_profile_id,
+        )
+        settings = get_settings()
+        messages = self._get_recent_langchain_messages(
+            user_id=user_id,
+            bot_profile_id=bot_profile_id,
+            limit=settings.memory_recent_messages,
+        )
+        return MemoryContext(
+            compacted_user_memory=summary,
+            recent_conversation_messages=[
+                _from_langchain_message(message) for message in messages
+            ],
+        )
+
+    def store_successful_turn(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+        user_message: str,
+        assistant_message: str,
+        telegram_chat_id: int | None = None,
+        telegram_message_id: int | None = None,
+        inbound_message_id: int | None = None,
+        request_id: str | None = None,
+    ) -> bool:
+        del telegram_chat_id, telegram_message_id, inbound_message_id, request_id
+
+        if not self._ensure_session_mapping(
+            user_id=user_id,
+            bot_profile_id=bot_profile_id,
+        ):
+            return False
+
+        settings = get_settings()
+        try:
+            self._add_langchain_messages(
+                user_id=user_id,
+                bot_profile_id=bot_profile_id,
+                messages=[
+                    HumanMessage(
+                        content=_truncate(
+                            user_message,
+                            settings.memory_max_message_chars,
+                        )
+                    ),
+                    AIMessage(
+                        content=_truncate(
+                            assistant_message,
+                            settings.memory_max_message_chars,
+                        )
+                    ),
+                ],
+            )
+            return True
+        except Exception:
+            logger.exception(
+                "langchain_memory_turn_insert_failed user_id=%s bot_profile_id=%s",
+                user_id,
+                bot_profile_id,
+            )
+            return False
+
+    async def compact_memory_if_needed(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+        summarizer: MemorySummarizer,
+    ) -> None:
+        compaction_lock = self._get_compaction_lock(
+            user_id=user_id,
+            bot_profile_id=bot_profile_id,
+        )
+        async with compaction_lock:
+            existing_summary, source_message_count = self._read_summary_state(
+                user_id=user_id,
+                bot_profile_id=bot_profile_id,
+            )
+            settings = get_settings()
+            unsummarized = [
+                _from_langchain_message(message)
+                for message in self._get_unsummarized_langchain_messages(
+                    user_id=user_id,
+                    bot_profile_id=bot_profile_id,
+                    source_message_count=source_message_count,
+                    limit=settings.memory_compaction_trigger_messages,
+                )
+            ]
+            if len(unsummarized) < settings.memory_compaction_trigger_messages:
+                return
+
+            source = unsummarized[: settings.memory_compaction_source_messages]
+            summary = await summarizer(
+                existing_summary,
+                source,
+                settings.memory_compacted_max_chars,
+            )
+            if not summary or not summary.strip():
+                return
+
+            clean_summary = _truncate(
+                summary.strip(),
+                settings.memory_compacted_max_chars,
+            )
+            self._save_summary_state(
+                user_id=user_id,
+                bot_profile_id=bot_profile_id,
+                summary=clean_summary,
+                source_message_count=source_message_count + len(source),
+            )
+
+    @classmethod
+    def _get_compaction_lock(
+        cls,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+    ) -> asyncio.Lock:
+        key = (user_id, bot_profile_id)
+        with cls._lock:
+            lock = cls._compaction_locks.get(key)
+            if lock is None:
+                lock = asyncio.Lock()
+                cls._compaction_locks[key] = lock
+            return lock
+
+    def _get_langchain_messages(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+    ) -> list[BaseMessage]:
+        try:
+            with self._history_for(
+                user_id=user_id,
+                bot_profile_id=bot_profile_id,
+            ) as history:
+                if history is None:
+                    return []
+                return list(history.messages)
+        except Exception:
+            logger.exception(
+                "langchain_memory_context_load_failed user_id=%s bot_profile_id=%s",
+                user_id,
+                bot_profile_id,
+            )
+            return []
+
+    def _get_recent_langchain_messages(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+        limit: int,
+    ) -> list[BaseMessage]:
+        if limit <= 0:
+            return []
+        rows = self._fetch_langchain_message_payloads(
+            session_id=_session_id(user_id=user_id, bot_profile_id=bot_profile_id),
+            order_desc=True,
+            limit=limit,
+        )
+        rows.reverse()
+        return _messages_from_payloads(rows)
+
+    def _get_unsummarized_langchain_messages(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+        source_message_count: int,
+        limit: int,
+    ) -> list[BaseMessage]:
+        if limit <= 0:
+            return []
+        rows = self._fetch_langchain_message_payloads(
+            session_id=_session_id(user_id=user_id, bot_profile_id=bot_profile_id),
+            order_desc=False,
+            limit=limit,
+            offset=max(source_message_count, 0),
+        )
+        return _messages_from_payloads(rows)
+
+    def _fetch_langchain_message_payloads(
+        self,
+        *,
+        session_id: str,
+        order_desc: bool,
+        limit: int,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        conn = conect_db()
+        if not conn:
+            return []
+
+        order = "DESC" if order_desc else "ASC"
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    SELECT message
+                    FROM {LANGCHAIN_CHAT_HISTORY_TABLE}
+                    WHERE session_id = %s
+                    ORDER BY id {order}
+                    LIMIT %s
+                    OFFSET %s
+                    """,
+                    (session_id, limit, offset),
+                )
+                rows = cursor.fetchall()
+        except psycopg.Error:
+            logger.exception(
+                "langchain_memory_window_load_failed session_id=%s", session_id
+            )
+            return []
+        finally:
+            conn.close()
+
+        payloads: list[dict[str, Any]] = []
+        for row in rows:
+            message = row.get("message")
+            if isinstance(message, dict):
+                payloads.append(message)
+        return payloads
+
+    def _add_langchain_messages(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+        messages: Sequence[BaseMessage],
+    ) -> None:
+        with self._history_for(
+            user_id=user_id,
+            bot_profile_id=bot_profile_id,
+        ) as history:
+            if history is None:
+                raise RuntimeError("LangChain PostgreSQL history is unavailable.")
+            history.add_messages(messages)
+
+    @contextmanager
+    def _history_for(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+    ) -> Iterator[PostgresChatMessageHistory | None]:
+        conn = _connect_langchain_history_db()
+        if conn is None:
+            yield None
+            return
+        try:
+            yield PostgresChatMessageHistory(
+                LANGCHAIN_CHAT_HISTORY_TABLE,
+                _session_id(user_id=user_id, bot_profile_id=bot_profile_id),
+                sync_connection=conn,
+            )
+        finally:
+            conn.close()
+
+    def _ensure_session_mapping(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+    ) -> bool:
+        conn = conect_db()
+        if not conn:
+            return False
+
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    INSERT INTO {LANGCHAIN_CHAT_SESSIONS_TABLE} (
+                        user_id,
+                        bot_profile_id,
+                        session_id
+                    )
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT (user_id, bot_profile_id)
+                    DO UPDATE SET
+                        session_id = EXCLUDED.session_id,
+                        updated_at = CURRENT_TIMESTAMP
+                    """,
+                    (
+                        user_id,
+                        bot_profile_id,
+                        _session_id(user_id=user_id, bot_profile_id=bot_profile_id),
+                    ),
+                )
+                conn.commit()
+            return True
+        except psycopg.Error:
+            conn.rollback()
+            logger.exception(
+                "langchain_memory_session_mapping_failed user_id=%s bot_profile_id=%s",
+                user_id,
+                bot_profile_id,
+            )
+            return False
+        finally:
+            conn.close()
+
+    def _read_summary_state(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+    ) -> tuple[str | None, int]:
+        conn = conect_db()
+        if not conn:
+            return None, 0
+
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT summary, source_message_count
+                    FROM user_memory_summaries
+                    WHERE user_id = %s
+                      AND bot_profile_id = %s
+                      AND deleted_at IS NULL
+                    """,
+                    (user_id, bot_profile_id),
+                )
+                row = cursor.fetchone()
+        except psycopg.Error:
+            logger.exception(
+                "langchain_memory_summary_load_failed user_id=%s bot_profile_id=%s",
+                user_id,
+                bot_profile_id,
+            )
+            return None, 0
+        finally:
+            conn.close()
+
+        if not row:
+            return None, 0
+        return str(row["summary"]), int(row["source_message_count"] or 0)
+
+    def _save_summary_state(
+        self,
+        *,
+        user_id: int,
+        bot_profile_id: str,
+        summary: str,
+        source_message_count: int,
+    ) -> None:
+        conn = conect_db()
+        if not conn:
+            return
+
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    INSERT INTO user_memory_summaries (
+                        user_id,
+                        bot_profile_id,
+                        summary,
+                        source_message_count,
+                        compaction_version
+                    )
+                    VALUES (%s, %s, %s, %s, %s)
+                    ON CONFLICT (user_id, bot_profile_id)
+                    DO UPDATE SET
+                        summary = EXCLUDED.summary,
+                        source_message_count = EXCLUDED.source_message_count,
+                        compaction_version = EXCLUDED.compaction_version,
+                        updated_at = CURRENT_TIMESTAMP,
+                        deleted_at = NULL
+                    """,
+                    (
+                        user_id,
+                        bot_profile_id,
+                        summary,
+                        source_message_count,
+                        LANGCHAIN_COMPACTION_VERSION,
+                    ),
+                )
+                conn.commit()
+        except psycopg.Error:
+            conn.rollback()
+            logger.exception(
+                "langchain_memory_summary_save_failed user_id=%s bot_profile_id=%s",
+                user_id,
+                bot_profile_id,
+            )
+        finally:
+            conn.close()
+
+
+def memory_backend_for_profile(profile: BotProfile) -> MemoryBackend:
+    """Return the configured memory backend for one bot profile."""
+    backend_name = profile.memory_backend.strip().lower()
+    if backend_name == "postgres":
+        return PostgresMemoryBackend()
+    if backend_name == "langchain_postgres":
+        return LangChainPostgresMemoryBackend()
+
+    options = ", ".join(sorted(SUPPORTED_MEMORY_BACKENDS))
+    raise BotProfileError(
+        f"Unsupported memory backend '{profile.memory_backend}' for profile "
+        f"'{profile.bot_profile_id}'. Expected one of: {options}."
+    )
+
+
+def _from_langchain_message(message: BaseMessage) -> ChatMessage:
+    role = "assistant" if isinstance(message, AIMessage) else "user"
+    content = message.content
+    if isinstance(content, str):
+        text = content
+    else:
+        text = "\n".join(str(item) for item in content)
+    return {"role": role, "content": text}
+
+
+def _messages_from_payloads(payloads: Sequence[dict[str, Any]]) -> list[BaseMessage]:
+    try:
+        return list(messages_from_dict(list(payloads)))
+    except Exception:
+        logger.exception("langchain_memory_message_decode_failed")
+        return []
+
+
+def _session_id(*, user_id: int, bot_profile_id: str) -> str:
+    return str(
+        uuid.uuid5(
+            LANGCHAIN_SESSION_NAMESPACE,
+            f"{user_id}:{bot_profile_id}",
+        )
+    )
+
+
+def _connect_langchain_history_db() -> psycopg.Connection[tuple[Any, ...]] | None:
+    settings = get_settings()
+    try:
+        return psycopg.connect(
+            host=settings.db_host,
+            user=settings.db_user,
+            password=settings.db_password,
+            dbname=settings.db_name,
+            port=settings.db_port,
+        )
+    except psycopg.Error:
+        logger.exception("langchain_memory_database_connection_failed")
+        return None
+
+
+def _truncate(content: str, max_chars: int) -> str:
+    if len(content) <= max_chars:
+        return content
+    return content[:max_chars].rstrip()

--- a/src/forge_bot/nutrition/__init__.py
+++ b/src/forge_bot/nutrition/__init__.py
@@ -1,0 +1,1 @@
+"""Nutrition-specific plan routing helpers."""

--- a/src/forge_bot/nutrition/daily_state.py
+++ b/src/forge_bot/nutrition/daily_state.py
@@ -53,10 +53,7 @@ class DailyNutritionUpdate:
     @property
     def has_changes(self) -> bool:
         return bool(
-            self.situation_key
-            or self.logged_meals
-            or self.skipped_moments
-            or self.note
+            self.situation_key or self.logged_meals or self.skipped_moments or self.note
         )
 
 

--- a/src/forge_bot/nutrition/daily_state.py
+++ b/src/forge_bot/nutrition/daily_state.py
@@ -1,0 +1,583 @@
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from psycopg.types.json import Jsonb
+
+from ..database import conect_db
+from .intent import NutritionMessageUnderstanding
+from .normalizer import NormalizedNutritionMessage
+from .plan import NutritionPlan
+from .router import detect_moments, detect_situations, normalize_text
+
+logger = logging.getLogger(__name__)
+
+NO_TRAINING_SITUATION_CANDIDATES = ("no_entreno", "descanso", "rest_day")
+ACTIVITY_CHANGE_PHRASES = (
+    "en lugar de",
+    "en vez de",
+    "cambio",
+    "cambiar",
+    "cambiamos",
+    "cambiado",
+    "he cambiado",
+    "hemos cambiado",
+    "al final hago",
+    "al final hacemos",
+    "al final voy a",
+    "al final toca",
+    "sustituyo",
+    "sustituimos",
+)
+
+
+@dataclass(frozen=True)
+class LoggedMealUpdate:
+    moment_key: str
+    text: str
+
+
+@dataclass(frozen=True)
+class DailyNutritionUpdate:
+    situation_key: str | None = None
+    logged_meals: tuple[LoggedMealUpdate, ...] = ()
+    skipped_moments: tuple[str, ...] = ()
+    note: str | None = None
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(
+            self.situation_key
+            or self.logged_meals
+            or self.skipped_moments
+            or self.note
+        )
+
+
+@dataclass(frozen=True)
+class NutritionDailyLog:
+    id: int
+    user_id: int
+    bot_profile_id: str
+    log_date: date
+    plan_id: str | None
+    situation_key: str | None
+    meals: Mapping[str, Any]
+    notes: tuple[Mapping[str, Any], ...]
+    situation_updated_at: datetime | None = None
+
+
+def today_local(timezone_name: str | None = None) -> date:
+    """Return today's date in the configured application timezone."""
+    if timezone_name:
+        return datetime.now(ZoneInfo(timezone_name)).date()
+    return datetime.now().astimezone().date()
+
+
+def load_daily_log(
+    *,
+    user_id: int,
+    bot_profile_id: str,
+    log_date: date,
+) -> NutritionDailyLog | None:
+    """Load the nutrition day state for one user/profile/date."""
+    connection = conect_db()
+    if connection is None:
+        return None
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT id, user_id, bot_profile_id, log_date, plan_id,
+                       situation_key, situation_updated_at, meals, notes
+                FROM nutrition_daily_logs
+                WHERE user_id = %s
+                  AND bot_profile_id = %s
+                  AND log_date = %s
+                """,
+                (user_id, bot_profile_id, log_date),
+            )
+            row = cursor.fetchone()
+            return _row_to_daily_log(row) if row else None
+    finally:
+        connection.close()
+
+
+def apply_daily_update(
+    *,
+    user_id: int,
+    bot_profile_id: str,
+    log_date: date,
+    plan: NutritionPlan,
+    update: DailyNutritionUpdate,
+    now: datetime | None = None,
+) -> NutritionDailyLog | None:
+    """Apply an idempotent-ish update to today's nutrition state."""
+    if not update.has_changes:
+        return load_daily_log(
+            user_id=user_id,
+            bot_profile_id=bot_profile_id,
+            log_date=log_date,
+        )
+
+    timestamp = now or datetime.now().astimezone()
+    connection = conect_db()
+    if connection is None:
+        return None
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO nutrition_daily_logs (
+                    user_id, bot_profile_id, log_date, plan_id,
+                    situation_key, situation_updated_at
+                )
+                VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (user_id, bot_profile_id, log_date) DO NOTHING
+                """,
+                (
+                    user_id,
+                    bot_profile_id,
+                    log_date,
+                    plan.plan_id,
+                    update.situation_key,
+                    timestamp if update.situation_key else None,
+                ),
+            )
+            cursor.execute(
+                """
+                SELECT id, user_id, bot_profile_id, log_date, plan_id,
+                       situation_key, situation_updated_at, meals, notes
+                FROM nutrition_daily_logs
+                WHERE user_id = %s
+                  AND bot_profile_id = %s
+                  AND log_date = %s
+                FOR UPDATE
+                """,
+                (user_id, bot_profile_id, log_date),
+            )
+            row = cursor.fetchone()
+            if row is None:
+                connection.rollback()
+                return None
+
+            merged = _merge_daily_update(
+                _row_to_daily_log(row),
+                plan=plan,
+                update=update,
+                timestamp=timestamp,
+            )
+            cursor.execute(
+                """
+                UPDATE nutrition_daily_logs
+                SET plan_id = %s,
+                    situation_key = %s,
+                    situation_updated_at = %s,
+                    meals = %s,
+                    notes = %s,
+                    updated_at = NOW()
+                WHERE id = %s
+                """,
+                (
+                    merged.plan_id,
+                    merged.situation_key,
+                    merged.situation_updated_at,
+                    Jsonb(dict(merged.meals)),
+                    Jsonb(list(merged.notes)),
+                    merged.id,
+                ),
+            )
+        connection.commit()
+        return merged
+    except Exception:
+        connection.rollback()
+        logger.warning(
+            "nutrition_daily_log_update_failed user_id=%s bot_profile_id=%s",
+            user_id,
+            bot_profile_id,
+            exc_info=True,
+        )
+        return None
+    finally:
+        connection.close()
+
+
+def preview_daily_update(
+    *,
+    log: NutritionDailyLog | None,
+    user_id: int,
+    bot_profile_id: str,
+    log_date: date,
+    plan: NutritionPlan,
+    update: DailyNutritionUpdate,
+    now: datetime | None = None,
+) -> NutritionDailyLog | None:
+    """Return the daily log as it would look after applying an update."""
+    if not update.has_changes:
+        return log
+
+    timestamp = now or datetime.now().astimezone()
+    base_log = log or NutritionDailyLog(
+        id=0,
+        user_id=user_id,
+        bot_profile_id=bot_profile_id,
+        log_date=log_date,
+        plan_id=plan.plan_id,
+        situation_key=None,
+        meals={},
+        notes=(),
+    )
+    return _merge_daily_update(
+        base_log,
+        plan=plan,
+        update=update,
+        timestamp=timestamp,
+    )
+
+
+def build_daily_update(
+    *,
+    plan: NutritionPlan,
+    message: str,
+    understanding: NutritionMessageUnderstanding,
+    normalized_message: NormalizedNutritionMessage | None,
+) -> DailyNutritionUpdate:
+    """Derive the daily-state mutation from the current user message."""
+    detected_situation_key = _selected_situation_key(
+        plan=plan,
+        message=message,
+        normalized_message=normalized_message,
+    )
+    replacement = _situation_replacement(plan, message)
+    no_training_key = _no_training_situation_key(plan)
+    day_situation_key = (
+        replacement if replacement is not None else detected_situation_key
+    )
+    if no_training_key and _message_cancels_training(message):
+        day_situation_key = no_training_key
+    if (
+        day_situation_key == detected_situation_key
+        and _message_mentions_activity_change(message)
+        and not _message_declares_current_activity(message)
+    ):
+        day_situation_key = None
+    logged_meals = _logged_meals_from_normalized(normalized_message)
+    skipped_moments = _skipped_moments_from_message(plan, message, understanding)
+    if day_situation_key and not _should_store_situation_for_today(
+        message=message,
+        logged_meals=logged_meals,
+        skipped_moments=skipped_moments,
+    ):
+        day_situation_key = None
+    note = (
+        f"Tipo de dia actualizado a {day_situation_key}."
+        if day_situation_key and _message_changes_day_type(message)
+        else None
+    )
+
+    return DailyNutritionUpdate(
+        situation_key=day_situation_key,
+        logged_meals=logged_meals,
+        skipped_moments=skipped_moments,
+        note=note,
+    )
+
+
+def to_prompt_payload(log: NutritionDailyLog | None) -> dict[str, Any] | None:
+    """Return a compact JSON payload for runtime LLM context."""
+    if log is None:
+        return None
+    return {
+        "log_date": log.log_date.isoformat(),
+        "plan_id": log.plan_id,
+        "situation_key": log.situation_key,
+        "tipo_dia": log.situation_key,
+        "meals": dict(log.meals),
+        "notes": list(log.notes)[-8:],
+    }
+
+
+def _merge_daily_update(
+    log: NutritionDailyLog,
+    *,
+    plan: NutritionPlan,
+    update: DailyNutritionUpdate,
+    timestamp: datetime,
+) -> NutritionDailyLog:
+    meals = dict(log.meals or {})
+    notes = list(log.notes or ())
+    situation_key = update.situation_key or log.situation_key
+    situation_updated_at = log.situation_updated_at
+    if update.situation_key:
+        situation_updated_at = timestamp
+
+    for meal in update.logged_meals:
+        meals[meal.moment_key] = {
+            **_existing_meal_entry(meals.get(meal.moment_key)),
+            "status": "completed",
+            "completed": True,
+            "text": meal.text,
+            "situation_key": situation_key,
+            "meal_block_key": _meal_block_key(
+                plan,
+                situation_key,
+                meal.moment_key,
+            ),
+            "updated_at": timestamp.isoformat(),
+        }
+    for moment_key in update.skipped_moments:
+        meals[moment_key] = {
+            **_existing_meal_entry(meals.get(moment_key)),
+            "status": "skipped",
+            "completed": True,
+            "text": "El usuario indica que se ha saltado esta comida.",
+            "situation_key": situation_key,
+            "meal_block_key": _meal_block_key(plan, situation_key, moment_key),
+            "updated_at": timestamp.isoformat(),
+        }
+    if update.note:
+        notes.append({"text": update.note, "created_at": timestamp.isoformat()})
+
+    return NutritionDailyLog(
+        id=log.id,
+        user_id=log.user_id,
+        bot_profile_id=log.bot_profile_id,
+        log_date=log.log_date,
+        plan_id=plan.plan_id,
+        situation_key=situation_key,
+        situation_updated_at=situation_updated_at,
+        meals=meals,
+        notes=tuple(notes),
+    )
+
+
+def _row_to_daily_log(row: Mapping[str, Any]) -> NutritionDailyLog:
+    raw_meals = row.get("meals")
+    raw_notes = row.get("notes")
+    meals: Mapping[str, Any] = raw_meals if isinstance(raw_meals, dict) else {}
+    notes: tuple[Mapping[str, Any], ...] = (
+        tuple(item for item in raw_notes if isinstance(item, dict))
+        if isinstance(raw_notes, list)
+        else ()
+    )
+    return NutritionDailyLog(
+        id=int(row["id"]),
+        user_id=int(row["user_id"]),
+        bot_profile_id=str(row["bot_profile_id"]),
+        log_date=row["log_date"],
+        plan_id=row.get("plan_id"),
+        situation_key=row.get("situation_key"),
+        situation_updated_at=row.get("situation_updated_at"),
+        meals=meals,
+        notes=notes,
+    )
+
+
+def _selected_situation_key(
+    *,
+    plan: NutritionPlan,
+    message: str,
+    normalized_message: NormalizedNutritionMessage | None,
+) -> str | None:
+    if normalized_message is not None and normalized_message.situation_key:
+        return normalized_message.situation_key
+    matches = detect_situations(plan, message)
+    return matches[0].key if len(matches) == 1 else None
+
+
+def _logged_meals_from_normalized(
+    normalized_message: NormalizedNutritionMessage | None,
+) -> tuple[LoggedMealUpdate, ...]:
+    if normalized_message is None:
+        return ()
+    meals: list[LoggedMealUpdate] = []
+    for item in normalized_message.logged_meals:
+        moment_key = item.get("moment_key")
+        text = item.get("text")
+        if moment_key and text:
+            meals.append(LoggedMealUpdate(moment_key=moment_key, text=text))
+    return tuple(meals)
+
+
+def _skipped_moments_from_message(
+    plan: NutritionPlan,
+    message: str,
+    understanding: NutritionMessageUnderstanding,
+) -> tuple[str, ...]:
+    if "skipped_meal" not in understanding.deviations:
+        return ()
+    normalized = normalize_text(message)
+    skipped_fragment = re.search(
+        r"\b(?:me he saltado|saltado|no he hecho)\s+(?P<fragment>.+?)(?:$|\bque\b)",
+        normalized,
+    )
+    if skipped_fragment is None:
+        return ()
+    matches = detect_moments(plan, skipped_fragment.group("fragment"))
+    return tuple(match.key for match in matches)
+
+
+def _message_cancels_training(message: str) -> bool:
+    normalized = normalize_text(message)
+    return any(
+        phrase in normalized
+        for phrase in (
+            "al final no he ido",
+            "al final no fui",
+            "no he ido",
+            "no fui",
+            "no voy a ir",
+            "no he entrenado",
+            "al final no entreno",
+        )
+    )
+
+
+def message_cancels_training(message: str) -> bool:
+    """Return true when the user corrects a planned training into no training."""
+    return _message_cancels_training(message)
+
+
+def message_changes_day_type(message: str) -> bool:
+    """Return true when the user explicitly changes today's day type."""
+    return _message_changes_day_type(message)
+
+
+def _message_changes_day_type(message: str) -> bool:
+    return _message_cancels_training(message) or _message_mentions_activity_change(
+        message
+    )
+
+
+def _should_store_situation_for_today(
+    *,
+    message: str,
+    logged_meals: tuple[LoggedMealUpdate, ...],
+    skipped_moments: tuple[str, ...],
+) -> bool:
+    normalized = normalize_text(message)
+    today_terms = (
+        "hoy",
+        "esta manana",
+        "esta tarde",
+        "esta noche",
+        "ahora",
+    )
+    return bool(
+        logged_meals
+        or skipped_moments
+        or _message_changes_day_type(message)
+        or any(term in normalized for term in today_terms)
+    )
+
+
+def _message_mentions_activity_change(message: str) -> bool:
+    normalized = normalize_text(message)
+    return any(phrase in normalized for phrase in ACTIVITY_CHANGE_PHRASES)
+
+
+def _message_declares_current_activity(message: str) -> bool:
+    normalized = normalize_text(message)
+    return any(
+        phrase in normalized
+        for phrase in (
+            "al final hago",
+            "al final hacemos",
+            "al final voy a",
+            "al final toca",
+        )
+    )
+
+
+def _situation_replacement(
+    plan: NutritionPlan,
+    message: str,
+) -> str | None:
+    if not _message_mentions_activity_change(message):
+        return None
+    positions = _situation_positions(plan, message)
+    if len(positions) < 2:
+        return None
+
+    previous_situation_key = positions[0][1]
+    replacement_situation_key = positions[-1][1]
+    if previous_situation_key == replacement_situation_key:
+        return None
+    return replacement_situation_key
+
+
+def _situation_positions(
+    plan: NutritionPlan,
+    message: str,
+) -> tuple[tuple[int, str], ...]:
+    normalized_message = normalize_text(message)
+    positions: list[tuple[int, str]] = []
+    for situation_key, situation in plan.situations.items():
+        for alias in _situation_aliases(situation_key, situation):
+            alias_pattern = r"\s+".join(re.escape(part) for part in alias.split())
+            for match in re.finditer(
+                rf"(?<!\w){alias_pattern}(?!\w)",
+                normalized_message,
+            ):
+                positions.append((match.start(), situation_key))
+    unique: list[tuple[int, str]] = []
+    seen: set[tuple[int, str]] = set()
+    for item in sorted(positions):
+        if item not in seen:
+            seen.add(item)
+            unique.append(item)
+    return tuple(unique)
+
+
+def _situation_aliases(
+    situation_key: str,
+    situation: Mapping[str, Any],
+) -> tuple[str, ...]:
+    aliases = situation.get("aliases", [])
+    values = [situation_key]
+    if isinstance(aliases, list):
+        values.extend(alias for alias in aliases if isinstance(alias, str))
+    return tuple(
+        alias for alias in (normalize_text(value) for value in values) if alias
+    )
+
+
+def _no_training_situation_key(plan: NutritionPlan) -> str | None:
+    for key in NO_TRAINING_SITUATION_CANDIDATES:
+        if key in plan.situations:
+            return key
+    for key, situation in plan.situations.items():
+        aliases = situation.get("aliases", [])
+        alias_values: Sequence[object] = aliases if isinstance(aliases, list) else ()
+        normalized_values = {
+            normalize_text(key),
+            *(normalize_text(str(item)) for item in alias_values),
+        }
+        if {"no entreno", "descanso"} & normalized_values:
+            return key
+    return None
+
+
+def _meal_block_key(
+    plan: NutritionPlan,
+    situation_key: str | None,
+    moment_key: str,
+) -> str | None:
+    if not situation_key:
+        return None
+    situation = plan.situations.get(situation_key, {})
+    moments = situation.get("momentos", {})
+    if not isinstance(moments, dict):
+        return None
+    meal_block_key = moments.get(moment_key)
+    return meal_block_key if isinstance(meal_block_key, str) else None
+
+
+def _existing_meal_entry(value: object) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}

--- a/src/forge_bot/nutrition/intent.py
+++ b/src/forge_bot/nutrition/intent.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+from .router import normalize_text
+
+ALL_NUTRITION_INTENTS = (
+    "weekly_planning",
+    "recommend_meal",
+    "adjust_existing_meal",
+    "log_meal",
+    "evaluate_day",
+    "calculate_macros",
+    "recover_from_high_fat_meal",
+    "recover_from_high_carb_meal",
+    "alcohol_recovery_or_guidance",
+    "recovery_guidance",
+    "body_composition_analysis",
+    "supplement_guidance",
+    "batch_cooking_or_recipe_preparation",
+    "multi_person_meal_planning",
+    "motivation_or_adherence_support",
+    "shopping_list",
+    "recipe_submission",
+    "plan_generation",
+    "hunger_management",
+    "unknown",
+)
+
+NutritionIntent = Literal[
+    "weekly_planning",
+    "recommend_meal",
+    "adjust_existing_meal",
+    "log_meal",
+    "evaluate_day",
+    "calculate_macros",
+    "recover_from_high_fat_meal",
+    "recover_from_high_carb_meal",
+    "alcohol_recovery_or_guidance",
+    "recovery_guidance",
+    "body_composition_analysis",
+    "supplement_guidance",
+    "batch_cooking_or_recipe_preparation",
+    "multi_person_meal_planning",
+    "motivation_or_adherence_support",
+    "shopping_list",
+    "recipe_submission",
+    "plan_generation",
+    "hunger_management",
+    "unknown",
+]
+
+
+@dataclass(frozen=True)
+class NutritionMessageUnderstanding:
+    """Cheap, local understanding used before selecting plan context."""
+
+    intent: NutritionIntent
+    normalized_message: str
+    mentioned_days: tuple[str, ...] = ()
+    foods: tuple[str, ...] = ()
+    deviations: tuple[str, ...] = ()
+    people: tuple[str, ...] = ()
+    needs_shopping_list: bool = False
+    asks_for_macros: bool = False
+    asks_for_full_day: bool = False
+
+    def to_prompt_payload(self) -> dict[str, object]:
+        return {
+            "intent": self.intent,
+            "mentioned_days": list(self.mentioned_days),
+            "foods": list(self.foods),
+            "deviations": list(self.deviations),
+            "people": list(self.people),
+            "needs_shopping_list": self.needs_shopping_list,
+            "asks_for_macros": self.asks_for_macros,
+            "asks_for_full_day": self.asks_for_full_day,
+        }
+
+
+INTENTS_THAT_NEED_PLAN_CONTEXT: frozenset[NutritionIntent] = frozenset(
+    {
+        "weekly_planning",
+        "multi_person_meal_planning",
+        "recommend_meal",
+        "adjust_existing_meal",
+        "log_meal",
+        "evaluate_day",
+        "recover_from_high_fat_meal",
+        "recover_from_high_carb_meal",
+        "alcohol_recovery_or_guidance",
+        "recovery_guidance",
+        "hunger_management",
+        "shopping_list",
+        "calculate_macros",
+    }
+)
+
+DAY_ALIASES: dict[str, tuple[str, ...]] = {
+    "lunes": ("lunes",),
+    "martes": ("martes",),
+    "miercoles": ("miercoles",),
+    "jueves": ("jueves",),
+    "viernes": ("viernes",),
+    "sabado": ("sabado",),
+    "domingo": ("domingo",),
+}
+
+FOOD_ALIASES: dict[str, tuple[str, ...]] = {
+    "aguacate": ("aguacate",),
+    "arroz": ("arroz",),
+    "atun": ("atun",),
+    "bacalao": ("bacalao",),
+    "cerveza": ("cerveza", "cervezas"),
+    "chuletas": ("chuleta", "chuletas"),
+    "dulces": ("dulce", "dulces"),
+    "ensalada": ("ensalada",),
+    "gofre": ("gofre", "gofres"),
+    "huevo": ("huevo", "huevos"),
+    "merluza": ("merluza",),
+    "palmera": ("palmera", "palmeras"),
+    "pasta": ("pasta",),
+    "patata": ("patata", "patatas"),
+    "pollo": ("pollo",),
+    "pavo": ("pavo",),
+    "rebujito": ("rebujito", "rebujitos"),
+    "salmon": ("salmon",),
+    "secreto": ("secreto",),
+    "verduras": ("verdura", "verduras"),
+}
+
+HIGH_FAT_TERMS = (
+    "secreto",
+    "chuleta",
+    "chuletas",
+    "cachopo",
+    "croqueta",
+    "croquetas",
+    "frito",
+    "fritos",
+    "grasa",
+    "grasienta",
+    "grasiento",
+)
+HIGH_CARB_TERMS = (
+    "atracon",
+    "dulce",
+    "dulces",
+    "dorayaki",
+    "dorayakis",
+    "gofre",
+    "gofres",
+    "palmera",
+    "palmeras",
+    "azucar",
+)
+ALCOHOL_TERMS = ("alcohol", "cerveza", "cervezas", "rebujito", "rebujitos", "vino")
+
+
+def classify_nutrition_message(message: str) -> NutritionMessageUnderstanding:
+    """Classify an informal nutrition message without calling an LLM."""
+    normalized = normalize_text(message)
+    foods = _detect_foods(normalized)
+    deviations = _detect_deviations(normalized)
+    mentioned_days = _detect_days(normalized)
+    people = _detect_people(normalized)
+    asks_for_macros = _contains_any(
+        normalized,
+        (
+            "macro",
+            "macros",
+            "caloria",
+            "calorias",
+            "proteina llevo",
+            "cuanta proteina",
+            "hidratos llevo",
+            "grasa llevo",
+        ),
+    )
+    needs_shopping_list = _contains_any(
+        normalized,
+        ("lista de la compra", "compra", "supermercado"),
+    )
+    asks_for_full_day = _contains_any(
+        normalized,
+        (
+            "todo el dia",
+            "dia completo",
+            "plan del dia",
+            "que puedo comer hoy",
+            "todo lo que puedo comer",
+            "todas las comidas",
+            "entre todas las comidas",
+            "comidas que tengo que hacer",
+        ),
+    ) or (
+        asks_for_macros
+        and _contains_any(normalized, ("dia", "todas las comidas", "comidas"))
+    )
+    intent = _detect_intent(
+        normalized,
+        foods=foods,
+        deviations=deviations,
+        mentioned_days=mentioned_days,
+        people=people,
+        asks_for_macros=asks_for_macros,
+        needs_shopping_list=needs_shopping_list,
+    )
+    return NutritionMessageUnderstanding(
+        intent=intent,
+        normalized_message=normalized,
+        mentioned_days=mentioned_days,
+        foods=foods,
+        deviations=deviations,
+        people=people,
+        needs_shopping_list=needs_shopping_list,
+        asks_for_macros=asks_for_macros,
+        asks_for_full_day=asks_for_full_day,
+    )
+
+
+def _detect_intent(
+    normalized: str,
+    *,
+    foods: tuple[str, ...],
+    deviations: tuple[str, ...],
+    mentioned_days: tuple[str, ...],
+    people: tuple[str, ...],
+    asks_for_macros: bool,
+    needs_shopping_list: bool,
+) -> NutritionIntent:
+    if _contains_any(
+        normalized,
+        ("/set_plan", "subir plan", "plan nuevo", "nuevo plan", "json"),
+    ):
+        return "plan_generation"
+    if _contains_any(
+        normalized,
+        ("te paso una receta", "guardar receta", "anadir receta", "nueva receta"),
+    ):
+        return "recipe_submission"
+    if needs_shopping_list:
+        return "shopping_list"
+    if mentioned_days and _contains_any(
+        normalized,
+        ("planificacion", "planificar", "semana", "plan de comidas"),
+    ):
+        return "multi_person_meal_planning" if people else "weekly_planning"
+    if _contains_any(normalized, ("planificacion de la semana", "plan de la semana")):
+        return "multi_person_meal_planning" if people else "weekly_planning"
+    if asks_for_macros:
+        return "calculate_macros"
+    if _contains_any(normalized, ("como vamos", "como queda el dia", "voy pasado")):
+        return "evaluate_day"
+    if _contains_any(normalized, ("porcentaje de grasa", "peso", "composicion")):
+        return "body_composition_analysis"
+    if _contains_any(
+        normalized,
+        ("suplemento", "suplementacion", "creatina", "magnesio", "whey"),
+    ):
+        return "supplement_guidance"
+    if _contains_any(
+        normalized,
+        ("batch", "congelado", "dejar preparado", "varios dias", "meal prep"),
+    ):
+        return "batch_cooking_or_recipe_preparation"
+    if _contains_any(
+        normalized,
+        ("estancado", "motivacion", "constancia", "me estoy rayando"),
+    ):
+        return "motivation_or_adherence_support"
+    if _contains_any(normalized, ("tengo hambre", "mucha hambre", "sin liarla")):
+        return "hunger_management"
+    if _contains_any(normalized, ALCOHOL_TERMS):
+        return "alcohol_recovery_or_guidance"
+    if _contains_any(normalized, HIGH_FAT_TERMS):
+        return "recover_from_high_fat_meal"
+    if _contains_any(normalized, HIGH_CARB_TERMS):
+        return "recover_from_high_carb_meal"
+    if _contains_any(
+        normalized,
+        ("reventado", "sobrecarga", "agujetas", "sin fuerza", "vacio"),
+    ):
+        return "recovery_guidance"
+    if _contains_any(
+        normalized,
+        (
+            "he comido",
+            "he cenado",
+            "me he comido",
+            "acabo de comer",
+            "me he saltado",
+        ),
+    ):
+        return "log_meal"
+    if _contains_any(
+        normalized,
+        (
+            "voy a cenar",
+            "voy a comer",
+            "le meto",
+            "le pongo",
+            "puedo meter",
+            "puedo anadir",
+            "cuanto le pongo",
+        ),
+    ):
+        return "adjust_existing_meal"
+    if _contains_any(
+        normalized,
+        (
+            "que como",
+            "que comer",
+            "que puedo comer",
+            "que puedo tomar",
+            "que ceno",
+            "que desayuno",
+            "que meriendo",
+            "que me hago",
+            "comida toca",
+            "cena toca",
+            "hoy tengo",
+            "hoy es dia",
+            "dia de no entreno",
+            "no entreno",
+        ),
+    ):
+        return "recommend_meal"
+    if foods and _contains_any(normalized, ("puedo", "encaja", "vale")):
+        return "adjust_existing_meal"
+    return "unknown"
+
+
+def _detect_days(normalized: str) -> tuple[str, ...]:
+    days: list[str] = []
+    for day, aliases in DAY_ALIASES.items():
+        if _contains_any(normalized, aliases):
+            days.append(day)
+    return tuple(days)
+
+
+def _detect_foods(normalized: str) -> tuple[str, ...]:
+    foods: list[str] = []
+    for food, aliases in FOOD_ALIASES.items():
+        if _contains_any(normalized, aliases):
+            foods.append(food)
+    return tuple(foods)
+
+
+def _detect_deviations(normalized: str) -> tuple[str, ...]:
+    deviations: list[str] = []
+    if _contains_any(normalized, HIGH_FAT_TERMS):
+        deviations.append("high_fat_meal")
+    if _contains_any(normalized, HIGH_CARB_TERMS):
+        deviations.append("high_carb_meal")
+    if _contains_any(normalized, ALCOHOL_TERMS):
+        deviations.append("alcohol")
+    if _contains_any(normalized, ("me he saltado", "saltado", "no he hecho")):
+        deviations.append("skipped_meal")
+    return tuple(deviations)
+
+
+def _detect_people(normalized: str) -> tuple[str, ...]:
+    people: list[str] = []
+    if _contains_any(normalized, ("pareja", "mi mujer", "mi marido", "los dos")):
+        people.append("pareja")
+    return tuple(people)
+
+
+def _contains_any(normalized: str, aliases: Iterable[str]) -> bool:
+    return any(_contains_phrase(normalized, normalize_text(alias)) for alias in aliases)
+
+
+def _contains_phrase(normalized: str, phrase: str) -> bool:
+    if not phrase:
+        return False
+    return f" {phrase} " in f" {normalized} "

--- a/src/forge_bot/nutrition/normalizer.py
+++ b/src/forge_bot/nutrition/normalizer.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol, cast
+
+from ..prompting import ChatMessage
+from .intent import (
+    ALL_NUTRITION_INTENTS,
+    NutritionIntent,
+    NutritionMessageUnderstanding,
+)
+from .plan import NutritionPlan
+
+
+class NutritionNormalizerClient(Protocol):
+    """Small chat interface used by the message-normalization chain step."""
+
+    async def chat(self, *, model: str, messages: list[ChatMessage]) -> str:
+        """Return the provider response for the normalization prompt."""
+
+
+@dataclass(frozen=True)
+class NormalizedNutritionMessage:
+    """Validated normalized interpretation of one user message."""
+
+    intent: NutritionIntent
+    situation_key: str | None = None
+    situation_keys: tuple[str, ...] = ()
+    target_moment_key: str | None = None
+    mentioned_moment_keys: tuple[str, ...] = ()
+    logged_meals: tuple[Mapping[str, str | None], ...] = ()
+    goal: str | None = None
+    wants_day_overview: bool = False
+    confidence: float = 0.0
+    route_message: str | None = None
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def has_route_signal(self) -> bool:
+        return bool(
+            self.situation_key
+            or self.situation_keys
+            or self.target_moment_key
+            or self.mentioned_moment_keys
+            or self.logged_meals
+            or self.wants_day_overview
+        )
+
+    def to_prompt_payload(self) -> dict[str, object]:
+        return {
+            "intent": self.intent,
+            "situation_key": self.situation_key,
+            "situation_keys": list(self.situation_keys),
+            "target_moment_key": self.target_moment_key,
+            "mentioned_moment_keys": list(self.mentioned_moment_keys),
+            "logged_meals": list(self.logged_meals),
+            "goal": self.goal,
+            "wants_day_overview": self.wants_day_overview,
+            "confidence": self.confidence,
+            "warnings": list(self.warnings),
+        }
+
+
+async def normalize_message_with_llm(
+    *,
+    client: NutritionNormalizerClient,
+    model: str,
+    plan: NutritionPlan,
+    message: str,
+    local_understanding: NutritionMessageUnderstanding,
+    compacted_user_memory: str | None = None,
+    recent_conversation_messages: Sequence[ChatMessage] | None = None,
+) -> NormalizedNutritionMessage | None:
+    """Ask a small model to map free text to plan-specific routing keys."""
+    response = await client.chat(
+        model=model,
+        messages=_normalization_prompt(
+            plan=plan,
+            message=message,
+            compacted_user_memory=compacted_user_memory,
+            recent_conversation_messages=recent_conversation_messages or (),
+        ),
+    )
+    payload = parse_json_object(response)
+    if payload is None:
+        return None
+    return validate_normalized_payload(
+        payload,
+        plan=plan,
+        local_understanding=local_understanding,
+    )
+
+
+def validate_normalized_payload(
+    payload: Mapping[str, Any],
+    *,
+    plan: NutritionPlan,
+    local_understanding: NutritionMessageUnderstanding,
+) -> NormalizedNutritionMessage:
+    """Validate model output against the active user's plan."""
+    warnings: list[str] = []
+    situation_keys = _plan_situation_keys(plan)
+    moment_keys = _plan_moment_keys(plan)
+
+    raw_intent = payload.get("intent")
+    intent = (
+        cast(NutritionIntent, raw_intent)
+        if isinstance(raw_intent, str) and raw_intent in ALL_NUTRITION_INTENTS
+        else local_understanding.intent
+    )
+    if intent == "unknown" and local_understanding.intent != "unknown":
+        intent = local_understanding.intent
+
+    situation_key = _validated_optional_key(
+        payload.get("situation_key"),
+        allowed=situation_keys,
+        warning_name="situation_key",
+        warnings=warnings,
+    )
+    selected_situation_keys = _validated_key_tuple(
+        payload.get("situation_keys"),
+        allowed=situation_keys,
+        warning_name="situation_keys",
+        warnings=warnings,
+    )
+    if situation_key and situation_key not in selected_situation_keys:
+        selected_situation_keys = (situation_key, *selected_situation_keys)
+
+    target_moment_key = _validated_optional_key(
+        payload.get("target_moment_key"),
+        allowed=moment_keys,
+        warning_name="target_moment_key",
+        warnings=warnings,
+    )
+    mentioned_moment_keys = _validated_key_tuple(
+        payload.get("mentioned_moment_keys"),
+        allowed=moment_keys,
+        warning_name="mentioned_moment_keys",
+        warnings=warnings,
+    )
+    if target_moment_key and target_moment_key not in mentioned_moment_keys:
+        mentioned_moment_keys = (target_moment_key, *mentioned_moment_keys)
+
+    logged_meals = _validated_logged_meals(
+        payload.get("logged_meals"),
+        moment_keys=moment_keys,
+    )
+    goal = _optional_text(payload.get("goal"))
+    wants_day_overview = _optional_bool(payload.get("wants_day_overview"))
+    confidence = _confidence(payload.get("confidence"))
+    route_message = _route_message(
+        situation_key=situation_key,
+        target_moment_key=target_moment_key,
+        wants_day_overview=wants_day_overview,
+    )
+
+    return NormalizedNutritionMessage(
+        intent=intent,
+        situation_key=situation_key,
+        situation_keys=selected_situation_keys,
+        target_moment_key=target_moment_key,
+        mentioned_moment_keys=mentioned_moment_keys,
+        logged_meals=logged_meals,
+        goal=goal,
+        wants_day_overview=wants_day_overview,
+        confidence=confidence,
+        route_message=route_message,
+        warnings=tuple(warnings),
+    )
+
+
+def _normalization_prompt(
+    *,
+    plan: NutritionPlan,
+    message: str,
+    compacted_user_memory: str | None,
+    recent_conversation_messages: Sequence[ChatMessage],
+) -> list[ChatMessage]:
+    options = {
+        "allowed_intents": list(ALL_NUTRITION_INTENTS),
+        "situations": {
+            key: {
+                "label": _optional_text(situation.get("label")) or key,
+                "aliases": _string_list(situation.get("aliases")),
+            }
+            for key, situation in plan.situations.items()
+        },
+        "moments": _moment_options(plan),
+    }
+    conversation_context = _normalizer_conversation_context(
+        compacted_user_memory=compacted_user_memory,
+        recent_conversation_messages=recent_conversation_messages,
+    )
+    return [
+        {
+            "role": "system",
+            "content": (
+                "/no_think\n"
+                "Normalize one Spanish nutrition-bot user message into strict "
+                "JSON. Use only the allowed situation and moment keys supplied "
+                "by the active user's plan. Do not infer quantities or foods "
+                "from the meal plan. Distinguish past logged meals from the "
+                "target meal the user wants to resolve.\n\n"
+                "Use the conversation context to resolve short follow-ups like "
+                "'eso', 'lo de antes', 'fútbol', 'para cenar', or corrections. "
+                "If the current message asks for macros, all meals, the whole "
+                "day, or 'entre todas las comidas', set wants_day_overview=true. "
+                "If the current message is just adding context to the previous "
+                "topic, keep the same situation/moment when it is clear from "
+                "conversation context. If it is not clear, leave keys null "
+                "instead of guessing.\n\n"
+                "Return only one JSON object with this schema:\n"
+                "{"
+                '"intent": string, '
+                '"situation_key": string|null, '
+                '"situation_keys": string[], '
+                '"target_moment_key": string|null, '
+                '"mentioned_moment_keys": string[], '
+                '"logged_meals": [{"moment_key": string|null, "text": string}], '
+                '"goal": string|null, '
+                '"wants_day_overview": boolean, '
+                '"confidence": "low|medium|high"'
+                "}\n\n"
+                f"Allowed options:\n{json.dumps(options, ensure_ascii=False)}"
+                f"{conversation_context}"
+            ),
+        },
+        {"role": "user", "content": message},
+    ]
+
+
+def parse_json_object(content: str) -> Mapping[str, Any] | None:
+    """Extract a JSON object from plain text or fenced model output."""
+    cleaned = content.strip()
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```(?:json)?", "", cleaned, flags=re.IGNORECASE).strip()
+        cleaned = re.sub(r"```$", "", cleaned).strip()
+    decoder = json.JSONDecoder()
+    try:
+        payload = decoder.decode(cleaned)
+    except json.JSONDecodeError:
+        payload = None
+        for index, char in enumerate(cleaned):
+            if char != "{":
+                continue
+            try:
+                candidate, _end = decoder.raw_decode(cleaned[index:])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(candidate, dict):
+                payload = candidate
+                break
+    return payload if isinstance(payload, dict) else None
+
+
+def _plan_situation_keys(plan: NutritionPlan) -> frozenset[str]:
+    return frozenset(plan.situations.keys())
+
+
+def _plan_moment_keys(plan: NutritionPlan) -> frozenset[str]:
+    keys = set(plan.moments.keys())
+    for situation in plan.situations.values():
+        moments = situation.get("momentos", {})
+        if isinstance(moments, dict):
+            keys.update(str(moment_key) for moment_key in moments)
+    return frozenset(keys)
+
+
+def _moment_options(plan: NutritionPlan) -> dict[str, dict[str, object]]:
+    options: dict[str, dict[str, object]] = {}
+    for key in sorted(_plan_moment_keys(plan)):
+        moment = plan.moments.get(key, {})
+        label = moment.get("label") if isinstance(moment, dict) else None
+        aliases = moment.get("aliases") if isinstance(moment, dict) else None
+        options[key] = {
+            "label": label.strip() if isinstance(label, str) and label.strip() else key,
+            "aliases": _string_list(aliases),
+        }
+    return options
+
+
+def _validated_optional_key(
+    value: object,
+    *,
+    allowed: frozenset[str],
+    warning_name: str,
+    warnings: list[str],
+) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str) and value in allowed:
+        return value
+    warnings.append(f"ignored_invalid_{warning_name}")
+    return None
+
+
+def _validated_key_tuple(
+    value: object,
+    *,
+    allowed: frozenset[str],
+    warning_name: str,
+    warnings: list[str],
+) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    keys: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        if isinstance(item, str) and item in allowed and item not in seen:
+            seen.add(item)
+            keys.append(item)
+        elif item is not None:
+            warnings.append(f"ignored_invalid_{warning_name}")
+    return tuple(keys)
+
+
+def _validated_logged_meals(
+    value: object,
+    *,
+    moment_keys: frozenset[str],
+) -> tuple[Mapping[str, str | None], ...]:
+    if not isinstance(value, list):
+        return ()
+    meals: list[Mapping[str, str | None]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        moment = item.get("moment_key")
+        text = item.get("text")
+        moment_key = (
+            moment if isinstance(moment, str) and moment in moment_keys else None
+        )
+        meal_text = text.strip() if isinstance(text, str) and text.strip() else None
+        meals.append(
+            {
+                "moment_key": moment_key,
+                "text": meal_text,
+            }
+        )
+    return tuple(meals)
+
+
+def _route_message(
+    *,
+    situation_key: str | None,
+    target_moment_key: str | None,
+    wants_day_overview: bool,
+) -> str | None:
+    parts = [part for part in (situation_key, target_moment_key) if part]
+    if wants_day_overview:
+        parts.append("todo el dia")
+    return " ".join(parts) if parts else None
+
+
+def _confidence(value: object) -> float:
+    if isinstance(value, int | float):
+        return max(0.0, min(float(value), 1.0))
+    if not isinstance(value, str):
+        return 0.0
+    normalized = value.strip().lower()
+    if normalized == "high":
+        return 0.9
+    if normalized == "medium":
+        return 0.6
+    if normalized == "low":
+        return 0.3
+    return 0.0
+
+
+def _optional_text(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _optional_bool(value: object) -> bool:
+    return value if isinstance(value, bool) else False
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _normalizer_conversation_context(
+    *,
+    compacted_user_memory: str | None,
+    recent_conversation_messages: Sequence[ChatMessage],
+) -> str:
+    sections: list[str] = []
+    if compacted_user_memory and compacted_user_memory.strip():
+        sections.append("Compacted memory:\n" + compacted_user_memory.strip()[:2500])
+    recent = [
+        f"{message['role']}: {message['content'].strip()[:500]}"
+        for message in recent_conversation_messages[-8:]
+        if message["content"].strip()
+    ]
+    if recent:
+        sections.append("Recent conversation:\n" + "\n".join(recent))
+    if not sections:
+        return ""
+    return "\n\nConversation context:\n" + "\n\n".join(sections)

--- a/src/forge_bot/nutrition/orchestrator.py
+++ b/src/forge_bot/nutrition/orchestrator.py
@@ -1,0 +1,1128 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from datetime import date
+from typing import Any, cast
+
+from langchain_core.runnables import Runnable, RunnableLambda
+
+from ..bot_profile import BotProfile
+from ..prompting import ChatMessage
+from . import daily_state as nutrition_daily_state
+from .intent import (
+    INTENTS_THAT_NEED_PLAN_CONTEXT,
+    NutritionMessageUnderstanding,
+    classify_nutrition_message,
+)
+from .normalizer import (
+    NormalizedNutritionMessage,
+    NutritionNormalizerClient,
+    normalize_message_with_llm,
+)
+from .plan import NutritionPlan, NutritionPlanError, load_nutrition_plan_file
+from .plan_store import load_active_nutrition_plan
+from .router import (
+    MealResolution,
+    SituationMatch,
+    detect_situations,
+    normalize_text,
+    resolve_meal_context,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class NutritionPromptSetup:
+    """Nutrition-specific prompt setup returned to the generic engine."""
+
+    prompt_profile: BotProfile
+    runtime_instructions: tuple[str, ...] = ()
+    direct_answer: str | None = None
+    include_memory: bool = True
+    understanding: NutritionMessageUnderstanding | None = None
+    normalized_message: NormalizedNutritionMessage | None = None
+    post_success_actions: tuple[Callable[[], None], ...] = ()
+
+
+@dataclass(frozen=True)
+class NutritionDailyLogContext:
+    """Daily log state to read now and persist only after answer delivery."""
+
+    log: nutrition_daily_state.NutritionDailyLog | None = None
+    post_success_actions: tuple[Callable[[], None], ...] = ()
+
+
+@dataclass(frozen=True)
+class NutritionDailyLogCommit:
+    """Deferred daily log write for a successfully answered turn."""
+
+    user_id: int
+    bot_profile_id: str
+    log_date: date
+    plan: NutritionPlan
+    update: nutrition_daily_state.DailyNutritionUpdate
+
+    def __call__(self) -> None:
+        if not self.update.has_changes:
+            return
+        nutrition_daily_state.apply_daily_update(
+            user_id=self.user_id,
+            bot_profile_id=self.bot_profile_id,
+            log_date=self.log_date,
+            plan=self.plan,
+            update=self.update,
+        )
+
+
+def prepare_nutrition_prompt(
+    profile: BotProfile,
+    message: str,
+    compacted_user_memory: str | None = None,
+    recent_conversation_messages: Sequence[ChatMessage] | None = None,
+    internal_user_id: int | None = None,
+    current_date: date | None = None,
+) -> NutritionPromptSetup:
+    """Build nutrition runtime instructions with a LangChain orchestration chain."""
+    if profile.bot_profile_id != "nutrition":
+        return NutritionPromptSetup(prompt_profile=profile)
+
+    chain = build_nutrition_orchestration_chain()
+    return chain.invoke(
+        {
+            "profile": profile,
+            "message": message,
+            "compacted_user_memory": compacted_user_memory,
+            "recent_conversation_messages": recent_conversation_messages or [],
+            "internal_user_id": internal_user_id,
+            "current_date": current_date,
+        }
+    )
+
+
+async def prepare_nutrition_prompt_async(
+    profile: BotProfile,
+    message: str,
+    compacted_user_memory: str | None = None,
+    recent_conversation_messages: Sequence[ChatMessage] | None = None,
+    normalizer_client: NutritionNormalizerClient | None = None,
+    normalizer_model: str | None = None,
+    internal_user_id: int | None = None,
+    current_date: date | None = None,
+) -> NutritionPromptSetup:
+    """Build nutrition prompt setup with an optional model normalization step."""
+    if profile.bot_profile_id != "nutrition":
+        return NutritionPromptSetup(prompt_profile=profile)
+
+    chain = _build_nutrition_orchestration_chain(
+        normalizer_enabled=normalizer_client is not None and bool(normalizer_model)
+    )
+    return await chain.ainvoke(
+        {
+            "profile": profile,
+            "message": message,
+            "compacted_user_memory": compacted_user_memory,
+            "recent_conversation_messages": recent_conversation_messages or [],
+            "normalizer_client": normalizer_client,
+            "normalizer_model": normalizer_model,
+            "internal_user_id": internal_user_id,
+            "current_date": current_date,
+        }
+    )
+
+
+def build_nutrition_orchestration_chain() -> Runnable[
+    Mapping[str, Any],
+    NutritionPromptSetup,
+]:
+    """Create the current nutrition orchestration pipeline.
+
+    The first runnable is intentionally local and cheap. It normalizes and
+    classifies the user message before any remote model sees the prompt. Later
+    steps can be swapped for MCP-backed tools or model calls without changing
+    the generic engine contract.
+    """
+    return _build_nutrition_orchestration_chain(normalizer_enabled=False)
+
+
+def _build_nutrition_orchestration_chain(
+    *,
+    normalizer_enabled: bool,
+) -> Runnable[
+    Mapping[str, Any],
+    NutritionPromptSetup,
+]:
+    route_step = (
+        _route_plan_context_async if normalizer_enabled else _route_plan_context
+    )
+    return RunnableLambda(_understand_message).pipe(RunnableLambda(route_step))
+
+
+def _understand_message(state: Mapping[str, Any]) -> dict[str, Any]:
+    message = str(state["message"])
+    return {
+        **state,
+        "prompt_profile": replace(state["profile"], context_documents=()),
+        "understanding": classify_nutrition_message(message),
+    }
+
+
+def _route_plan_context(state: Mapping[str, Any]) -> NutritionPromptSetup:
+    return _route_plan_context_loaded(state, normalized_message=None)
+
+
+async def _route_plan_context_async(state: Mapping[str, Any]) -> NutritionPromptSetup:
+    return await _route_plan_context_loaded_async(state)
+
+
+def _route_plan_context_loaded(
+    state: Mapping[str, Any],
+    *,
+    normalized_message: NormalizedNutritionMessage | None,
+) -> NutritionPromptSetup:
+    profile: BotProfile = state["profile"]
+    prompt_profile: BotProfile = state["prompt_profile"]
+    understanding: NutritionMessageUnderstanding = state["understanding"]
+
+    try:
+        plan = _load_plan_for_state(profile=profile, state=state)
+    except NutritionPlanError:
+        logger.exception(
+            "nutrition_plan_load_failed profile=%s",
+            profile.bot_profile_id,
+        )
+        return NutritionPromptSetup(
+            prompt_profile=prompt_profile,
+            direct_answer="No puedo leer el plan nutricional configurado ahora mismo.",
+            understanding=understanding,
+            normalized_message=normalized_message,
+        )
+    if plan is None:
+        return _missing_active_plan_setup(
+            prompt_profile=prompt_profile,
+            message=str(state["message"]),
+            understanding=understanding,
+            normalized_message=normalized_message,
+        )
+
+    return _route_plan_context_loaded_with_plan(
+        state,
+        plan=plan,
+        normalized_message=normalized_message,
+    )
+
+
+async def _route_plan_context_loaded_async(
+    state: Mapping[str, Any],
+) -> NutritionPromptSetup:
+    profile: BotProfile = state["profile"]
+    prompt_profile: BotProfile = state["prompt_profile"]
+    understanding: NutritionMessageUnderstanding = state["understanding"]
+
+    try:
+        plan = _load_plan_for_state(profile=profile, state=state)
+    except NutritionPlanError:
+        logger.exception(
+            "nutrition_plan_load_failed profile=%s",
+            profile.bot_profile_id,
+        )
+        return NutritionPromptSetup(
+            prompt_profile=prompt_profile,
+            direct_answer="No puedo leer el plan nutricional configurado ahora mismo.",
+            understanding=understanding,
+        )
+    if plan is None:
+        return _missing_active_plan_setup(
+            prompt_profile=prompt_profile,
+            message=str(state["message"]),
+            understanding=understanding,
+            normalized_message=None,
+        )
+
+    normalized_message = await _normalize_with_model(
+        state=state,
+        plan=plan,
+        understanding=understanding,
+    )
+    return _route_plan_context_loaded_with_plan(
+        state,
+        plan=plan,
+        normalized_message=normalized_message,
+    )
+
+
+def _route_plan_context_loaded_with_plan(
+    state: Mapping[str, Any],
+    *,
+    plan: NutritionPlan,
+    normalized_message: NormalizedNutritionMessage | None,
+) -> NutritionPromptSetup:
+    copied_state = dict(state)
+    copied_state["loaded_plan"] = plan
+    return _route_plan_context_from_loaded_plan(
+        copied_state,
+        normalized_message=normalized_message,
+    )
+
+
+def _route_plan_context_from_loaded_plan(
+    state: Mapping[str, Any],
+    *,
+    normalized_message: NormalizedNutritionMessage | None,
+) -> NutritionPromptSetup:
+    prompt_profile: BotProfile = state["prompt_profile"]
+    message = str(state["message"])
+    recent_conversation_messages: Sequence[ChatMessage] = state[
+        "recent_conversation_messages"
+    ]
+    compacted_user_memory = _optional_state_text(state.get("compacted_user_memory"))
+    understanding: NutritionMessageUnderstanding = state["understanding"]
+    plan: NutritionPlan = state["loaded_plan"]
+
+    if not _should_use_plan_context(
+        understanding,
+        message,
+        plan=plan,
+        normalized_message=normalized_message,
+    ):
+        return NutritionPromptSetup(
+            prompt_profile=prompt_profile,
+            understanding=understanding,
+            normalized_message=normalized_message,
+        )
+
+    effective_intent = _effective_intent(understanding, normalized_message)
+    daily_log_context = _load_daily_log_context(
+        state=state,
+        plan=plan,
+        normalized_message=normalized_message,
+    )
+    if effective_intent in {"weekly_planning", "multi_person_meal_planning"}:
+        return _weekly_planning_setup(
+            plan=plan,
+            prompt_profile=prompt_profile,
+            message=message,
+            understanding=understanding,
+            normalized_message=normalized_message,
+            daily_log_context=daily_log_context,
+        )
+
+    if effective_intent == "shopping_list":
+        return _shopping_list_setup(
+            plan=plan,
+            prompt_profile=prompt_profile,
+            understanding=understanding,
+            normalized_message=normalized_message,
+            daily_log_context=daily_log_context,
+        )
+
+    route_message = _routing_message_for_context(
+        message,
+        understanding,
+        normalized_message=normalized_message,
+    )
+    route_message = _route_message_with_daily_log(
+        plan=plan,
+        message=message,
+        route_message=route_message,
+        daily_log=daily_log_context.log,
+        understanding=understanding,
+        normalized_message=normalized_message,
+    )
+    resolution = _resolve_nutrition_context_with_follow_up(
+        plan,
+        route_message,
+        recent_conversation_messages,
+        compacted_user_memory=compacted_user_memory,
+    )
+    if not resolution.is_resolved:
+        if _should_defer_clarification_to_llm(
+            understanding=understanding,
+            normalized_message=normalized_message,
+            resolution=resolution,
+        ):
+            return _unresolved_context_setup(
+                plan=plan,
+                prompt_profile=prompt_profile,
+                resolution=resolution,
+                understanding=understanding,
+                normalized_message=normalized_message,
+                daily_log_context=daily_log_context,
+            )
+        return NutritionPromptSetup(
+            prompt_profile=prompt_profile,
+            direct_answer=_nutrition_clarification(resolution),
+            understanding=understanding,
+            normalized_message=normalized_message,
+            post_success_actions=daily_log_context.post_success_actions,
+        )
+
+    return NutritionPromptSetup(
+        prompt_profile=prompt_profile,
+        runtime_instructions=(
+            _runtime_context_instruction(
+                context=_attach_daily_log(
+                    _nutrition_context_payload(resolution),
+                    daily_log=daily_log_context.log,
+                ),
+                understanding=understanding,
+                normalized_message=normalized_message,
+            ),
+        ),
+        include_memory=True,
+        understanding=understanding,
+        normalized_message=normalized_message,
+        post_success_actions=daily_log_context.post_success_actions,
+    )
+
+
+def _load_plan_for_state(
+    *,
+    profile: BotProfile,
+    state: Mapping[str, Any],
+) -> NutritionPlan | None:
+    if profile.nutrition_plan_path is not None:
+        return load_nutrition_plan_file(profile.nutrition_plan_path)
+
+    user_id = state.get("internal_user_id")
+    if not isinstance(user_id, int):
+        return None
+    return load_active_nutrition_plan(user_id=user_id)
+
+
+def _missing_active_plan_setup(
+    *,
+    prompt_profile: BotProfile,
+    message: str,
+    understanding: NutritionMessageUnderstanding,
+    normalized_message: NormalizedNutritionMessage | None,
+) -> NutritionPromptSetup:
+    if not _looks_like_nutrition_question_without_plan(understanding, message):
+        return NutritionPromptSetup(
+            prompt_profile=prompt_profile,
+            understanding=understanding,
+            normalized_message=normalized_message,
+        )
+    return NutritionPromptSetup(
+        prompt_profile=prompt_profile,
+        direct_answer=(
+            "Todavia no tengo tu plan nutricional activo. Sube un JSON con "
+            "/set_plan para poder darte cantidades y opciones concretas."
+        ),
+        understanding=understanding,
+        normalized_message=normalized_message,
+    )
+
+
+async def _normalize_with_model(
+    *,
+    state: Mapping[str, Any],
+    plan: NutritionPlan,
+    understanding: NutritionMessageUnderstanding,
+) -> NormalizedNutritionMessage | None:
+    client = state.get("normalizer_client")
+    model = state.get("normalizer_model")
+    if client is None or not isinstance(model, str) or not model.strip():
+        return None
+    try:
+        return await normalize_message_with_llm(
+            client=client,
+            model=model,
+            plan=plan,
+            message=str(state["message"]),
+            local_understanding=understanding,
+            compacted_user_memory=_optional_state_text(
+                state.get("compacted_user_memory")
+            ),
+            recent_conversation_messages=cast(
+                Sequence[ChatMessage],
+                state.get("recent_conversation_messages", ()),
+            ),
+        )
+    except Exception:
+        logger.warning("nutrition_message_normalization_failed", exc_info=True)
+        return None
+
+
+def _should_use_plan_context(
+    understanding: NutritionMessageUnderstanding,
+    message: str,
+    *,
+    plan: NutritionPlan,
+    normalized_message: NormalizedNutritionMessage | None = None,
+) -> bool:
+    if (
+        normalized_message is not None
+        and (
+            normalized_message.has_route_signal
+            or normalized_message.intent != "unknown"
+        )
+        and normalized_message.confidence >= 0.55
+        and normalized_message.intent in INTENTS_THAT_NEED_PLAN_CONTEXT
+    ):
+        return True
+    if understanding.intent in INTENTS_THAT_NEED_PLAN_CONTEXT:
+        return True
+    return _looks_like_nutrition_routing_query(message, plan=plan)
+
+
+def _looks_like_nutrition_question_without_plan(
+    understanding: NutritionMessageUnderstanding,
+    message: str,
+) -> bool:
+    if understanding.intent in INTENTS_THAT_NEED_PLAN_CONTEXT:
+        return True
+    normalized = normalize_text(message)
+    keywords = (
+        "que como",
+        "que comer",
+        "que puedo comer",
+        "que ceno",
+        "que desayuno",
+        "que meriendo",
+        "plan nutricional",
+        "mi plan",
+        "comidas del dia",
+        "lista de la compra",
+    )
+    return any(keyword in normalized for keyword in keywords)
+
+
+def _effective_intent(
+    understanding: NutritionMessageUnderstanding,
+    normalized_message: NormalizedNutritionMessage | None,
+) -> str:
+    if normalized_message is not None and normalized_message.intent != "unknown":
+        return normalized_message.intent
+    return understanding.intent
+
+
+def _message_wants_day_overview(
+    *,
+    understanding: NutritionMessageUnderstanding,
+    normalized_message: NormalizedNutritionMessage | None,
+) -> bool:
+    if _effective_intent(understanding, normalized_message) == "evaluate_day":
+        return True
+    return understanding.asks_for_full_day or (
+        normalized_message is not None and normalized_message.wants_day_overview
+    )
+
+
+def _should_defer_clarification_to_llm(
+    *,
+    understanding: NutritionMessageUnderstanding,
+    normalized_message: NormalizedNutritionMessage | None,
+    resolution: MealResolution,
+) -> bool:
+    if resolution.status not in {"missing_situation", "missing_moment"}:
+        return False
+    effective_intent = _effective_intent(understanding, normalized_message)
+    if effective_intent in {"recommend_meal", "weekly_planning"}:
+        return False
+    return True
+
+
+def _unresolved_context_setup(
+    *,
+    plan: NutritionPlan,
+    prompt_profile: BotProfile,
+    resolution: MealResolution,
+    understanding: NutritionMessageUnderstanding,
+    normalized_message: NormalizedNutritionMessage | None,
+    daily_log_context: NutritionDailyLogContext,
+) -> NutritionPromptSetup:
+    return NutritionPromptSetup(
+        prompt_profile=prompt_profile,
+        runtime_instructions=(
+            _runtime_context_instruction(
+                context=_attach_daily_log(
+                    _unresolved_context_payload(
+                        plan=plan,
+                        resolution=resolution,
+                    ),
+                    daily_log=daily_log_context.log,
+                ),
+                understanding=understanding,
+                normalized_message=normalized_message,
+            ),
+        ),
+        include_memory=True,
+        understanding=understanding,
+        normalized_message=normalized_message,
+        post_success_actions=daily_log_context.post_success_actions,
+    )
+
+
+def _weekly_planning_setup(
+    *,
+    plan: NutritionPlan,
+    prompt_profile: BotProfile,
+    message: str,
+    understanding: NutritionMessageUnderstanding,
+    normalized_message: NormalizedNutritionMessage | None = None,
+    daily_log_context: NutritionDailyLogContext | None = None,
+) -> NutritionPromptSetup:
+    daily_log_context = daily_log_context or NutritionDailyLogContext()
+    normalized_situations = (
+        normalized_message.situation_keys if normalized_message is not None else ()
+    )
+    situation_matches = detect_situations(plan, message)
+    if not situation_matches and not normalized_situations:
+        options = _join_options(_available_situation_labels(plan.situations))
+        return NutritionPromptSetup(
+            prompt_profile=prompt_profile,
+            direct_answer=(
+                "Puedo montarlo, pero dime que tipo de dia tiene cada dia. "
+                f"Opciones del plan: {options}."
+            ),
+            understanding=understanding,
+            normalized_message=normalized_message,
+            post_success_actions=daily_log_context.post_success_actions,
+        )
+
+    context = _planning_context_payload(
+        plan=plan,
+        situation_matches=situation_matches,
+        situation_keys=normalized_situations,
+        mode="weekly_planning",
+    )
+    return NutritionPromptSetup(
+        prompt_profile=prompt_profile,
+        runtime_instructions=(
+            _runtime_context_instruction(
+                context=_attach_daily_log(context, daily_log=daily_log_context.log),
+                understanding=understanding,
+                normalized_message=normalized_message,
+            ),
+        ),
+        include_memory=True,
+        understanding=understanding,
+        normalized_message=normalized_message,
+        post_success_actions=daily_log_context.post_success_actions,
+    )
+
+
+def _shopping_list_setup(
+    *,
+    plan: NutritionPlan,
+    prompt_profile: BotProfile,
+    understanding: NutritionMessageUnderstanding,
+    normalized_message: NormalizedNutritionMessage | None = None,
+    daily_log_context: NutritionDailyLogContext | None = None,
+) -> NutritionPromptSetup:
+    daily_log_context = daily_log_context or NutritionDailyLogContext()
+    context = _planning_context_payload(
+        plan=plan,
+        situation_matches=(),
+        mode="shopping_list",
+    )
+    return NutritionPromptSetup(
+        prompt_profile=prompt_profile,
+        runtime_instructions=(
+            _runtime_context_instruction(
+                context=_attach_daily_log(context, daily_log=daily_log_context.log),
+                understanding=understanding,
+                normalized_message=normalized_message,
+            ),
+        ),
+        include_memory=True,
+        understanding=understanding,
+        normalized_message=normalized_message,
+        post_success_actions=daily_log_context.post_success_actions,
+    )
+
+
+def _resolve_nutrition_context_with_follow_up(
+    plan: NutritionPlan,
+    message: str,
+    recent_conversation_messages: Sequence[ChatMessage],
+    *,
+    compacted_user_memory: str | None = None,
+) -> MealResolution:
+    resolution = resolve_meal_context(plan, message)
+    if resolution.is_resolved or resolution.status not in {
+        "missing_situation",
+        "missing_moment",
+    }:
+        return resolution
+
+    recent_messages = [
+        item["content"].strip()
+        for item in recent_conversation_messages
+        if item["content"].strip()
+    ]
+    context_candidates: list[str] = []
+    if compacted_user_memory and compacted_user_memory.strip():
+        context_candidates.append(compacted_user_memory.strip())
+    context_candidates.extend(recent_messages[-8:])
+    for previous_message in reversed(context_candidates):
+        combined_resolution = resolve_meal_context(
+            plan,
+            f"{previous_message}\n{message}",
+        )
+        if combined_resolution.is_resolved:
+            return combined_resolution
+    return resolution
+
+
+def _load_daily_log_context(
+    *,
+    state: Mapping[str, Any],
+    plan: NutritionPlan,
+    normalized_message: NormalizedNutritionMessage | None,
+) -> NutritionDailyLogContext:
+    user_id = state.get("internal_user_id")
+    if not isinstance(user_id, int):
+        return NutritionDailyLogContext()
+
+    log_date = state.get("current_date")
+    if not isinstance(log_date, date):
+        log_date = nutrition_daily_state.today_local()
+
+    try:
+        bot_profile_id = cast(BotProfile, state["profile"]).bot_profile_id
+        current_log = nutrition_daily_state.load_daily_log(
+            user_id=user_id,
+            bot_profile_id=bot_profile_id,
+            log_date=log_date,
+        )
+        update = nutrition_daily_state.build_daily_update(
+            plan=plan,
+            message=str(state["message"]),
+            understanding=cast(NutritionMessageUnderstanding, state["understanding"]),
+            normalized_message=normalized_message,
+        )
+        preview_log = nutrition_daily_state.preview_daily_update(
+            log=current_log,
+            user_id=user_id,
+            bot_profile_id=bot_profile_id,
+            log_date=log_date,
+            plan=plan,
+            update=update,
+        )
+        actions: tuple[Callable[[], None], ...] = (
+            (
+                NutritionDailyLogCommit(
+                    user_id=user_id,
+                    bot_profile_id=bot_profile_id,
+                    log_date=log_date,
+                    plan=plan,
+                    update=update,
+                ),
+            )
+            if update.has_changes
+            else ()
+        )
+        return NutritionDailyLogContext(
+            log=preview_log,
+            post_success_actions=actions,
+        )
+    except Exception:
+        logger.warning(
+            "nutrition_daily_log_context_failed user_id=%s profile=%s",
+            user_id,
+            cast(BotProfile, state["profile"]).bot_profile_id,
+            exc_info=True,
+        )
+        return NutritionDailyLogContext()
+
+
+def _route_message_with_daily_log(
+    *,
+    plan: NutritionPlan,
+    message: str,
+    route_message: str,
+    daily_log: nutrition_daily_state.NutritionDailyLog | None,
+    understanding: NutritionMessageUnderstanding,
+    normalized_message: NormalizedNutritionMessage | None,
+) -> str:
+    if daily_log is None or not daily_log.situation_key:
+        return route_message
+
+    day_situation = daily_log.situation_key
+    if nutrition_daily_state.message_changes_day_type(message):
+        target_moment = _target_moment_for_routing(message, normalized_message)
+        if target_moment:
+            return f"{day_situation} {target_moment}"
+        if _message_wants_day_overview(
+            understanding=understanding,
+            normalized_message=normalized_message,
+        ):
+            return f"{day_situation} todo el dia"
+        return f"{day_situation} {route_message}".strip()
+
+    if not detect_situations(plan, route_message):
+        return f"{route_message} {day_situation}".strip()
+    return route_message
+
+
+def _target_moment_for_routing(
+    message: str,
+    normalized_message: NormalizedNutritionMessage | None,
+) -> str | None:
+    if normalized_message is not None and normalized_message.target_moment_key:
+        return normalized_message.target_moment_key
+    return _target_moment_from_message(normalize_text(message))
+
+
+def _routing_message_for_context(
+    message: str,
+    understanding: NutritionMessageUnderstanding,
+    *,
+    normalized_message: NormalizedNutritionMessage | None = None,
+) -> str:
+    if normalized_message is not None and normalized_message.route_message:
+        return normalized_message.route_message
+
+    normalized = normalize_text(message)
+    target_moment = _target_moment_from_message(normalized)
+
+    route_message = normalized
+    if "skipped_meal" in understanding.deviations:
+        route_message = re.sub(
+            r"\b(?:me he saltado|saltado|no he hecho)\s+"
+            r"(?:la|el)?\s*"
+            r"(?:media manana|desayuno|almuerzo|comida|merienda|cena)\b",
+            " ",
+            route_message,
+        )
+
+    if target_moment is not None:
+        route_message = _remove_logged_meal_context(
+            route_message,
+            target_moment=target_moment,
+        )
+
+    if _message_wants_day_overview(
+        understanding=understanding,
+        normalized_message=normalized_message,
+    ):
+        route_message = f"{route_message} todo el dia"
+
+    return re.sub(r"\s+", " ", route_message).strip()
+
+
+def _target_moment_from_message(normalized_message: str) -> str | None:
+    patterns: tuple[tuple[str, tuple[str, ...]], ...] = (
+        (
+            "cena",
+            (
+                r"\bque\s+(?:puedo\s+)?(?:tomar|comer|hacer|preparar)\s+"
+                r"para\s+(?:la\s+)?cena\b",
+                r"\bque\s+ceno\b",
+                r"\bpara\s+cenar\b",
+            ),
+        ),
+        (
+            "almuerzo",
+            (
+                r"\bque\s+(?:puedo\s+)?(?:tomar|comer|hacer|preparar)\s+"
+                r"para\s+(?:el\s+)?(?:almuerzo|mediodia|medio dia|comida)\b",
+                r"\bque\s+como\s+(?:al\s+)?(?:mediodia|medio dia)\b",
+            ),
+        ),
+        (
+            "desayuno",
+            (
+                r"\bque\s+(?:puedo\s+)?(?:tomar|comer|hacer|preparar)\s+"
+                r"para\s+(?:el\s+)?desayuno\b",
+                r"\bque\s+desayuno\b",
+            ),
+        ),
+        (
+            "merienda",
+            (
+                r"\bque\s+(?:puedo\s+)?(?:tomar|comer|hacer|preparar)\s+"
+                r"para\s+(?:la\s+)?merienda\b",
+                r"\bque\s+meriendo\b",
+            ),
+        ),
+    )
+    for moment_key, moment_patterns in patterns:
+        if any(
+            re.search(pattern, normalized_message) is not None
+            for pattern in moment_patterns
+        ):
+            return moment_key
+    return None
+
+
+def _remove_logged_meal_context(
+    route_message: str,
+    *,
+    target_moment: str,
+) -> str:
+    moment_terms_by_key = {
+        "desayuno": ("desayuno",),
+        "media_manana": ("media manana",),
+        "almuerzo": ("almuerzo", "comida", "mediodia", "medio dia"),
+        "merienda": ("merienda",),
+        "cena": ("cena",),
+    }
+    context_terms = [
+        re.escape(term)
+        for moment_key, terms in moment_terms_by_key.items()
+        if moment_key != target_moment
+        for term in terms
+    ]
+    if not context_terms:
+        return route_message
+
+    route_message = re.sub(
+        rf"\ben\s+(?:el|la)?\s*(?:{'|'.join(context_terms)})\s+.*?"
+        r"(?=\b(?:que|para)\b|$)",
+        " ",
+        route_message,
+    )
+    return re.sub(
+        rf"\ben\s+(?:el|la)?\s*(?:{'|'.join(context_terms)})\b",
+        " ",
+        route_message,
+    )
+
+
+def _looks_like_nutrition_routing_query(message: str, *, plan: NutritionPlan) -> bool:
+    normalized = normalize_text(message)
+    plan_terms = [
+        normalize_text(term)
+        for situation_key, situation in plan.situations.items()
+        for term in (situation_key, *_string_aliases(situation.get("aliases")))
+    ]
+    plan_terms.extend(
+        normalize_text(term)
+        for moment_key, moment in plan.moments.items()
+        for term in (moment_key, *_string_aliases(moment.get("aliases")))
+    )
+    if any(term and term in normalized for term in plan_terms):
+        return True
+
+    keywords = (
+        "que como",
+        "que comer",
+        "que puedo comer",
+        "todo lo que puedo comer",
+        "todo el dia",
+        "dia completo",
+        "plan del dia",
+        "comidas del dia",
+        "desayuno",
+        "almuerzo",
+        "comida",
+        "mediodia",
+        "merienda",
+        "cena",
+        "cenar",
+        "ceno",
+    )
+    return any(keyword in normalized for keyword in keywords)
+
+
+def _nutrition_clarification(resolution: MealResolution) -> str:
+    if resolution.status == "missing_situation":
+        options = _join_options(resolution.available_situations)
+        return f"Para ajustarlo al plan, dime que tipo de dia es: {options}."
+    if resolution.status == "missing_moment":
+        options = _join_options(resolution.available_moments)
+        return f"Te lo ajusto, pero dime el momento: {options}."
+    if resolution.status == "ambiguous_situation":
+        options = _join_options(match.label for match in resolution.situation_matches)
+        return f"Te he entendido varios contextos posibles: {options}. Cual usamos?"
+    if resolution.status == "ambiguous_moment":
+        options = _join_options(match.key for match in resolution.moment_matches)
+        return f"Te he entendido varios momentos posibles: {options}. Cual usamos?"
+    return "No tengo configurado que bloque usar para ese contexto del plan."
+
+
+def _join_options(options: Iterable[str]) -> str:
+    cleaned = [option for option in options if option]
+    if not cleaned:
+        return "desayuno, almuerzo, merienda o cena"
+    if len(cleaned) == 1:
+        return cleaned[0]
+    return ", ".join(cleaned[:-1]) + " o " + cleaned[-1]
+
+
+def _optional_state_text(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _nutrition_context_payload(resolution: MealResolution) -> dict[str, Any]:
+    if resolution.status == "resolved_day":
+        return {
+            "mode": "full_day",
+            "situation_key": resolution.situation_key,
+            "supplementation": list(resolution.supplementation),
+            "meal_blocks": [
+                {
+                    "moment_key": day_meal.moment_key,
+                    "moment_label": day_meal.moment_label,
+                    "meal_block_key": day_meal.meal_block_key,
+                    "meal_block": day_meal.meal_block,
+                }
+                for day_meal in resolution.day_meal_blocks
+            ],
+        }
+    return {
+        "mode": "single_meal",
+        "situation_key": resolution.situation_key,
+        "moment_key": resolution.moment_key,
+        "meal_block_key": resolution.meal_block_key,
+        "supplementation": list(resolution.supplementation),
+        "meal_block": resolution.meal_block,
+    }
+
+
+def _unresolved_context_payload(
+    *,
+    plan: NutritionPlan,
+    resolution: MealResolution,
+) -> dict[str, Any]:
+    selected_situations = (
+        tuple(match.key for match in resolution.situation_matches)
+        if resolution.situation_matches
+        else tuple(plan.situations.keys())
+    )
+    meal_keys = _meal_keys_for_situations(plan, selected_situations)
+    return {
+        "mode": "unresolved_with_memory_fallback",
+        "resolution_status": resolution.status,
+        "available_situations": list(resolution.available_situations),
+        "available_moments": list(resolution.available_moments),
+        "candidate_situations": {
+            situation_key: plan.situations[situation_key]
+            for situation_key in selected_situations
+            if situation_key in plan.situations
+        },
+        "candidate_meal_blocks": {
+            meal_key: plan.meals[meal_key]
+            for meal_key in meal_keys
+            if meal_key in plan.meals
+        },
+    }
+
+
+def _planning_context_payload(
+    *,
+    plan: NutritionPlan,
+    situation_matches: Sequence[SituationMatch],
+    situation_keys: Sequence[str] = (),
+    mode: str,
+) -> dict[str, Any]:
+    selected_situations = (
+        tuple(situation_keys)
+        if situation_keys
+        else (
+            tuple(match.key for match in situation_matches)
+            if situation_matches
+            else tuple(plan.situations.keys())
+        )
+    )
+    meal_keys = _meal_keys_for_situations(plan, selected_situations)
+    return {
+        "mode": mode,
+        "plan_id": plan.plan_id,
+        "situations": {
+            situation_key: plan.situations[situation_key]
+            for situation_key in selected_situations
+            if situation_key in plan.situations
+        },
+        "meal_blocks": {
+            meal_key: plan.meals[meal_key]
+            for meal_key in meal_keys
+            if meal_key in plan.meals
+        },
+    }
+
+
+def _attach_daily_log(
+    context: Mapping[str, Any],
+    *,
+    daily_log: nutrition_daily_state.NutritionDailyLog | None,
+) -> dict[str, Any]:
+    payload = dict(context)
+    daily_log_payload = nutrition_daily_state.to_prompt_payload(daily_log)
+    if daily_log_payload is not None:
+        payload["daily_log"] = daily_log_payload
+    return payload
+
+
+def _meal_keys_for_situations(
+    plan: NutritionPlan,
+    situation_keys: Sequence[str],
+) -> tuple[str, ...]:
+    meal_keys: list[str] = []
+    seen: set[str] = set()
+    for situation_key in situation_keys:
+        situation = plan.situations.get(situation_key, {})
+        moments = situation.get("momentos", {})
+        if not isinstance(moments, dict):
+            continue
+        for meal_key in moments.values():
+            if isinstance(meal_key, str) and meal_key not in seen:
+                seen.add(meal_key)
+                meal_keys.append(meal_key)
+    return tuple(meal_keys)
+
+
+def _available_situation_labels(
+    situations: Mapping[str, Mapping[str, Any]],
+) -> tuple[str, ...]:
+    labels: list[str] = []
+    for situation_key, situation in situations.items():
+        label = situation.get("label")
+        labels.append(
+            label.strip()
+            if isinstance(label, str) and label.strip()
+            else situation_key
+        )
+    return tuple(labels)
+
+
+def _string_aliases(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, str) and item.strip())
+
+
+def _runtime_context_instruction(
+    *,
+    context: Mapping[str, Any],
+    understanding: NutritionMessageUnderstanding,
+    normalized_message: NormalizedNutritionMessage | None,
+) -> str:
+    payload = {
+        "message_understanding": understanding.to_prompt_payload(),
+        "normalized_message": (
+            normalized_message.to_prompt_payload()
+            if normalized_message is not None
+            else None
+        ),
+        "nutrition_context": context,
+    }
+    return (
+        "Resolved nutrition plan context. Nutrition orchestration context "
+        "resolved before the LLM call. Use this as the active nutrition plan "
+        "context for the current answer.\n"
+        "- Use only foods, quantities, options, and meal blocks present here.\n"
+        "- Do not invent extra foods, recipes, calories, or macros.\n"
+        "- If the user asks for macros, use only macro values present in the "
+        "provided meal blocks; if a macro is missing, say that exact value is "
+        "not available.\n"
+        "- If the user asks for a weekly plan, produce a concrete plan from the "
+        "provided situations and meal blocks.\n"
+        "- If context mode is unresolved_with_memory_fallback, use memory and "
+        "conversation context to infer the situation or meal moment when it is "
+        "clear. If it is still unclear, ask one natural, specific question and "
+        "do not repeat a clarification that the user already answered.\n"
+        "- If the user reports a deviation, keep the next meal prudent without "
+        "punishment or aggressive compensation.\n"
+        "- Telegram format: maximo 5 lineas for single-meal answers; weekly "
+        "plans may be longer but still compact.\n"
+        "- No raw JSON unless the user explicitly asks.\n"
+        f"{json.dumps(payload, ensure_ascii=False)}"
+    )

--- a/src/forge_bot/nutrition/orchestrator.py
+++ b/src/forge_bot/nutrition/orchestrator.py
@@ -1076,9 +1076,7 @@ def _available_situation_labels(
     for situation_key, situation in situations.items():
         label = situation.get("label")
         labels.append(
-            label.strip()
-            if isinstance(label, str) and label.strip()
-            else situation_key
+            label.strip() if isinstance(label, str) and label.strip() else situation_key
         )
     return tuple(labels)
 

--- a/src/forge_bot/nutrition/plan.py
+++ b/src/forge_bot/nutrition/plan.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class NutritionPlanError(RuntimeError):
+    """Raised when a nutrition plan document is invalid."""
+
+
+@dataclass(frozen=True)
+class NutritionPlan:
+    """Validated nutrition plan shape used by the local router."""
+
+    plan_id: str
+    situations: Mapping[str, Mapping[str, Any]]
+    meals: Mapping[str, Mapping[str, Any]]
+
+    @property
+    def situation_keys(self) -> tuple[str, ...]:
+        return tuple(self.situations.keys())
+
+
+def parse_nutrition_plan(data: Mapping[str, Any]) -> NutritionPlan:
+    """Validate a loaded nutrition plan document for situation routing."""
+    plan_id = data.get("plan_id", "nutrition_plan")
+    if not isinstance(plan_id, str) or not plan_id.strip():
+        raise NutritionPlanError("Nutrition plan field 'plan_id' must be a string.")
+
+    situations = data.get("situaciones")
+    meals = data.get("comidas")
+    if not isinstance(situations, dict) or not situations:
+        raise NutritionPlanError("Nutrition plan requires non-empty 'situaciones'.")
+    if not isinstance(meals, dict) or not meals:
+        raise NutritionPlanError("Nutrition plan requires non-empty 'comidas'.")
+
+    _validate_meals(meals)
+    validated_situations = _validate_situations(situations, meals)
+    return NutritionPlan(
+        plan_id=plan_id.strip(),
+        situations=validated_situations,
+        meals=meals,
+    )
+
+
+def _validate_meals(meals: Mapping[str, Any]) -> None:
+    for meal_key, meal in meals.items():
+        if not isinstance(meal_key, str) or not meal_key.strip():
+            raise NutritionPlanError("Meal keys must be non-empty strings.")
+        if not isinstance(meal, dict):
+            raise NutritionPlanError(f"Meal '{meal_key}' must be an object.")
+        description = meal.get("descripcion")
+        if not isinstance(description, str) or not description.strip():
+            raise NutritionPlanError(
+                f"Meal '{meal_key}' must include non-empty 'descripcion'."
+            )
+
+
+def _validate_situations(
+    situations: Mapping[str, Any],
+    meals: Mapping[str, Any],
+) -> Mapping[str, Mapping[str, Any]]:
+    validated: dict[str, Mapping[str, Any]] = {}
+    for situation_key, situation in situations.items():
+        if not isinstance(situation_key, str) or not situation_key.strip():
+            raise NutritionPlanError("Situation keys must be non-empty strings.")
+        if not isinstance(situation, dict):
+            raise NutritionPlanError(f"Situation '{situation_key}' must be an object.")
+
+        aliases = situation.get("aliases", [])
+        if aliases is not None and not _is_string_list(aliases):
+            raise NutritionPlanError(
+                f"Situation '{situation_key}' field 'aliases' must be a string list."
+            )
+
+        supplementation = situation.get("suplementacion", [])
+        if supplementation is not None and not _is_string_list(supplementation):
+            raise NutritionPlanError(
+                f"Situation '{situation_key}' field 'suplementacion' must be a "
+                "string list."
+            )
+
+        moments = situation.get("momentos")
+        if not isinstance(moments, dict) or not moments:
+            raise NutritionPlanError(
+                f"Situation '{situation_key}' requires non-empty 'momentos'."
+            )
+        for moment_key, meal_key in moments.items():
+            if not isinstance(moment_key, str) or not moment_key.strip():
+                raise NutritionPlanError(
+                    f"Situation '{situation_key}' moment keys must be strings."
+                )
+            if not isinstance(meal_key, str) or not meal_key.strip():
+                raise NutritionPlanError(
+                    f"Situation '{situation_key}' moment '{moment_key}' must point "
+                    "to a meal key string."
+                )
+            if meal_key not in meals:
+                raise NutritionPlanError(
+                    f"Situation '{situation_key}' moment '{moment_key}' references "
+                    f"missing meal '{meal_key}'."
+                )
+        validated[situation_key] = situation
+    return validated
+
+
+def _is_string_list(value: object) -> bool:
+    return isinstance(value, list) and all(
+        isinstance(item, str) and item.strip() for item in value
+    )
+
+
+def load_nutrition_plan_file(
+    profile_root: Path,
+    plan_file: str,
+) -> NutritionPlan:
+    """Load a configured profile plan file and validate its JSON content."""
+    plan_path = _resolve_profile_plan_file(profile_root, plan_file)
+    try:
+        data = json.loads(plan_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise NutritionPlanError(
+            f"Nutrition plan file is not valid JSON: {plan_path}"
+        ) from exc
+    except OSError as exc:
+        raise NutritionPlanError(
+            f"Nutrition plan file could not be read: {plan_path}"
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise NutritionPlanError("Nutrition plan file must contain a JSON object.")
+    return parse_nutrition_plan(data)
+
+
+def _resolve_profile_plan_file(profile_root: Path, plan_file: str) -> Path:
+    if not plan_file.strip():
+        raise NutritionPlanError("Nutrition plan file path must not be empty.")
+    path = Path(plan_file)
+    if path.is_absolute():
+        raise NutritionPlanError("Nutrition plan file must use a relative path.")
+
+    profile_root_resolved = profile_root.resolve()
+    resolved = (profile_root / path).resolve()
+    if resolved != profile_root_resolved and profile_root_resolved not in (
+        resolved.parents
+    ):
+        raise NutritionPlanError(
+            "Nutrition plan file must stay inside the profile folder."
+        )
+    return resolved

--- a/src/forge_bot/nutrition/plan.py
+++ b/src/forge_bot/nutrition/plan.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+MEAL_OPERATOR_KEYS = ("and", "or")
+
 
 class NutritionPlanError(RuntimeError):
     """Raised when a nutrition plan document is invalid."""
@@ -63,6 +65,39 @@ def _validate_meals(meals: Mapping[str, Any]) -> None:
             raise NutritionPlanError(
                 f"Meal '{meal_key}' must include non-empty 'descripcion'."
             )
+        _validate_meal_node(meal, path=f"Meal '{meal_key}'")
+
+
+def _validate_meal_node(node: Any, *, path: str) -> None:
+    if isinstance(node, str):
+        if not node.strip():
+            raise NutritionPlanError(f"{path} cannot contain empty text options.")
+        return
+
+    if not isinstance(node, dict):
+        raise NutritionPlanError(f"{path} must be a text option or object.")
+
+    operator_keys = [key for key in MEAL_OPERATOR_KEYS if key in node]
+    if len(operator_keys) != 1:
+        raise NutritionPlanError(
+            f"{path} must include exactly one logical operator: 'and' or 'or'."
+        )
+    operator_key = operator_keys[0]
+    group = node[operator_key]
+    if not isinstance(group, list) or not group:
+        raise NutritionPlanError(
+            f"{path}.{operator_key} must be a non-empty list of options."
+        )
+
+    for metadata_key in ("condiciones", "notas", "warnings"):
+        metadata_value = node.get(metadata_key)
+        if metadata_value is not None and not _is_string_list(metadata_value):
+            raise NutritionPlanError(
+                f"{path} field '{metadata_key}' must be a string list."
+            )
+
+    for index, child in enumerate(group):
+        _validate_meal_node(child, path=f"{path}.{operator_key}[{index}]")
 
 
 def _validate_situations(

--- a/src/forge_bot/nutrition/plan.py
+++ b/src/forge_bot/nutrition/plan.py
@@ -16,6 +16,7 @@ class NutritionPlan:
     """Validated nutrition plan shape used by the local router."""
 
     plan_id: str
+    moments: Mapping[str, Mapping[str, Any]]
     situations: Mapping[str, Mapping[str, Any]]
     meals: Mapping[str, Mapping[str, Any]]
 
@@ -32,15 +33,20 @@ def parse_nutrition_plan(data: Mapping[str, Any]) -> NutritionPlan:
 
     situations = data.get("situaciones")
     meals = data.get("comidas")
+    moments = data.get("momentos", {})
+    if moments is not None and not isinstance(moments, dict):
+        raise NutritionPlanError("Nutrition plan field 'momentos' must be an object.")
     if not isinstance(situations, dict) or not situations:
         raise NutritionPlanError("Nutrition plan requires non-empty 'situaciones'.")
     if not isinstance(meals, dict) or not meals:
         raise NutritionPlanError("Nutrition plan requires non-empty 'comidas'.")
 
     _validate_meals(meals)
+    validated_moments = _validate_moments(moments or {})
     validated_situations = _validate_situations(situations, meals)
     return NutritionPlan(
         plan_id=plan_id.strip(),
+        moments=validated_moments,
         situations=validated_situations,
         meals=meals,
     )
@@ -107,18 +113,35 @@ def _validate_situations(
     return validated
 
 
+def _validate_moments(moments: Mapping[str, Any]) -> Mapping[str, Mapping[str, Any]]:
+    validated: dict[str, Mapping[str, Any]] = {}
+    for moment_key, moment in moments.items():
+        if not isinstance(moment_key, str) or not moment_key.strip():
+            raise NutritionPlanError("Moment keys must be non-empty strings.")
+        if not isinstance(moment, dict):
+            raise NutritionPlanError(f"Moment '{moment_key}' must be an object.")
+        aliases = moment.get("aliases", [])
+        if aliases is not None and not _is_string_list(aliases):
+            raise NutritionPlanError(
+                f"Moment '{moment_key}' field 'aliases' must be a string list."
+            )
+        label = moment.get("label")
+        if label is not None and (not isinstance(label, str) or not label.strip()):
+            raise NutritionPlanError(
+                f"Moment '{moment_key}' field 'label' must be a non-empty string."
+            )
+        validated[moment_key] = moment
+    return validated
+
+
 def _is_string_list(value: object) -> bool:
     return isinstance(value, list) and all(
         isinstance(item, str) and item.strip() for item in value
     )
 
 
-def load_nutrition_plan_file(
-    profile_root: Path,
-    plan_file: str,
-) -> NutritionPlan:
-    """Load a configured profile plan file and validate its JSON content."""
-    plan_path = _resolve_profile_plan_file(profile_root, plan_file)
+def load_nutrition_plan_file(plan_path: Path) -> NutritionPlan:
+    """Load a configured nutrition plan file and validate its JSON content."""
     try:
         data = json.loads(plan_path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
@@ -133,21 +156,3 @@ def load_nutrition_plan_file(
     if not isinstance(data, dict):
         raise NutritionPlanError("Nutrition plan file must contain a JSON object.")
     return parse_nutrition_plan(data)
-
-
-def _resolve_profile_plan_file(profile_root: Path, plan_file: str) -> Path:
-    if not plan_file.strip():
-        raise NutritionPlanError("Nutrition plan file path must not be empty.")
-    path = Path(plan_file)
-    if path.is_absolute():
-        raise NutritionPlanError("Nutrition plan file must use a relative path.")
-
-    profile_root_resolved = profile_root.resolve()
-    resolved = (profile_root / path).resolve()
-    if resolved != profile_root_resolved and profile_root_resolved not in (
-        resolved.parents
-    ):
-        raise NutritionPlanError(
-            "Nutrition plan file must stay inside the profile folder."
-        )
-    return resolved

--- a/src/forge_bot/nutrition/plan_normalizer.py
+++ b/src/forge_bot/nutrition/plan_normalizer.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from ..prompting import ChatMessage
+from .normalizer import parse_json_object
+from .plan import NutritionPlan, NutritionPlanError, parse_nutrition_plan
+
+logger = logging.getLogger(__name__)
+
+
+class NutritionPlanNormalizerClient(Protocol):
+    """Small chat interface used to normalize uploaded nutrition plans."""
+
+    async def chat(self, *, model: str, messages: list[ChatMessage]) -> str:
+        """Return the provider response for the normalization prompt."""
+
+
+@dataclass(frozen=True)
+class NormalizedPlanDocument:
+    """Validated uploaded nutrition plan ready to persist."""
+
+    content: Mapping[str, Any]
+    plan: NutritionPlan
+    normalized_by_llm: bool
+
+
+async def normalize_uploaded_plan(
+    *,
+    raw_text: str,
+    client: NutritionPlanNormalizerClient | None,
+    model: str | None,
+) -> NormalizedPlanDocument:
+    """Normalize and validate an uploaded JSON plan document."""
+    local_payload = _json_object_from_text(raw_text)
+    if client is not None and model:
+        try:
+            llm_payload = await _normalize_with_llm(
+                raw_text=raw_text,
+                client=client,
+                model=model,
+                local_payload=local_payload,
+            )
+            return _validated_document(llm_payload, normalized_by_llm=True)
+        except Exception:
+            logger.warning("nutrition_plan_llm_normalization_failed", exc_info=True)
+
+    if local_payload is None:
+        raise NutritionPlanError(
+            "El fichero debe contener JSON valido o poder normalizarse con el LLM."
+        )
+    return _validated_document(local_payload, normalized_by_llm=False)
+
+
+async def _normalize_with_llm(
+    *,
+    raw_text: str,
+    client: NutritionPlanNormalizerClient,
+    model: str,
+    local_payload: Mapping[str, Any] | None,
+) -> Mapping[str, Any]:
+    response = await client.chat(
+        model=model,
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "/no_think\n"
+                    "Normaliza un plan nutricional en JSON estricto para un bot. "
+                    "Devuelve solo un objeto JSON. No inventes comidas ni "
+                    "cantidades: conserva lo que exista en la entrada. Si la "
+                    "entrada ya contiene JSON correcto, limpialo y normalizalo "
+                    "sin cambiar el significado.\n\n"
+                    "Contrato obligatorio:\n"
+                    "{"
+                    '"plan_id": string, '
+                    '"momentos": {"moment_key": {"label": string, '
+                    '"aliases": string[]}}, '
+                    '"situaciones": {'
+                    '"situation_key": {'
+                    '"label": string, '
+                    '"aliases": string[], '
+                    '"tipo_dia": string|null, '
+                    '"suplementacion": string[], '
+                    '"momentos": {"moment_key": "comida_key"}'
+                    "}"
+                    "}, "
+                    '"comidas": {'
+                    '"comida_key": {'
+                    '"descripcion": string, '
+                    '"macros_plan": object|null, '
+                    '"and": array, '
+                    '"or": array'
+                    "}"
+                    "}, "
+                    '"reglas_adaptacion": object|null, '
+                    '"recetas": array|null'
+                    "}\n\n"
+                    "Reglas:\n"
+                    "- Todas las referencias situaciones.*.momentos deben apuntar "
+                    "a claves existentes en comidas.\n"
+                    "- Si la entrada trae ficheros separados de situaciones.json "
+                    "y comidas.json dentro del mismo objeto, conserva ambas "
+                    "raices como `situaciones` y `comidas`.\n"
+                    "- Los nombres de claves deben ser snake_case sin acentos.\n"
+                    "- Mantén grupos and/or anidados si existen.\n"
+                    "- Conserva macros_plan cuando exista; no calcules macros "
+                    "nuevos.\n"
+                    "- Conserva reglas_adaptacion si existen porque guian "
+                    "conversiones y ajustes de recetas.\n"
+                    "- Conserva recetas si existen, sin usarlas para cambiar "
+                    "cantidades del plan.\n"
+                    "- Si faltan aliases, crea aliases obvios desde label/clave.\n"
+                    "- Si falta plan_id, usa user_nutrition_plan.\n"
+                    "- No añadas situaciones ni alimentos nuevos.\n"
+                    "- No expliques nada fuera del JSON."
+                ),
+            },
+            {
+                "role": "user",
+                "content": _normalizer_user_payload(
+                    raw_text=raw_text,
+                    local_payload=local_payload,
+                ),
+            },
+        ],
+    )
+    payload = parse_json_object(response)
+    if payload is None:
+        raise NutritionPlanError("El LLM no devolvio JSON valido.")
+    return payload
+
+
+def _normalizer_user_payload(
+    *,
+    raw_text: str,
+    local_payload: Mapping[str, Any] | None,
+) -> str:
+    if local_payload is not None:
+        return json.dumps(local_payload, ensure_ascii=False)
+    return raw_text[:120_000]
+
+
+def _validated_document(
+    payload: Mapping[str, Any],
+    *,
+    normalized_by_llm: bool,
+) -> NormalizedPlanDocument:
+    plan = parse_nutrition_plan(payload)
+    return NormalizedPlanDocument(
+        content=payload,
+        plan=plan,
+        normalized_by_llm=normalized_by_llm,
+    )
+
+
+def _json_object_from_text(raw_text: str) -> Mapping[str, Any] | None:
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError:
+        payload = parse_json_object(raw_text)
+    return payload if isinstance(payload, dict) else None

--- a/src/forge_bot/nutrition/plan_store.py
+++ b/src/forge_bot/nutrition/plan_store.py
@@ -1,0 +1,521 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import psycopg
+from psycopg.types.json import Jsonb
+
+from ..database import conect_db
+from .plan import NutritionPlan, parse_nutrition_plan
+
+logger = logging.getLogger(__name__)
+
+LEGACY_NUTRITION_PLAN_DOCUMENT_TYPE = "meal_plan"
+NUTRITION_PLAN_SITUATIONS_DOCUMENT_TYPE = "situaciones"
+NUTRITION_PLAN_MEALS_DOCUMENT_TYPE = "comidas"
+NUTRITION_PLAN_ADAPTATION_RULES_DOCUMENT_TYPE = "reglas_adaptacion"
+NUTRITION_PLAN_RECIPES_DOCUMENT_TYPE = "recetas"
+
+
+class NutritionPlanStoreError(RuntimeError):
+    """Raised when nutrition plan persistence cannot complete."""
+
+
+@dataclass(frozen=True)
+class SavedNutritionPlan:
+    """Stored active nutrition plan metadata."""
+
+    plan_uuid: str
+    user_id: int
+    plan: NutritionPlan
+
+
+@dataclass(frozen=True)
+class SavedNutritionPlanPart:
+    """Result of storing one partial plan document."""
+
+    plan_uuid: str
+    user_id: int
+    document_type: str
+    missing_document_types: tuple[str, ...]
+    activated_plan: NutritionPlan | None = None
+
+    @property
+    def activated(self) -> bool:
+        return self.activated_plan is not None
+
+
+@dataclass(frozen=True)
+class ActiveNutritionPlanDocuments:
+    """Raw JSONB documents stored for the active nutrition plan."""
+
+    plan_uuid: str
+    documents: Mapping[str, Mapping[str, Any]]
+    combined: Mapping[str, Any]
+
+
+def load_active_nutrition_plan(*, user_id: int) -> NutritionPlan | None:
+    """Load the active normalized nutrition plan for one internal user."""
+    connection = conect_db()
+    if connection is None:
+        return None
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT p.id AS plan_uuid, d.document_type, d.content
+                FROM nutrition_plans p
+                JOIN nutrition_plan_documents d ON d.plan_id = p.id
+                WHERE p.id = (
+                    SELECT id
+                    FROM nutrition_plans
+                    WHERE user_id = %s
+                      AND status = 'active'
+                    ORDER BY updated_at DESC, created_at DESC
+                    LIMIT 1
+                )
+                """,
+                (user_id,),
+            )
+            rows = list(cursor.fetchall())
+    except psycopg.Error:
+        logger.exception("nutrition_active_plan_load_failed user_id=%s", user_id)
+        return None
+    finally:
+        connection.close()
+
+    if not rows:
+        return None
+    content = _combine_plan_documents(rows)
+    if content is None:
+        logger.warning("nutrition_active_plan_invalid_content user_id=%s", user_id)
+        return None
+    try:
+        return parse_nutrition_plan(content)
+    except Exception:
+        logger.exception("nutrition_active_plan_parse_failed user_id=%s", user_id)
+        return None
+
+
+def load_active_nutrition_plan_documents(
+    *,
+    user_id: int,
+) -> ActiveNutritionPlanDocuments | None:
+    """Load raw active plan documents for user-facing review/export."""
+    connection = conect_db()
+    if connection is None:
+        return None
+    try:
+        with connection.cursor() as cursor:
+            rows = _fetch_active_plan_document_rows(cursor=cursor, user_id=user_id)
+    except psycopg.Error:
+        logger.exception(
+            "nutrition_active_plan_documents_load_failed user_id=%s",
+            user_id,
+        )
+        return None
+    finally:
+        connection.close()
+
+    if not rows:
+        return None
+    combined = _combine_plan_documents(rows)
+    if combined is None:
+        return None
+
+    documents: dict[str, Mapping[str, Any]] = {}
+    plan_uuid = ""
+    for row in rows:
+        if not plan_uuid and row.get("plan_uuid") is not None:
+            plan_uuid = str(row["plan_uuid"])
+        document_type = row.get("document_type")
+        content = row.get("content")
+        if isinstance(document_type, str) and isinstance(content, dict):
+            documents[document_type] = content
+    return ActiveNutritionPlanDocuments(
+        plan_uuid=plan_uuid,
+        documents=documents,
+        combined=combined,
+    )
+
+
+def save_active_nutrition_plan(
+    *,
+    user_id: int,
+    plan_data: Mapping[str, Any],
+    source_filename: str | None = None,
+) -> SavedNutritionPlan:
+    """Archive the current active plan and store a new active normalized plan."""
+    plan = parse_nutrition_plan(plan_data)
+    connection = conect_db()
+    if connection is None:
+        raise NutritionPlanStoreError("La base de datos no esta disponible.")
+
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                UPDATE nutrition_plans
+                SET status = 'archived',
+                    updated_at = NOW()
+                WHERE user_id = %s
+                  AND status = 'active'
+                """,
+                (user_id,),
+            )
+            cursor.execute(
+                """
+                INSERT INTO nutrition_plans (user_id, status, source_filename)
+                VALUES (%s, 'active', %s)
+                RETURNING id
+                """,
+                (user_id, source_filename),
+            )
+            row = cursor.fetchone()
+            if row is None:
+                raise NutritionPlanStoreError("No se pudo crear el plan.")
+            plan_uuid = str(row["id"])
+            cursor.execute(
+                """
+                INSERT INTO nutrition_plan_documents (
+                    plan_id, document_type, content
+                )
+                VALUES (%s, %s, %s)
+                """,
+                (
+                    plan_uuid,
+                    NUTRITION_PLAN_SITUATIONS_DOCUMENT_TYPE,
+                    Jsonb(
+                        {
+                            "plan_id": plan.plan_id,
+                            "situaciones": dict(plan_data["situaciones"]),
+                        }
+                    ),
+                ),
+            )
+            cursor.execute(
+                """
+                INSERT INTO nutrition_plan_documents (
+                    plan_id, document_type, content
+                )
+                VALUES (%s, %s, %s)
+                """,
+                (
+                    plan_uuid,
+                    NUTRITION_PLAN_MEALS_DOCUMENT_TYPE,
+                    Jsonb(
+                        {
+                            "plan_id": plan.plan_id,
+                            "comidas": dict(plan_data["comidas"]),
+                        }
+                    ),
+                ),
+            )
+            _insert_optional_document(
+                cursor=cursor,
+                plan_uuid=plan_uuid,
+                plan_data=plan_data,
+                source_key="reglas_adaptacion",
+                document_type=NUTRITION_PLAN_ADAPTATION_RULES_DOCUMENT_TYPE,
+            )
+            _insert_optional_document(
+                cursor=cursor,
+                plan_uuid=plan_uuid,
+                plan_data=plan_data,
+                source_key="recetas",
+                document_type=NUTRITION_PLAN_RECIPES_DOCUMENT_TYPE,
+            )
+        connection.commit()
+        return SavedNutritionPlan(plan_uuid=plan_uuid, user_id=user_id, plan=plan)
+    except NutritionPlanStoreError:
+        connection.rollback()
+        raise
+    except Exception as exc:
+        connection.rollback()
+        raise NutritionPlanStoreError(
+            "No se pudo guardar el plan nutricional."
+        ) from exc
+    finally:
+        connection.close()
+
+
+def save_nutrition_plan_part(
+    *,
+    user_id: int,
+    document_type: str,
+    content: Mapping[str, Any],
+    source_filename: str | None = None,
+) -> SavedNutritionPlanPart:
+    """Store one uploaded plan part and activate the draft once complete."""
+    if document_type not in {
+        NUTRITION_PLAN_SITUATIONS_DOCUMENT_TYPE,
+        NUTRITION_PLAN_MEALS_DOCUMENT_TYPE,
+    }:
+        raise NutritionPlanStoreError("Tipo de documento de plan no soportado.")
+    _validate_plan_part(document_type=document_type, content=content)
+
+    connection = conect_db()
+    if connection is None:
+        raise NutritionPlanStoreError("La base de datos no esta disponible.")
+
+    try:
+        with connection.cursor() as cursor:
+            plan_uuid = _get_or_create_draft_plan(
+                cursor=cursor,
+                user_id=user_id,
+                source_filename=source_filename,
+            )
+            _upsert_plan_document(
+                cursor=cursor,
+                plan_uuid=plan_uuid,
+                document_type=document_type,
+                content=content,
+            )
+            draft_documents = _fetch_plan_documents(cursor=cursor, plan_uuid=plan_uuid)
+            combined = _combine_plan_documents(draft_documents)
+            if combined is None:
+                connection.commit()
+                return SavedNutritionPlanPart(
+                    plan_uuid=plan_uuid,
+                    user_id=user_id,
+                    document_type=document_type,
+                    missing_document_types=_missing_required_documents(
+                        draft_documents
+                    ),
+                )
+
+            plan = parse_nutrition_plan(combined)
+            cursor.execute(
+                """
+                UPDATE nutrition_plans
+                SET status = 'archived',
+                    updated_at = NOW()
+                WHERE user_id = %s
+                  AND status = 'active'
+                """,
+                (user_id,),
+            )
+            cursor.execute(
+                """
+                UPDATE nutrition_plans
+                SET status = 'active',
+                    updated_at = NOW()
+                WHERE id = %s
+                """,
+                (plan_uuid,),
+            )
+            connection.commit()
+            return SavedNutritionPlanPart(
+                plan_uuid=plan_uuid,
+                user_id=user_id,
+                document_type=document_type,
+                missing_document_types=(),
+                activated_plan=plan,
+            )
+    except NutritionPlanStoreError:
+        connection.rollback()
+        raise
+    except Exception as exc:
+        connection.rollback()
+        raise NutritionPlanStoreError(
+            "No se pudo guardar esa parte del plan nutricional."
+        ) from exc
+    finally:
+        connection.close()
+
+
+def _get_or_create_draft_plan(
+    *,
+    cursor: Any,
+    user_id: int,
+    source_filename: str | None,
+) -> str:
+    cursor.execute(
+        """
+        SELECT id
+        FROM nutrition_plans
+        WHERE user_id = %s
+          AND status = 'draft'
+        ORDER BY updated_at DESC, created_at DESC
+        LIMIT 1
+        """,
+        (user_id,),
+    )
+    row = cursor.fetchone()
+    if row is not None:
+        plan_uuid = str(row["id"])
+        cursor.execute(
+            """
+            UPDATE nutrition_plans
+            SET source_filename = COALESCE(%s, source_filename),
+                updated_at = NOW()
+            WHERE id = %s
+            """,
+            (source_filename, plan_uuid),
+        )
+        return plan_uuid
+
+    cursor.execute(
+        """
+        INSERT INTO nutrition_plans (user_id, status, source_filename)
+        VALUES (%s, 'draft', %s)
+        RETURNING id
+        """,
+        (user_id, source_filename),
+    )
+    created = cursor.fetchone()
+    if created is None:
+        raise NutritionPlanStoreError("No se pudo crear el borrador del plan.")
+    return str(created["id"])
+
+
+def _upsert_plan_document(
+    *,
+    cursor: Any,
+    plan_uuid: str,
+    document_type: str,
+    content: Mapping[str, Any],
+) -> None:
+    cursor.execute(
+        """
+        INSERT INTO nutrition_plan_documents (
+            plan_id, document_type, content
+        )
+        VALUES (%s, %s, %s)
+        ON CONFLICT (plan_id, document_type)
+        DO UPDATE SET content = EXCLUDED.content,
+                      updated_at = NOW()
+        """,
+        (plan_uuid, document_type, Jsonb(dict(content))),
+    )
+
+
+def _fetch_plan_documents(
+    *,
+    cursor: Any,
+    plan_uuid: str,
+) -> list[Mapping[str, Any]]:
+    cursor.execute(
+        """
+        SELECT document_type, content
+        FROM nutrition_plan_documents
+        WHERE plan_id = %s
+        """,
+        (plan_uuid,),
+    )
+    return list(cursor.fetchall())
+
+
+def _fetch_active_plan_document_rows(
+    *,
+    cursor: Any,
+    user_id: int,
+) -> list[Mapping[str, Any]]:
+    cursor.execute(
+        """
+        SELECT p.id AS plan_uuid, d.document_type, d.content
+        FROM nutrition_plans p
+        JOIN nutrition_plan_documents d ON d.plan_id = p.id
+        WHERE p.id = (
+            SELECT id
+            FROM nutrition_plans
+            WHERE user_id = %s
+              AND status = 'active'
+            ORDER BY updated_at DESC, created_at DESC
+            LIMIT 1
+        )
+        ORDER BY d.document_type
+        """,
+        (user_id,),
+    )
+    return list(cursor.fetchall())
+
+
+def _insert_optional_document(
+    *,
+    cursor: Any,
+    plan_uuid: str,
+    plan_data: Mapping[str, Any],
+    source_key: str,
+    document_type: str,
+) -> None:
+    content = plan_data.get(source_key)
+    if not isinstance(content, (dict, list)):
+        return
+    cursor.execute(
+        """
+        INSERT INTO nutrition_plan_documents (
+            plan_id, document_type, content
+        )
+        VALUES (%s, %s, %s)
+        """,
+        (plan_uuid, document_type, Jsonb({source_key: content})),
+    )
+
+
+def _combine_plan_documents(
+    rows: list[Mapping[str, Any]],
+) -> dict[str, Any] | None:
+    combined: dict[str, Any] = {"plan_id": "nutrition_plan"}
+    for row in rows:
+        document_type = row.get("document_type")
+        content = row.get("content")
+        if not isinstance(content, dict):
+            continue
+        plan_id = content.get("plan_id")
+        if isinstance(plan_id, str) and plan_id.strip():
+            combined["plan_id"] = plan_id.strip()
+        if document_type == LEGACY_NUTRITION_PLAN_DOCUMENT_TYPE:
+            return dict(content)
+        if document_type == NUTRITION_PLAN_SITUATIONS_DOCUMENT_TYPE:
+            situations = content.get("situaciones")
+            if isinstance(situations, dict):
+                combined["situaciones"] = situations
+        elif document_type == NUTRITION_PLAN_MEALS_DOCUMENT_TYPE:
+            meals = content.get("comidas")
+            if isinstance(meals, dict):
+                combined["comidas"] = meals
+        elif document_type == NUTRITION_PLAN_ADAPTATION_RULES_DOCUMENT_TYPE:
+            rules = content.get("reglas_adaptacion")
+            if isinstance(rules, dict):
+                combined["reglas_adaptacion"] = rules
+        elif document_type == NUTRITION_PLAN_RECIPES_DOCUMENT_TYPE:
+            recipes = content.get("recetas")
+            if isinstance(recipes, (dict, list)):
+                combined["recetas"] = recipes
+
+    if "situaciones" not in combined or "comidas" not in combined:
+        return None
+    return combined
+
+
+def _missing_required_documents(
+    rows: list[Mapping[str, Any]],
+) -> tuple[str, ...]:
+    document_types = {
+        row.get("document_type")
+        for row in rows
+        if isinstance(row.get("document_type"), str)
+    }
+    missing: list[str] = []
+    if NUTRITION_PLAN_SITUATIONS_DOCUMENT_TYPE not in document_types:
+        missing.append(NUTRITION_PLAN_SITUATIONS_DOCUMENT_TYPE)
+    if NUTRITION_PLAN_MEALS_DOCUMENT_TYPE not in document_types:
+        missing.append(NUTRITION_PLAN_MEALS_DOCUMENT_TYPE)
+    return tuple(missing)
+
+
+def _validate_plan_part(
+    *,
+    document_type: str,
+    content: Mapping[str, Any],
+) -> None:
+    root_key = document_type
+    value = content.get(root_key)
+    if not isinstance(value, dict) or not value:
+        raise NutritionPlanStoreError(
+            f"El fichero debe contener un objeto raiz '{root_key}'."
+        )

--- a/src/forge_bot/nutrition/plan_store.py
+++ b/src/forge_bot/nutrition/plan_store.py
@@ -178,6 +178,14 @@ def save_active_nutrition_plan(
             if row is None:
                 raise NutritionPlanStoreError("No se pudo crear el plan.")
             plan_uuid = str(row["id"])
+            situations_document: dict[str, Any] = {
+                "plan_id": plan.plan_id,
+                "situaciones": dict(plan_data["situaciones"]),
+            }
+            moments = plan_data.get("momentos")
+            if isinstance(moments, dict):
+                situations_document["momentos"] = dict(moments)
+
             cursor.execute(
                 """
                 INSERT INTO nutrition_plan_documents (
@@ -188,12 +196,7 @@ def save_active_nutrition_plan(
                 (
                     plan_uuid,
                     NUTRITION_PLAN_SITUATIONS_DOCUMENT_TYPE,
-                    Jsonb(
-                        {
-                            "plan_id": plan.plan_id,
-                            "situaciones": dict(plan_data["situaciones"]),
-                        }
-                    ),
+                    Jsonb(situations_document),
                 ),
             )
             cursor.execute(
@@ -474,6 +477,9 @@ def _combine_plan_documents(
             situations = content.get("situaciones")
             if isinstance(situations, dict):
                 combined["situaciones"] = situations
+            moments = content.get("momentos")
+            if isinstance(moments, dict):
+                combined["momentos"] = moments
         elif document_type == NUTRITION_PLAN_MEALS_DOCUMENT_TYPE:
             meals = content.get("comidas")
             if isinstance(meals, dict):

--- a/src/forge_bot/nutrition/plan_store.py
+++ b/src/forge_bot/nutrition/plan_store.py
@@ -285,9 +285,7 @@ def save_nutrition_plan_part(
                     plan_uuid=plan_uuid,
                     user_id=user_id,
                     document_type=document_type,
-                    missing_document_types=_missing_required_documents(
-                        draft_documents
-                    ),
+                    missing_document_types=_missing_required_documents(draft_documents),
                 )
 
             plan = parse_nutrition_plan(combined)

--- a/src/forge_bot/nutrition/router.py
+++ b/src/forge_bot/nutrition/router.py
@@ -372,9 +372,11 @@ def _available_moments(
     if not isinstance(moments, dict):
         return ()
     return _dedupe_labels(
-        _moment_label(plan, str(moment))
-        for moment in moments.keys()
-        if not plan.moments or moment in plan.moments
+        tuple(
+            _moment_label(plan, str(moment))
+            for moment in moments.keys()
+            if not plan.moments or moment in plan.moments
+        )
     )
 
 

--- a/src/forge_bot/nutrition/router.py
+++ b/src/forge_bot/nutrition/router.py
@@ -122,9 +122,7 @@ def detect_moments(plan: NutritionPlan, message: str) -> tuple[MomentMatch, ...]
     matches: list[MomentMatch] = []
     for moment_key, aliases in _moment_aliases(plan).items():
         matched = tuple(
-            alias
-            for alias in aliases
-            if _contains_alias(normalized_message, alias)
+            alias for alias in aliases if _contains_alias(normalized_message, alias)
         )
         if matched:
             matches.append(MomentMatch(key=moment_key, matched_aliases=matched))

--- a/src/forge_bot/nutrition/router.py
+++ b/src/forge_bot/nutrition/router.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from .plan import NutritionPlan
+
+ResolutionStatus = Literal[
+    "resolved",
+    "missing_situation",
+    "missing_moment",
+    "ambiguous_situation",
+    "ambiguous_moment",
+    "invalid_mapping",
+]
+
+MOMENT_ALIASES: Mapping[str, tuple[str, ...]] = {
+    "desayuno": ("desayuno", "desayunar"),
+    "almuerzo": ("almuerzo", "comida", "comer", "mediodia", "medio dia"),
+    "merienda": ("merienda", "merendar", "media tarde", "pre entreno"),
+    "cena": ("cena", "cenar", "ceno", "noche"),
+}
+
+
+@dataclass(frozen=True)
+class SituationMatch:
+    """Situation detected from configured plan aliases."""
+
+    key: str
+    label: str
+    matched_aliases: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MomentMatch:
+    """Meal moment detected from natural language aliases."""
+
+    key: str
+    matched_aliases: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MealResolution:
+    """Result of routing one user message to a meal block."""
+
+    status: ResolutionStatus
+    situation_key: str | None = None
+    moment_key: str | None = None
+    meal_block_key: str | None = None
+    meal_block: Mapping[str, Any] | None = None
+    supplementation: tuple[str, ...] = ()
+    situation_matches: tuple[SituationMatch, ...] = ()
+    moment_matches: tuple[MomentMatch, ...] = ()
+    available_situations: tuple[str, ...] = ()
+    available_moments: tuple[str, ...] = ()
+
+    @property
+    def is_resolved(self) -> bool:
+        return self.status == "resolved"
+
+
+def normalize_text(text: str) -> str:
+    """Normalize user text for cheap alias matching."""
+    decomposed = unicodedata.normalize("NFD", text.lower())
+    without_accents = "".join(
+        char for char in decomposed if unicodedata.category(char) != "Mn"
+    )
+    cleaned = re.sub(r"[^a-z0-9_]+", " ", without_accents)
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def detect_situations(plan: NutritionPlan, message: str) -> tuple[SituationMatch, ...]:
+    """Return situation candidates detected from configured aliases."""
+    normalized_message = normalize_text(message)
+    matches: list[SituationMatch] = []
+    for situation_key, situation in plan.situations.items():
+        aliases = _situation_aliases(situation_key, situation)
+        matched = tuple(
+            alias for alias in aliases if _contains_alias(normalized_message, alias)
+        )
+        if matched:
+            matches.append(
+                SituationMatch(
+                    key=situation_key,
+                    label=_situation_label(situation_key, situation),
+                    matched_aliases=matched,
+                )
+            )
+    return tuple(matches)
+
+
+def detect_moments(message: str) -> tuple[MomentMatch, ...]:
+    """Return meal moment candidates detected from built-in Spanish aliases."""
+    normalized_message = normalize_text(message)
+    matches: list[MomentMatch] = []
+    for moment_key, aliases in MOMENT_ALIASES.items():
+        normalized_aliases = tuple(normalize_text(alias) for alias in aliases)
+        matched = tuple(
+            alias
+            for alias in normalized_aliases
+            if _contains_alias(normalized_message, alias)
+        )
+        if matched:
+            matches.append(MomentMatch(key=moment_key, matched_aliases=matched))
+    return tuple(matches)
+
+
+def resolve_meal_context(plan: NutritionPlan, message: str) -> MealResolution:
+    """Resolve one natural language message to the smallest useful meal chunk."""
+    situation_matches = detect_situations(plan, message)
+    moment_matches = detect_moments(message)
+    available_situations = _available_situations(plan)
+    available_moments = _available_moments(plan, situation_matches)
+
+    if not situation_matches:
+        return MealResolution(
+            status="missing_situation",
+            moment_matches=moment_matches,
+            available_situations=available_situations,
+            available_moments=available_moments,
+        )
+    if len(situation_matches) > 1:
+        return MealResolution(
+            status="ambiguous_situation",
+            situation_matches=situation_matches,
+            moment_matches=moment_matches,
+            available_situations=available_situations,
+            available_moments=available_moments,
+        )
+    if not moment_matches:
+        return MealResolution(
+            status="missing_moment",
+            situation_key=situation_matches[0].key,
+            situation_matches=situation_matches,
+            available_situations=available_situations,
+            available_moments=available_moments,
+        )
+    if len(moment_matches) > 1:
+        return MealResolution(
+            status="ambiguous_moment",
+            situation_key=situation_matches[0].key,
+            situation_matches=situation_matches,
+            moment_matches=moment_matches,
+            available_situations=available_situations,
+            available_moments=available_moments,
+        )
+
+    situation_key = situation_matches[0].key
+    moment_key = moment_matches[0].key
+    situation = plan.situations[situation_key]
+    moments = situation.get("momentos", {})
+    meal_block_key = moments.get(moment_key) if isinstance(moments, dict) else None
+    if not isinstance(meal_block_key, str):
+        return MealResolution(
+            status="invalid_mapping",
+            situation_key=situation_key,
+            moment_key=moment_key,
+            situation_matches=situation_matches,
+            moment_matches=moment_matches,
+            available_situations=available_situations,
+            available_moments=available_moments,
+        )
+    meal_block = plan.meals.get(meal_block_key)
+    if not isinstance(meal_block, dict):
+        return MealResolution(
+            status="invalid_mapping",
+            situation_key=situation_key,
+            moment_key=moment_key,
+            meal_block_key=meal_block_key,
+            situation_matches=situation_matches,
+            moment_matches=moment_matches,
+            available_situations=available_situations,
+            available_moments=available_moments,
+        )
+
+    return MealResolution(
+        status="resolved",
+        situation_key=situation_key,
+        moment_key=moment_key,
+        meal_block_key=meal_block_key,
+        meal_block=meal_block,
+        supplementation=_supplementation(situation),
+        situation_matches=situation_matches,
+        moment_matches=moment_matches,
+        available_situations=available_situations,
+        available_moments=available_moments,
+    )
+
+
+def _situation_aliases(
+    situation_key: str,
+    situation: Mapping[str, Any],
+) -> tuple[str, ...]:
+    aliases = situation.get("aliases", [])
+    values = [situation_key]
+    if isinstance(aliases, list):
+        values.extend(alias for alias in aliases if isinstance(alias, str))
+    return _dedupe_normalized(values)
+
+
+def _dedupe_normalized(values: Sequence[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for value in values:
+        alias = normalize_text(value)
+        if alias and alias not in seen:
+            seen.add(alias)
+            normalized.append(alias)
+    return tuple(normalized)
+
+
+def _contains_alias(normalized_message: str, normalized_alias: str) -> bool:
+    if not normalized_alias:
+        return False
+    alias_pattern = r"\s+".join(re.escape(part) for part in normalized_alias.split())
+    return re.search(rf"(?<!\w){alias_pattern}(?!\w)", normalized_message) is not None
+
+
+def _situation_label(situation_key: str, situation: Mapping[str, Any]) -> str:
+    label = situation.get("label")
+    return label.strip() if isinstance(label, str) and label.strip() else situation_key
+
+
+def _available_situations(plan: NutritionPlan) -> tuple[str, ...]:
+    return tuple(
+        _situation_label(situation_key, situation)
+        for situation_key, situation in plan.situations.items()
+    )
+
+
+def _available_moments(
+    plan: NutritionPlan,
+    situation_matches: tuple[SituationMatch, ...],
+) -> tuple[str, ...]:
+    if len(situation_matches) != 1:
+        return tuple(MOMENT_ALIASES.keys())
+    situation = plan.situations[situation_matches[0].key]
+    moments = situation.get("momentos", {})
+    if not isinstance(moments, dict):
+        return ()
+    return tuple(str(moment) for moment in moments.keys())
+
+
+def _supplementation(situation: Mapping[str, Any]) -> tuple[str, ...]:
+    value = situation.get("suplementacion", [])
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, str) and item.strip())

--- a/src/forge_bot/nutrition/router.py
+++ b/src/forge_bot/nutrition/router.py
@@ -10,6 +10,7 @@ from .plan import NutritionPlan
 
 ResolutionStatus = Literal[
     "resolved",
+    "resolved_day",
     "missing_situation",
     "missing_moment",
     "ambiguous_situation",
@@ -17,12 +18,24 @@ ResolutionStatus = Literal[
     "invalid_mapping",
 ]
 
-MOMENT_ALIASES: Mapping[str, tuple[str, ...]] = {
+DEFAULT_MOMENT_ALIASES: Mapping[str, tuple[str, ...]] = {
     "desayuno": ("desayuno", "desayunar"),
     "almuerzo": ("almuerzo", "comida", "comer", "mediodia", "medio dia"),
     "merienda": ("merienda", "merendar", "media tarde", "pre entreno"),
     "cena": ("cena", "cenar", "ceno", "noche"),
 }
+
+DAY_OVERVIEW_ALIASES: tuple[str, ...] = (
+    "todo lo que puedo comer",
+    "todo lo que comer",
+    "todo el dia",
+    "dia completo",
+    "plan del dia",
+    "comidas del dia",
+    "plan de comidas del dia",
+    "que puedo comer hoy",
+    "que comer hoy",
+)
 
 
 @dataclass(frozen=True)
@@ -43,6 +56,16 @@ class MomentMatch:
 
 
 @dataclass(frozen=True)
+class DayMealBlock:
+    """One resolved meal block inside a whole-day nutrition answer."""
+
+    moment_key: str
+    moment_label: str
+    meal_block_key: str
+    meal_block: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
 class MealResolution:
     """Result of routing one user message to a meal block."""
 
@@ -51,6 +74,7 @@ class MealResolution:
     moment_key: str | None = None
     meal_block_key: str | None = None
     meal_block: Mapping[str, Any] | None = None
+    day_meal_blocks: tuple[DayMealBlock, ...] = ()
     supplementation: tuple[str, ...] = ()
     situation_matches: tuple[SituationMatch, ...] = ()
     moment_matches: tuple[MomentMatch, ...] = ()
@@ -59,7 +83,7 @@ class MealResolution:
 
     @property
     def is_resolved(self) -> bool:
-        return self.status == "resolved"
+        return self.status in {"resolved", "resolved_day"}
 
 
 def normalize_text(text: str) -> str:
@@ -92,15 +116,14 @@ def detect_situations(plan: NutritionPlan, message: str) -> tuple[SituationMatch
     return tuple(matches)
 
 
-def detect_moments(message: str) -> tuple[MomentMatch, ...]:
-    """Return meal moment candidates detected from built-in Spanish aliases."""
+def detect_moments(plan: NutritionPlan, message: str) -> tuple[MomentMatch, ...]:
+    """Return meal moment candidates detected from plan-defined aliases."""
     normalized_message = normalize_text(message)
     matches: list[MomentMatch] = []
-    for moment_key, aliases in MOMENT_ALIASES.items():
-        normalized_aliases = tuple(normalize_text(alias) for alias in aliases)
+    for moment_key, aliases in _moment_aliases(plan).items():
         matched = tuple(
             alias
-            for alias in normalized_aliases
+            for alias in aliases
             if _contains_alias(normalized_message, alias)
         )
         if matched:
@@ -110,8 +133,9 @@ def detect_moments(message: str) -> tuple[MomentMatch, ...]:
 
 def resolve_meal_context(plan: NutritionPlan, message: str) -> MealResolution:
     """Resolve one natural language message to the smallest useful meal chunk."""
+    wants_day_overview = _is_day_overview_request(message)
     situation_matches = detect_situations(plan, message)
-    moment_matches = detect_moments(message)
+    moment_matches = detect_moments(plan, message)
     available_situations = _available_situations(plan)
     available_moments = _available_moments(plan, situation_matches)
 
@@ -126,6 +150,14 @@ def resolve_meal_context(plan: NutritionPlan, message: str) -> MealResolution:
         return MealResolution(
             status="ambiguous_situation",
             situation_matches=situation_matches,
+            moment_matches=moment_matches,
+            available_situations=available_situations,
+            available_moments=available_moments,
+        )
+    if wants_day_overview:
+        return _resolve_day_context(
+            plan=plan,
+            situation_match=situation_matches[0],
             moment_matches=moment_matches,
             available_situations=available_situations,
             available_moments=available_moments,
@@ -190,6 +222,82 @@ def resolve_meal_context(plan: NutritionPlan, message: str) -> MealResolution:
     )
 
 
+def _resolve_day_context(
+    *,
+    plan: NutritionPlan,
+    situation_match: SituationMatch,
+    moment_matches: tuple[MomentMatch, ...],
+    available_situations: tuple[str, ...],
+    available_moments: tuple[str, ...],
+) -> MealResolution:
+    situation = plan.situations[situation_match.key]
+    moments = situation.get("momentos", {})
+    if not isinstance(moments, dict):
+        return MealResolution(
+            status="invalid_mapping",
+            situation_key=situation_match.key,
+            situation_matches=(situation_match,),
+            moment_matches=moment_matches,
+            available_situations=available_situations,
+            available_moments=available_moments,
+        )
+
+    day_meal_blocks: list[DayMealBlock] = []
+    for moment_key, meal_block_key in moments.items():
+        if plan.moments and moment_key not in plan.moments:
+            continue
+        if not isinstance(moment_key, str) or not isinstance(meal_block_key, str):
+            return MealResolution(
+                status="invalid_mapping",
+                situation_key=situation_match.key,
+                situation_matches=(situation_match,),
+                moment_matches=moment_matches,
+                available_situations=available_situations,
+                available_moments=available_moments,
+            )
+        meal_block = plan.meals.get(meal_block_key)
+        if not isinstance(meal_block, dict):
+            return MealResolution(
+                status="invalid_mapping",
+                situation_key=situation_match.key,
+                moment_key=moment_key,
+                meal_block_key=meal_block_key,
+                situation_matches=(situation_match,),
+                moment_matches=moment_matches,
+                available_situations=available_situations,
+                available_moments=available_moments,
+            )
+        day_meal_blocks.append(
+            DayMealBlock(
+                moment_key=moment_key,
+                moment_label=_moment_label(plan, moment_key),
+                meal_block_key=meal_block_key,
+                meal_block=meal_block,
+            )
+        )
+
+    if not day_meal_blocks:
+        return MealResolution(
+            status="invalid_mapping",
+            situation_key=situation_match.key,
+            situation_matches=(situation_match,),
+            moment_matches=moment_matches,
+            available_situations=available_situations,
+            available_moments=available_moments,
+        )
+
+    return MealResolution(
+        status="resolved_day",
+        situation_key=situation_match.key,
+        day_meal_blocks=tuple(day_meal_blocks),
+        supplementation=_supplementation(situation),
+        situation_matches=(situation_match,),
+        moment_matches=moment_matches,
+        available_situations=available_situations,
+        available_moments=available_moments,
+    )
+
+
 def _situation_aliases(
     situation_key: str,
     situation: Mapping[str, Any],
@@ -199,6 +307,20 @@ def _situation_aliases(
     if isinstance(aliases, list):
         values.extend(alias for alias in aliases if isinstance(alias, str))
     return _dedupe_normalized(values)
+
+
+def _moment_aliases(plan: NutritionPlan) -> Mapping[str, tuple[str, ...]]:
+    if not plan.moments:
+        return DEFAULT_MOMENT_ALIASES
+
+    aliases_by_moment: dict[str, tuple[str, ...]] = {}
+    for moment_key, moment in plan.moments.items():
+        values = [moment_key]
+        aliases = moment.get("aliases", [])
+        if isinstance(aliases, list):
+            values.extend(alias for alias in aliases if isinstance(alias, str))
+        aliases_by_moment[moment_key] = _dedupe_normalized(values)
+    return aliases_by_moment
 
 
 def _dedupe_normalized(values: Sequence[str]) -> tuple[str, ...]:
@@ -219,6 +341,14 @@ def _contains_alias(normalized_message: str, normalized_alias: str) -> bool:
     return re.search(rf"(?<!\w){alias_pattern}(?!\w)", normalized_message) is not None
 
 
+def _is_day_overview_request(message: str) -> bool:
+    normalized_message = normalize_text(message)
+    return any(
+        _contains_alias(normalized_message, alias)
+        for alias in _dedupe_normalized(DAY_OVERVIEW_ALIASES)
+    )
+
+
 def _situation_label(situation_key: str, situation: Mapping[str, Any]) -> str:
     label = situation.get("label")
     return label.strip() if isinstance(label, str) and label.strip() else situation_key
@@ -236,12 +366,38 @@ def _available_moments(
     situation_matches: tuple[SituationMatch, ...],
 ) -> tuple[str, ...]:
     if len(situation_matches) != 1:
-        return tuple(MOMENT_ALIASES.keys())
+        return _all_available_moment_labels(plan)
     situation = plan.situations[situation_matches[0].key]
     moments = situation.get("momentos", {})
     if not isinstance(moments, dict):
         return ()
-    return tuple(str(moment) for moment in moments.keys())
+    return _dedupe_labels(
+        _moment_label(plan, str(moment))
+        for moment in moments.keys()
+        if not plan.moments or moment in plan.moments
+    )
+
+
+def _all_available_moment_labels(plan: NutritionPlan) -> tuple[str, ...]:
+    if plan.moments:
+        return tuple(_moment_label(plan, moment_key) for moment_key in plan.moments)
+    return tuple(DEFAULT_MOMENT_ALIASES.keys())
+
+
+def _dedupe_labels(values: Sequence[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    labels: list[str] = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            labels.append(value)
+    return tuple(labels)
+
+
+def _moment_label(plan: NutritionPlan, moment_key: str) -> str:
+    moment = plan.moments.get(moment_key, {})
+    label = moment.get("label") if isinstance(moment, dict) else None
+    return label.strip() if isinstance(label, str) and label.strip() else moment_key
 
 
 def _supplementation(situation: Mapping[str, Any]) -> tuple[str, ...]:

--- a/src/forge_bot/prompting.py
+++ b/src/forge_bot/prompting.py
@@ -84,6 +84,19 @@ def _system_content(
         f"Default language: {profile.default_language}",
         f"Disclaimer: {profile.disclaimer_text}",
     ]
+    if profile.context_documents:
+        context_sections = [
+            (
+                f"Document: {document.name}\n"
+                "Use this as read-only profile context. Do not expose raw JSON "
+                "unless the user explicitly asks for it.\n"
+                f"{document.content}"
+            )
+            for document in profile.context_documents
+        ]
+        sections.append(
+            "Profile context documents:\n\n" + "\n\n".join(context_sections)
+        )
 
     if runtime_safety_instructions:
         instructions = [

--- a/src/forge_bot/prompting.py
+++ b/src/forge_bot/prompting.py
@@ -26,20 +26,20 @@ def assemble_prompt_messages(
     The order is intentionally explicit so later memory work can plug into the
     contract without changing Telegram routing or generic runtime code.
     """
-    messages: list[ChatMessage] = [
-        {
-            "role": "system",
-            "content": _system_content(profile, runtime_safety_instructions),
-        }
-    ]
-
     memory_content = _memory_content(
         compacted_user_memory=compacted_user_memory,
         recent_conversation_messages=recent_conversation_messages,
     )
-    if memory_content:
-        messages.append({"role": "system", "content": memory_content})
-
+    messages: list[ChatMessage] = [
+        {
+            "role": "system",
+            "content": _system_content(
+                profile,
+                runtime_safety_instructions,
+                memory_content=memory_content,
+            ),
+        }
+    ]
     messages.append({"role": "user", "content": current_user_message.strip()})
     return messages
 
@@ -66,16 +66,25 @@ def _memory_content(
         return None
 
     return (
-        "User memory for this same authenticated user and bot profile. "
-        "Use it as previous conversation context. If the user asks about their "
-        "name, preferences, priorities, dates, or earlier statements, answer "
-        "from this memory when it contains the information.\n\n" + "\n\n".join(sections)
+        "Available conversation context for this same authenticated user and "
+        "bot profile. This is the bot's memory for the current answer. Treat it "
+        "as authoritative conversation context supplied by the application.\n\n"
+        "Rules:\n"
+        "- If the user asks what they said, asked, or discussed before, answer "
+        "from the recent conversation below.\n"
+        "- Do not say you have no memory or no access to previous messages when "
+        "the relevant information appears below.\n"
+        "- If the answer is not present below, say that you do not have that "
+        "specific previous detail available.\n\n"
+        + "\n\n".join(sections)
     )
 
 
 def _system_content(
     profile: BotProfile,
     runtime_safety_instructions: Iterable[str] | None,
+    *,
+    memory_content: str | None = None,
 ) -> str:
     """Combine profile instructions and runtime safety rules."""
     sections = [
@@ -84,6 +93,9 @@ def _system_content(
         f"Default language: {profile.default_language}",
         f"Disclaimer: {profile.disclaimer_text}",
     ]
+    if memory_content:
+        sections.append(memory_content)
+
     if profile.context_documents:
         context_sections = [
             (

--- a/src/forge_bot/prompting.py
+++ b/src/forge_bot/prompting.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
+from datetime import datetime
 from typing import TypedDict
 
 from .bot_profile import BotProfile
@@ -20,6 +21,7 @@ def assemble_prompt_messages(
     compacted_user_memory: str | None = None,
     recent_conversation_messages: Sequence[ChatMessage] | None = None,
     runtime_safety_instructions: Iterable[str] | None = None,
+    now: datetime | None = None,
 ) -> list[ChatMessage]:
     """Build the ordered message list sent to the configured LLM.
 
@@ -37,6 +39,7 @@ def assemble_prompt_messages(
                 profile,
                 runtime_safety_instructions,
                 memory_content=memory_content,
+                now=now or datetime.now().astimezone(),
             ),
         }
     ]
@@ -85,6 +88,7 @@ def _system_content(
     runtime_safety_instructions: Iterable[str] | None,
     *,
     memory_content: str | None = None,
+    now: datetime,
 ) -> str:
     """Combine profile instructions and runtime safety rules."""
     sections = [
@@ -92,6 +96,7 @@ def _system_content(
         "Domain rules:\n" + "\n".join(f"- {rule}" for rule in profile.domain_rules),
         f"Default language: {profile.default_language}",
         f"Disclaimer: {profile.disclaimer_text}",
+        _current_datetime_content(now),
     ]
     if memory_content:
         sections.append(memory_content)
@@ -121,3 +126,15 @@ def _system_content(
             )
 
     return "\n\n".join(sections)
+
+
+def _current_datetime_content(now: datetime) -> str:
+    local_now = now if now.tzinfo is not None else now.astimezone()
+    return (
+        "Current runtime date and time:\n"
+        f"- ISO datetime: {local_now.isoformat()}\n"
+        f"- Date: {local_now.date().isoformat()}\n"
+        f"- Timezone: {local_now.tzname() or 'local'}\n"
+        "- Use this as the real current date/time for relative references like "
+        "today, tomorrow, yesterday, this week, or tonight."
+    )

--- a/src/forge_bot/prompting.py
+++ b/src/forge_bot/prompting.py
@@ -78,8 +78,7 @@ def _memory_content(
         "- Do not say you have no memory or no access to previous messages when "
         "the relevant information appears below.\n"
         "- If the answer is not present below, say that you do not have that "
-        "specific previous detail available.\n\n"
-        + "\n\n".join(sections)
+        "specific previous detail available.\n\n" + "\n\n".join(sections)
     )
 
 

--- a/src/forge_bot/router.py
+++ b/src/forge_bot/router.py
@@ -175,7 +175,7 @@ async def ask_ia(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         )
 
         # Send the generated answer back into the same chat.
-        await update.message.reply_text(answer)
+        await _reply_ai_answer(update.message, answer)
         mark_answered(update.update_id)
         if internal_user and memory_is_enabled:
             stored = _store_successful_turn(
@@ -312,6 +312,13 @@ async def _ignore_with_reply(update: Update, message: str) -> None:
         mark_ignored(update.update_id)
     if update.message:
         await update.message.reply_text(message)
+
+
+async def _reply_ai_answer(message: object, answer: str) -> None:
+    try:
+        await message.reply_text(answer, parse_mode="HTML")  # type: ignore[attr-defined]
+    except TypeError:
+        await message.reply_text(answer)  # type: ignore[attr-defined]
 
 
 async def _finish_ignored_request(

--- a/src/forge_bot/router.py
+++ b/src/forge_bot/router.py
@@ -1,7 +1,11 @@
+import asyncio
+import contextlib
 import logging
+import time
 from collections.abc import Sequence
 
 from telegram import Update
+from telegram.error import RetryAfter
 from telegram.ext import ContextTypes
 
 from . import engine
@@ -9,11 +13,11 @@ from .bot_profile import BotProfile
 from .commands.auth_guard import require_login
 from .config import get_settings
 from .database import get_user_by_telegram_id
-from .memory_store import (
-    compact_memory_if_needed,
-    get_memory_context,
-    store_successful_turn,
+from .debug_conversation_log import (
+    DebugConversationTurn,
+    append_debug_conversation_turn,
 )
+from .memory_backend import MemoryBackend, memory_backend_for_profile
 from .message_store import (
     mark_answered,
     mark_failed,
@@ -29,6 +33,16 @@ from .rate_limits import LimitDecision, abuse_limiter
 from .request_state import REQUEST_WAITING_MESSAGE, request_state
 
 logger = logging.getLogger(__name__)
+PROCESSING_NOTICE_INITIAL_DELAY_SECONDS = 15
+PROCESSING_NOTICE_INTERVAL_SECONDS = 60
+PROCESSING_NOTICE_MESSAGE = (
+    "Estoy revisandolo. Puede tardar un poco; no hace falta que lo reenvies."
+)
+PROCESSING_NOTICE_REPEAT_MESSAGE = (
+    "Sigo trabajando en tu respuesta. Te contesto aqui en cuanto termine."
+)
+STREAM_LOADING_DRAFT_INTERVAL_SECONDS = 2.0
+STREAM_DRAFT_UPDATE_INTERVAL_SECONDS = 2.0
 
 
 async def record_inbound_update(
@@ -79,12 +93,18 @@ async def ask_ia(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     active_profile = engine.load_default_profile()
     memory_is_enabled = _memory_enabled(active_profile)
+    memory_backend = memory_backend_for_profile(active_profile)
+    needs_internal_user = (
+        memory_is_enabled or active_profile.bot_profile_id == "nutrition"
+    )
     internal_user = (
-        get_user_by_telegram_id(update.effective_user.id) if memory_is_enabled else None
+        get_user_by_telegram_id(update.effective_user.id)
+        if needs_internal_user
+        else None
     )
     memory_context = None
     if internal_user and memory_is_enabled:
-        memory_context = get_memory_context(
+        memory_context = memory_backend.get_context(
             user_id=int(internal_user["id"]),
             bot_profile_id=active_profile.bot_profile_id,
             exclude_inbound_message_id=(
@@ -141,7 +161,9 @@ async def ask_ia(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
 
     finished_status = "failed"
-    memory_compaction_job: tuple[int, str, str, BotProfile] | None = None
+    memory_compaction_job: tuple[int, str, str, BotProfile, MemoryBackend] | None = None
+    processing_notice_task: asyncio.Task[None] | None = None
+    stream_loading_task: asyncio.Task[None] | None = None
 
     try:
         if current_status in {"persisted", "received", "failed"}:
@@ -158,25 +180,91 @@ async def ask_ia(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await context.bot.send_chat_action(
             chat_id=update.effective_chat.id, action="typing"
         )
-
-        # Delegate prompt assembly and LLM provider selection to the engine module.
-        answer = await engine.answer(
-            user,
-            message,
-            profile=active_profile,
-            request_id=processing_request.request_id,
-            queue_wait_seconds=processing_request.queue_wait_seconds,
-            compacted_user_memory=(
-                memory_context.compacted_user_memory if memory_context else None
-            ),
-            recent_conversation_messages=(
-                memory_context.recent_conversation_messages if memory_context else []
-            ),
+        draft_streamer = _TelegramDraftStreamer(
+            context.bot,
+            chat_id=update.effective_chat.id,
+            draft_id=update.update_id,
         )
+        streaming_enabled = _streaming_enabled(active_profile)
+        if streaming_enabled:
+            stream_loading_task = asyncio.create_task(
+                _send_loading_drafts(draft_streamer)
+            )
+        else:
+            processing_notice_task = asyncio.create_task(
+                _send_processing_notices(update.message)
+            )
+
+        async def publish_partial_answer(text: str) -> None:
+            nonlocal processing_notice_task
+            nonlocal stream_loading_task
+            if stream_loading_task is not None:
+                stream_loading_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await stream_loading_task
+                stream_loading_task = None
+            if processing_notice_task is not None:
+                processing_notice_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await processing_notice_task
+                processing_notice_task = None
+            await draft_streamer.publish(text, force=True)
+
+        compacted_user_memory = (
+            memory_context.compacted_user_memory if memory_context else None
+        )
+        recent_conversation_messages = (
+            memory_context.recent_conversation_messages if memory_context else []
+        )
+        internal_user_id = (
+            int(internal_user["id"])
+            if internal_user and internal_user.get("id") is not None
+            else None
+        )
+        # Delegate prompt assembly and LLM provider selection to the engine module.
+        if streaming_enabled:
+            answer = await engine.answer_stream(
+                user,
+                message,
+                on_partial=publish_partial_answer,
+                profile=active_profile,
+                request_id=processing_request.request_id,
+                queue_wait_seconds=processing_request.queue_wait_seconds,
+                compacted_user_memory=compacted_user_memory,
+                recent_conversation_messages=recent_conversation_messages,
+                internal_user_id=internal_user_id,
+            )
+        else:
+            answer = await engine.answer(
+                user,
+                message,
+                profile=active_profile,
+                request_id=processing_request.request_id,
+                queue_wait_seconds=processing_request.queue_wait_seconds,
+                compacted_user_memory=compacted_user_memory,
+                recent_conversation_messages=recent_conversation_messages,
+                internal_user_id=internal_user_id,
+            )
 
         # Send the generated answer back into the same chat.
         await _reply_ai_answer(update.message, answer)
         mark_answered(update.update_id)
+        engine.finalize_successful_answer(answer)
+        _append_debug_conversation_turn(
+            profile=active_profile,
+            user_message=message,
+            assistant_message=answer,
+            telegram_user_id=update.effective_user.id,
+            telegram_chat_id=update.effective_chat.id,
+            telegram_message_id=getattr(update.message, "message_id", None),
+            inbound_message_id=claimed.get("id") if claimed else None,
+            request_id=processing_request.request_id,
+            internal_user_id=(
+                int(internal_user["id"])
+                if internal_user and internal_user.get("id") is not None
+                else None
+            ),
+        )
         if internal_user and memory_is_enabled:
             stored = _store_successful_turn(
                 internal_user_id=int(internal_user["id"]),
@@ -187,6 +275,7 @@ async def ask_ia(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 telegram_message_id=getattr(update.message, "message_id", None),
                 inbound_message_id=claimed.get("id") if claimed else None,
                 request_id=processing_request.request_id,
+                memory_backend=memory_backend,
             )
             if stored:
                 memory_compaction_job = (
@@ -194,6 +283,7 @@ async def ask_ia(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                     active_profile.bot_profile_id,
                     processing_request.request_id,
                     active_profile,
+                    memory_backend,
                 )
         finished_status = "answered"
     except Exception as exc:
@@ -203,6 +293,14 @@ async def ask_ia(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             "review. Please try again in a moment."
         )
     finally:
+        if stream_loading_task is not None:
+            stream_loading_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stream_loading_task
+        if processing_notice_task is not None:
+            processing_notice_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await processing_notice_task
         await ai_lease.release()
         await request_state.finish(
             user_id=update.effective_user.id,
@@ -215,6 +313,7 @@ async def ask_ia(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             bot_profile_id=memory_compaction_job[1],
             request_id=memory_compaction_job[2],
             profile=memory_compaction_job[3],
+            memory_backend=memory_compaction_job[4],
         )
 
 
@@ -222,6 +321,15 @@ def _memory_enabled(profile: BotProfile) -> bool:
     if not profile.memory_enabled:
         return False
     return get_settings().memory_enabled
+
+
+def _streaming_enabled(profile: BotProfile) -> bool:
+    settings = get_settings()
+    configured_primary_provider = settings.llm_primary_provider.lower()
+    profile_provider = profile.llm_provider.lower()
+    return configured_primary_provider == "nvidia" or (
+        configured_primary_provider in {"", "profile"} and profile_provider == "nvidia"
+    )
 
 
 def _store_successful_turn(
@@ -234,9 +342,10 @@ def _store_successful_turn(
     telegram_message_id: int | None,
     inbound_message_id: int | None,
     request_id: str,
+    memory_backend: MemoryBackend,
 ) -> bool:
     try:
-        return store_successful_turn(
+        return memory_backend.store_successful_turn(
             user_id=internal_user_id,
             bot_profile_id=bot_profile_id,
             user_message=user_message,
@@ -257,12 +366,40 @@ def _store_successful_turn(
         return False
 
 
+def _append_debug_conversation_turn(
+    *,
+    profile: BotProfile,
+    user_message: str,
+    assistant_message: str,
+    telegram_user_id: int,
+    telegram_chat_id: int,
+    telegram_message_id: int | None,
+    inbound_message_id: int | None,
+    request_id: str,
+    internal_user_id: int | None,
+) -> None:
+    append_debug_conversation_turn(
+        DebugConversationTurn(
+            bot_profile_id=profile.bot_profile_id,
+            internal_user_id=internal_user_id,
+            telegram_user_id=telegram_user_id,
+            telegram_chat_id=telegram_chat_id,
+            telegram_message_id=telegram_message_id,
+            inbound_message_id=inbound_message_id,
+            request_id=request_id,
+            user_message=user_message,
+            assistant_message=assistant_message,
+        )
+    )
+
+
 async def _compact_successful_turn(
     *,
     internal_user_id: int,
     bot_profile_id: str,
     request_id: str,
     profile: BotProfile,
+    memory_backend: MemoryBackend,
 ) -> None:
     async def summarize(
         existing_summary: str | None,
@@ -278,7 +415,7 @@ async def _compact_successful_turn(
         )
 
     try:
-        await compact_memory_if_needed(
+        await memory_backend.compact_memory_if_needed(
             user_id=internal_user_id,
             bot_profile_id=bot_profile_id,
             summarizer=summarize,
@@ -319,6 +456,113 @@ async def _reply_ai_answer(message: object, answer: str) -> None:
         await message.reply_text(answer, parse_mode="HTML")  # type: ignore[attr-defined]
     except TypeError:
         await message.reply_text(answer)  # type: ignore[attr-defined]
+
+
+class _TelegramDraftStreamer:
+    def __init__(self, bot: object, *, chat_id: int, draft_id: int) -> None:
+        self._bot = bot
+        self._chat_id = chat_id
+        self._draft_id = draft_id
+        self._last_text = ""
+        self._last_sent_at = 0.0
+        self._retry_after_until = 0.0
+        self._disabled = False
+
+    async def publish(
+        self,
+        text: str,
+        *,
+        force: bool = False,
+        min_interval_seconds: float = STREAM_DRAFT_UPDATE_INTERVAL_SECONDS,
+    ) -> None:
+        if self._disabled or not text or text == self._last_text:
+            return
+        now = time.monotonic()
+        if now < self._retry_after_until:
+            return
+        if (
+            not force
+            and self._last_text
+            and now - self._last_sent_at < min_interval_seconds
+        ):
+            return
+
+        send_message_draft = getattr(self._bot, "send_message_draft", None)
+        if send_message_draft is None:
+            self._disabled = True
+            return
+
+        try:
+            await send_message_draft(
+                chat_id=self._chat_id,
+                draft_id=self._draft_id,
+                text=text,
+                parse_mode="HTML",
+            )
+            self._last_text = text
+            self._last_sent_at = now
+        except TypeError:
+            try:
+                await send_message_draft(
+                    chat_id=self._chat_id,
+                    draft_id=self._draft_id,
+                    text=text,
+                )
+                self._last_text = text
+                self._last_sent_at = now
+            except RetryAfter as exc:
+                self._pause_for_retry_after(exc)
+            except Exception:
+                self._disabled = True
+                logger.exception("telegram_draft_stream_failed")
+        except RetryAfter as exc:
+            self._pause_for_retry_after(exc)
+        except Exception:
+            self._disabled = True
+            logger.exception("telegram_draft_stream_failed")
+
+    def _pause_for_retry_after(self, exc: RetryAfter) -> None:
+        retry_after = float(getattr(exc, "retry_after", 3.0) or 3.0)
+        self._retry_after_until = time.monotonic() + retry_after + 0.5
+        logger.warning(
+            "telegram_draft_stream_rate_limited retry_after_seconds=%s",
+            retry_after,
+        )
+
+
+async def _send_loading_drafts(streamer: _TelegramDraftStreamer) -> None:
+    """Animate a lightweight Telegram draft until the first streamed token arrives."""
+    states = (".", "..", "...")
+    index = 0
+    try:
+        while True:
+            await streamer.publish(
+                states[index % len(states)],
+                min_interval_seconds=0,
+            )
+            index += 1
+            await asyncio.sleep(STREAM_LOADING_DRAFT_INTERVAL_SECONDS)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.exception("telegram_loading_draft_failed")
+
+
+async def _send_processing_notices(message: object) -> None:
+    """Send progress notes while the LLM call takes long enough to feel stuck."""
+    try:
+        await asyncio.sleep(PROCESSING_NOTICE_INITIAL_DELAY_SECONDS)
+        reply_text = getattr(message, "reply_text", None)
+        if reply_text is None:
+            return
+        await reply_text(PROCESSING_NOTICE_MESSAGE)
+        while True:
+            await asyncio.sleep(PROCESSING_NOTICE_INTERVAL_SECONDS)
+            await reply_text(PROCESSING_NOTICE_REPEAT_MESSAGE)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.exception("processing_notice_failed")
 
 
 async def _finish_ignored_request(

--- a/src/forge_bot/router.py
+++ b/src/forge_bot/router.py
@@ -250,22 +250,27 @@ async def ask_ia(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await _reply_ai_answer(update.message, answer)
         mark_answered(update.update_id)
         engine.finalize_successful_answer(answer)
-        _append_debug_conversation_turn(
-            profile=active_profile,
-            user_message=message,
-            assistant_message=answer,
-            telegram_user_id=update.effective_user.id,
-            telegram_chat_id=update.effective_chat.id,
-            telegram_message_id=getattr(update.message, "message_id", None),
-            inbound_message_id=claimed.get("id") if claimed else None,
-            request_id=processing_request.request_id,
-            internal_user_id=(
-                int(internal_user["id"])
-                if internal_user and internal_user.get("id") is not None
-                else None
-            ),
-        )
-        if internal_user and memory_is_enabled:
+        if engine.answer_should_be_debug_logged(answer):
+            _append_debug_conversation_turn(
+                profile=active_profile,
+                user_message=message,
+                assistant_message=answer,
+                telegram_user_id=update.effective_user.id,
+                telegram_chat_id=update.effective_chat.id,
+                telegram_message_id=getattr(update.message, "message_id", None),
+                inbound_message_id=claimed.get("id") if claimed else None,
+                request_id=processing_request.request_id,
+                internal_user_id=(
+                    int(internal_user["id"])
+                    if internal_user and internal_user.get("id") is not None
+                    else None
+                ),
+            )
+        if (
+            internal_user
+            and memory_is_enabled
+            and engine.answer_should_be_stored_in_memory(answer)
+        ):
             stored = _store_successful_turn(
                 internal_user_id=int(internal_user["id"]),
                 bot_profile_id=active_profile.bot_profile_id,

--- a/tests/fixtures/nutrition_plan.json
+++ b/tests/fixtures/nutrition_plan.json
@@ -1,5 +1,5 @@
 {
-  "plan_id": "demo_nutrition_plan_v1",
+  "plan_id": "sample_nutrition_plan_v1",
   "description": "Plan demo cargado desde el repo para validar respuestas del bot nutricionista antes de persistencia por usuario.",
   "usage_notes": [
     "situaciones enruta tipo de dia + momento a una clave de comidas.",
@@ -149,6 +149,28 @@
         "carrera",
         "series",
         "tirada"
+      ],
+      "tipo_dia": "entrenamiento_resistencia",
+      "suplementacion": [
+        "10g de creatina monohidrato creapure"
+      ],
+      "momentos": {
+        "desayuno": "comida_1",
+        "almuerzo": "comida_2",
+        "comida": "comida_2",
+        "mediodia": "comida_2",
+        "merienda": "comida_0",
+        "cena": "comida_3"
+      }
+    },
+    "natacion": {
+      "label": "Natacion",
+      "aliases": [
+        "natacion",
+        "natación",
+        "nadar",
+        "piscina",
+        "swimming"
       ],
       "tipo_dia": "entrenamiento_resistencia",
       "suplementacion": [

--- a/tests/test_admin_memory.py
+++ b/tests/test_admin_memory.py
@@ -1,0 +1,138 @@
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from forge_bot.commands import admin_memory as admin_memory_module
+from forge_bot.commands.admin_memory import admin_memory, admin_users
+
+
+class FakeMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str) -> None:
+        self.replies.append(text)
+
+
+def create_update() -> Any:
+    return SimpleNamespace(
+        effective_user=SimpleNamespace(id=123),
+        message=FakeMessage(),
+    )
+
+
+def create_context(args: list[str] | None = None) -> Any:
+    return SimpleNamespace(args=args or [])
+
+
+@pytest.fixture(autouse=True)
+def admin_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "forge_bot.commands.auth_guard.verify_user",
+        lambda user_id: True,
+    )
+    monkeypatch.setattr("forge_bot.commands.auth_guard.is_admin", lambda user_id: True)
+    monkeypatch.setattr(
+        "forge_bot.commands.auth_guard.has_current_policy_acceptance",
+        lambda user_id: True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_admin_users_lists_identifiers(monkeypatch: pytest.MonkeyPatch) -> None:
+    update = create_update()
+    monkeypatch.setattr(
+        admin_memory_module,
+        "list_admin_users",
+        lambda *, limit: [
+            {
+                "id": 7,
+                "telegram_id": 456,
+                "role": "user",
+                "username": "telegram_456",
+                "email": "person@example.com",
+            }
+        ],
+    )
+
+    await admin_users(update, create_context(args=["10"]))
+
+    assert "id=7" in update.message.replies[0]
+    assert "tg=456" in update.message.replies[0]
+    assert "email=person@example.com" in update.message.replies[0]
+    assert "/admin_memory" in update.message.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_admin_memory_returns_report(monkeypatch: pytest.MonkeyPatch) -> None:
+    update = create_update()
+    calls: list[tuple[str, str]] = []
+
+    def build_report(identifier: str, *, profile_id: str) -> str:
+        calls.append((identifier, profile_id))
+        return "User memory\n\nDaily logs: none"
+
+    monkeypatch.setattr(admin_memory_module, "build_admin_memory_report", build_report)
+
+    await admin_memory(update, create_context(args=["7", "nutrition"]))
+
+    assert calls == [("7", "nutrition")]
+    assert update.message.replies == ["User memory\n\nDaily logs: none"]
+
+
+def test_format_memory_report_sections() -> None:
+    report = admin_memory_module._format_memory_report(
+        user={
+            "id": 7,
+            "telegram_id": 456,
+            "username": "telegram_456",
+            "email": None,
+            "role": "user",
+        },
+        profile_id="nutrition",
+        snapshot={
+            "db_active_plan": None,
+            "daily_logs": [
+                {
+                    "log_date": "2026-05-24",
+                    "situation_key": "natacion",
+                    "meals": {"desayuno": {"completed": True, "text": "tostada"}},
+                    "notes": [],
+                }
+            ],
+            "compact_memory": {
+                "summary": "Le gusta cenar pescado.",
+                "source_message_count": 12,
+                "updated_at": "2026-05-24T10:00:00Z",
+            },
+            "langchain_messages": [
+                {
+                    "message": {
+                        "type": "human",
+                        "data": {"content": "Que ceno?"},
+                    }
+                }
+            ],
+            "legacy_messages": [],
+        },
+    )
+
+    assert "Profile: nutrition" in report
+    assert "tipo_dia: natacion" in report
+    assert "completed" in report
+    assert "Compact memory:" in report
+    assert "LangChain recent messages:" in report
+
+
+def test_resolve_admin_user_rejects_bad_numeric_identifier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        admin_memory_module,
+        "conect_db",
+        lambda: pytest.fail("database should not be opened"),
+    )
+
+    assert admin_memory_module.resolve_admin_user("id:not-a-number") is None
+    assert admin_memory_module.resolve_admin_user("tg:not-a-number") is None

--- a/tests/test_auth_guard.py
+++ b/tests/test_auth_guard.py
@@ -14,6 +14,56 @@ class FakeMessage:
 
 
 @pytest.mark.asyncio
+async def test_require_linked_user_denies_unlinked_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    message = FakeMessage()
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=123),
+        message=message,
+    )
+    context = SimpleNamespace()
+    called = False
+
+    async def protected_handler(update: object, context: object) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(auth_guard, "verify_user", lambda telegram_id: False)
+
+    wrapped = auth_guard.require_linked_user(protected_handler)
+    await wrapped(update, context)
+
+    assert not called
+    assert message.replies == [auth_guard.INVITE_REQUIRED_MESSAGE]
+
+
+@pytest.mark.asyncio
+async def test_require_linked_user_allows_linked_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    message = FakeMessage()
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=123),
+        message=message,
+    )
+    context = SimpleNamespace()
+    called = False
+
+    async def protected_handler(update: object, context: object) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(auth_guard, "verify_user", lambda telegram_id: True)
+
+    wrapped = auth_guard.require_linked_user(protected_handler)
+    await wrapped(update, context)
+
+    assert called
+    assert message.replies == []
+
+
+@pytest.mark.asyncio
 async def test_admin_required_denies_non_admin(monkeypatch: pytest.MonkeyPatch) -> None:
     message = FakeMessage()
     update = SimpleNamespace(

--- a/tests/test_bot_profile.py
+++ b/tests/test_bot_profile.py
@@ -51,6 +51,20 @@ def test_load_default_bot_profile_successfully() -> None:
     assert profile.llm_provider == "ollama"
 
 
+def test_load_nutrition_bot_profile_successfully() -> None:
+    profile = load_active_bot_profile("nutrition", "bot_profiles")
+
+    assert profile.bot_profile_id == "nutrition"
+    assert profile.bot_display_name == "Bot Nutricionista"
+    assert profile.default_language == "es"
+    assert profile.llm_provider == "ollama"
+    assert profile.llm_model == "gemma3:4b"
+    assert profile.memory_enabled is True
+    assert "no finjas que lo hay" in profile.system_prompt
+    assert "No diagnostiques" in profile.system_prompt
+    assert any("no inventes dietas" in rule for rule in profile.domain_rules)
+
+
 def test_fail_when_selected_profile_is_missing(tmp_path: Path) -> None:
     with pytest.raises(BotProfileError, match="was not found"):
         load_active_bot_profile(
@@ -106,6 +120,28 @@ def test_prompt_assembly_includes_system_prompt_before_user_message(
         "role": "user",
         "content": "What should I eat after training?",
     }
+
+
+def test_nutrition_profile_prompt_assembly_includes_guardrails() -> None:
+    profile = load_active_bot_profile("nutrition", "bot_profiles")
+
+    messages = assemble_prompt_messages(
+        profile,
+        current_user_message="Hoy tengo crossfit, que como al mediodia?",
+        compacted_user_memory="El usuario prefiere cenas sencillas.",
+    )
+
+    system_message = messages[0]["content"]
+    assert "Eres un bot nutricionista conversacional" in system_message
+    assert "Las cantidades, opciones y ajustes concretos deben salir del plan" in (
+        system_message
+    )
+    assert "No muestres macros, calorias ni calculos detallados" in system_message
+    assert "Disclaimer: Este bot ayuda a interpretar un plan nutricional" in (
+        system_message
+    )
+    assert messages[1]["role"] == "system"
+    assert "El usuario prefiere cenas sencillas." in messages[1]["content"]
 
 
 def test_changing_profile_changes_prompt_without_code_changes(tmp_path: Path) -> None:

--- a/tests/test_bot_profile.py
+++ b/tests/test_bot_profile.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -53,6 +54,7 @@ def test_load_default_bot_profile_successfully() -> None:
     )
     assert "Do not reveal internal reasoning" in profile.system_prompt
     assert profile.llm_provider == "ollama"
+    assert profile.memory_backend == "postgres"
 
 
 def test_load_nutrition_bot_profile_successfully() -> None:
@@ -64,12 +66,46 @@ def test_load_nutrition_bot_profile_successfully() -> None:
     assert profile.llm_provider == "nvidia"
     assert profile.llm_model == "nvidia/llama-3.3-nemotron-super-49b-v1.5"
     assert profile.memory_enabled is True
+    assert profile.memory_backend == "langchain_postgres"
     assert profile.context_documents == ()
-    assert profile.nutrition_plan_path is not None
-    assert profile.nutrition_plan_path.name == "demo_plan.json"
+    assert profile.nutrition_plan_path is None
     assert "no finjas que lo hay" in profile.system_prompt
     assert "No diagnostiques" in profile.system_prompt
     assert any("no inventes dietas" in rule for rule in profile.domain_rules)
+
+
+def test_memory_backend_can_be_configured_per_profile(tmp_path: Path) -> None:
+    write_profile(tmp_path, overrides={"memory_backend": "langchain_postgres"})
+
+    profile = load_active_bot_profile(
+        "nutrition_dev",
+        "bot_profiles",
+        base_path=tmp_path,
+    )
+
+    assert profile.memory_backend == "langchain_postgres"
+
+
+def test_memory_backend_rejects_empty_value(tmp_path: Path) -> None:
+    write_profile(tmp_path, overrides={"memory_backend": ""})
+
+    with pytest.raises(BotProfileError, match="memory_backend"):
+        load_active_bot_profile(
+            "nutrition_dev",
+            "bot_profiles",
+            base_path=tmp_path,
+        )
+
+
+def test_memory_backend_rejects_unknown_value(tmp_path: Path) -> None:
+    write_profile(tmp_path, overrides={"memory_backend": "unknown_backend"})
+
+    with pytest.raises(BotProfileError, match="memory_backend"):
+        load_active_bot_profile(
+            "nutrition_dev",
+            "bot_profiles",
+            base_path=tmp_path,
+        )
 
 
 def test_fail_when_selected_profile_is_missing(tmp_path: Path) -> None:
@@ -160,11 +196,15 @@ def test_prompt_assembly_includes_system_prompt_before_user_message(
             {"role": "assistant", "content": "How can I help today?"}
         ],
         runtime_safety_instructions=["Escalate emergency symptoms."],
+        now=datetime(2026, 5, 24, 12, 30, tzinfo=timezone.utc),
     )
 
     assert messages[0]["role"] == "system"
     assert "You are a nutrition assistant." in messages[0]["content"]
     assert "Avoid medical diagnosis." in messages[0]["content"]
+    assert "Current runtime date and time" in messages[0]["content"]
+    assert "2026-05-24" in messages[0]["content"]
+    assert "today, tomorrow, yesterday" in messages[0]["content"]
     assert "Available conversation context" in messages[0]["content"]
     assert "Do not say you have no memory" in messages[0]["content"]
     assert "Compacted memory:\nPrefers vegetarian meals." in messages[0]["content"]
@@ -188,16 +228,17 @@ def test_nutrition_profile_prompt_assembly_includes_guardrails() -> None:
     )
 
     system_message = messages[0]["content"]
-    assert "Eres un bot nutricionista conversacional" in system_message
-    assert "Las cantidades, opciones y ajustes concretos deben salir del plan" in (
-        system_message
-    )
-    assert "No muestres macros, calorias ni calculos detallados" in system_message
+    assert "Eres un asistente nutricional conversacional" in system_message
+    assert "El plan activo del usuario manda." in system_message
+    assert "`situaciones` decide que bloque toca" in system_message
+    assert "`comidas` define alimentos, cantidades" in system_message
+    assert "no muestres JSON ni claves internas" in system_message
+    assert "no expliques macros salvo que se pidan" in system_message
     assert "Disclaimer: Este bot ayuda a interpretar un plan nutricional" in (
         system_message
     )
     assert "Profile context documents:" not in system_message
-    assert "Document: demo_plan.json" not in system_message
+    assert "Document: nutrition_plan.json" not in system_message
     assert '"crossfit"' not in system_message
     assert '"comida_2"' not in system_message
     assert "El usuario prefiere cenas sencillas." in messages[0]["content"]

--- a/tests/test_bot_profile.py
+++ b/tests/test_bot_profile.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 import pytest
 
-from forge_bot.bot_profile import BotProfileError, load_active_bot_profile
+from forge_bot.bot_profile import (
+    MAX_CONTEXT_DOCUMENT_CHARS,
+    BotProfileError,
+    load_active_bot_profile,
+)
 from forge_bot.prompting import assemble_prompt_messages
 
 
@@ -60,6 +64,10 @@ def test_load_nutrition_bot_profile_successfully() -> None:
     assert profile.llm_provider == "nvidia"
     assert profile.llm_model == "nvidia/llama-3.3-nemotron-super-49b-v1.5"
     assert profile.memory_enabled is True
+    assert len(profile.context_documents) == 1
+    assert profile.context_documents[0].name == "demo_plan.json"
+    assert '"situaciones"' in profile.context_documents[0].content
+    assert '"comidas"' in profile.context_documents[0].content
     assert "no finjas que lo hay" in profile.system_prompt
     assert "No diagnostiques" in profile.system_prompt
     assert any("no inventes dietas" in rule for rule in profile.domain_rules)
@@ -78,6 +86,44 @@ def test_fail_when_required_profile_field_is_empty(tmp_path: Path) -> None:
     write_profile(tmp_path, overrides={"bot_display_name": ""})
 
     with pytest.raises(BotProfileError, match="bot_display_name"):
+        load_active_bot_profile(
+            "nutrition_dev",
+            "bot_profiles",
+            base_path=tmp_path,
+        )
+
+
+def test_fail_when_context_file_is_missing(tmp_path: Path) -> None:
+    write_profile(tmp_path, overrides={"context_files": ["missing.json"]})
+
+    with pytest.raises(BotProfileError, match="context file was not found"):
+        load_active_bot_profile(
+            "nutrition_dev",
+            "bot_profiles",
+            base_path=tmp_path,
+        )
+
+
+def test_fail_when_context_file_leaves_profile_folder(tmp_path: Path) -> None:
+    write_profile(tmp_path, overrides={"context_files": ["../outside.json"]})
+    (tmp_path / "bot_profiles" / "outside.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(BotProfileError, match="inside the profile folder"):
+        load_active_bot_profile(
+            "nutrition_dev",
+            "bot_profiles",
+            base_path=tmp_path,
+        )
+
+
+def test_fail_when_context_file_is_too_large(tmp_path: Path) -> None:
+    profile_dir = write_profile(tmp_path, overrides={"context_files": ["large.txt"]})
+    (profile_dir / "large.txt").write_text(
+        "x" * (MAX_CONTEXT_DOCUMENT_CHARS + 1),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(BotProfileError, match="too large"):
         load_active_bot_profile(
             "nutrition_dev",
             "bot_profiles",
@@ -140,6 +186,10 @@ def test_nutrition_profile_prompt_assembly_includes_guardrails() -> None:
     assert "Disclaimer: Este bot ayuda a interpretar un plan nutricional" in (
         system_message
     )
+    assert "Profile context documents:" in system_message
+    assert "Document: demo_plan.json" in system_message
+    assert '"crossfit"' in system_message
+    assert '"comida_2"' in system_message
     assert messages[1]["role"] == "system"
     assert "El usuario prefiere cenas sencillas." in messages[1]["content"]
 

--- a/tests/test_bot_profile.py
+++ b/tests/test_bot_profile.py
@@ -57,8 +57,8 @@ def test_load_nutrition_bot_profile_successfully() -> None:
     assert profile.bot_profile_id == "nutrition"
     assert profile.bot_display_name == "Bot Nutricionista"
     assert profile.default_language == "es"
-    assert profile.llm_provider == "ollama"
-    assert profile.llm_model == "gemma3:4b"
+    assert profile.llm_provider == "nvidia"
+    assert profile.llm_model == "nvidia/llama-3.3-nemotron-super-49b-v1.5"
     assert profile.memory_enabled is True
     assert "no finjas que lo hay" in profile.system_prompt
     assert "No diagnostiques" in profile.system_prompt

--- a/tests/test_bot_profile.py
+++ b/tests/test_bot_profile.py
@@ -64,10 +64,9 @@ def test_load_nutrition_bot_profile_successfully() -> None:
     assert profile.llm_provider == "nvidia"
     assert profile.llm_model == "nvidia/llama-3.3-nemotron-super-49b-v1.5"
     assert profile.memory_enabled is True
-    assert len(profile.context_documents) == 1
-    assert profile.context_documents[0].name == "demo_plan.json"
-    assert '"situaciones"' in profile.context_documents[0].content
-    assert '"comidas"' in profile.context_documents[0].content
+    assert profile.context_documents == ()
+    assert profile.nutrition_plan_path is not None
+    assert profile.nutrition_plan_path.name == "demo_plan.json"
     assert "no finjas que lo hay" in profile.system_prompt
     assert "No diagnostiques" in profile.system_prompt
     assert any("no inventes dietas" in rule for rule in profile.domain_rules)
@@ -131,6 +130,17 @@ def test_fail_when_context_file_is_too_large(tmp_path: Path) -> None:
         )
 
 
+def test_fail_when_nutrition_plan_file_is_missing(tmp_path: Path) -> None:
+    write_profile(tmp_path, overrides={"nutrition_plan_file": "missing.json"})
+
+    with pytest.raises(BotProfileError, match="nutrition_plan_file"):
+        load_active_bot_profile(
+            "nutrition_dev",
+            "bot_profiles",
+            base_path=tmp_path,
+        )
+
+
 def test_prompt_assembly_includes_system_prompt_before_user_message(
     tmp_path: Path,
 ) -> None:
@@ -155,12 +165,12 @@ def test_prompt_assembly_includes_system_prompt_before_user_message(
     assert messages[0]["role"] == "system"
     assert "You are a nutrition assistant." in messages[0]["content"]
     assert "Avoid medical diagnosis." in messages[0]["content"]
-    assert messages[1]["role"] == "system"
-    assert "User memory for this same authenticated user" in messages[1]["content"]
-    assert "Compacted memory:\nPrefers vegetarian meals." in messages[1]["content"]
+    assert "Available conversation context" in messages[0]["content"]
+    assert "Do not say you have no memory" in messages[0]["content"]
+    assert "Compacted memory:\nPrefers vegetarian meals." in messages[0]["content"]
     assert (
         "Recent conversation:\nassistant: How can I help today?"
-        in messages[1]["content"]
+        in messages[0]["content"]
     )
     assert messages[-1] == {
         "role": "user",
@@ -186,12 +196,11 @@ def test_nutrition_profile_prompt_assembly_includes_guardrails() -> None:
     assert "Disclaimer: Este bot ayuda a interpretar un plan nutricional" in (
         system_message
     )
-    assert "Profile context documents:" in system_message
-    assert "Document: demo_plan.json" in system_message
-    assert '"crossfit"' in system_message
-    assert '"comida_2"' in system_message
-    assert messages[1]["role"] == "system"
-    assert "El usuario prefiere cenas sencillas." in messages[1]["content"]
+    assert "Profile context documents:" not in system_message
+    assert "Document: demo_plan.json" not in system_message
+    assert '"crossfit"' not in system_message
+    assert '"comida_2"' not in system_message
+    assert "El usuario prefiere cenas sencillas." in messages[0]["content"]
 
 
 def test_changing_profile_changes_prompt_without_code_changes(tmp_path: Path) -> None:

--- a/tests/test_command_imports.py
+++ b/tests/test_command_imports.py
@@ -1,28 +1,35 @@
 def test_command_modules_import() -> None:
     import forge_bot.commands.invite as invite_module
+    from forge_bot.commands.admin_memory import admin_memory, admin_users
     from forge_bot.commands.auth import status
     from forge_bot.commands.auth_guard import admin_required
     from forge_bot.commands.campaign_invite import campaign_invite
+    from forge_bot.commands.get_plan import get_plan
     from forge_bot.commands.greet import greet
     from forge_bot.commands.help import help_command
     from forge_bot.commands.ping import ping
     from forge_bot.commands.policy import accept_policy, decline_policy, policy
     from forge_bot.commands.privacy import delete_my_data, memory_clear, privacy
+    from forge_bot.commands.set_plan import set_plan
     from forge_bot.commands.time import time
     from forge_bot.commands.translate import translate
     from forge_bot.commands.unknown import unknown_command
 
     assert hasattr(invite_module, "invite")
     assert callable(greet)
+    assert callable(admin_users)
+    assert callable(admin_memory)
     assert callable(help_command)
     assert callable(admin_required)
     assert callable(campaign_invite)
+    assert callable(get_plan)
     assert callable(ping)
     assert callable(policy)
     assert callable(privacy)
     assert callable(memory_clear)
     assert callable(delete_my_data)
     assert callable(status)
+    assert callable(set_plan)
     assert callable(time)
     assert callable(translate)
     assert callable(unknown_command)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,9 +8,11 @@ from forge_bot.config import (
     DEFAULT_BOT_PRIVACY_NOTICE_VERSION,
     DEFAULT_BOT_PROFILE,
     DEFAULT_BOT_PROFILES_DIR,
+    DEFAULT_BOT_TIMEZONE,
     DEFAULT_CAMPAIGN_INVITE_MAX_USES_LIMIT,
     DEFAULT_CHAT_MESSAGES_PER_MINUTE,
     DEFAULT_DB_PORT,
+    DEFAULT_DEBUG_CONVERSATION_LOG_DIR,
     DEFAULT_GLOBAL_ACTIVE_AI_REQUESTS,
     DEFAULT_GLOBAL_AI_QUEUE_SIZE,
     DEFAULT_LLM_FALLBACK_PROVIDER,
@@ -25,6 +27,8 @@ from forge_bot.config import (
     DEFAULT_MESSAGE_EXPIRATION_HOURS,
     DEFAULT_MESSAGE_MAX_RETRIES,
     DEFAULT_MESSAGE_PROCESSING_STALE_MINUTES,
+    DEFAULT_NUTRITION_NORMALIZER_MODEL,
+    DEFAULT_NUTRITION_NORMALIZER_PROVIDER,
     DEFAULT_NVIDIA_BASE_URL,
     DEFAULT_NVIDIA_MODEL,
     DEFAULT_OLLAMA_MODEL,
@@ -84,6 +88,10 @@ def test_defaults_are_applied() -> None:
     assert settings.nvidia_api_key == ""
     assert settings.nvidia_base_url == DEFAULT_NVIDIA_BASE_URL
     assert settings.nvidia_model == DEFAULT_NVIDIA_MODEL
+    assert settings.nutrition_normalizer_provider == (
+        DEFAULT_NUTRITION_NORMALIZER_PROVIDER
+    )
+    assert settings.nutrition_normalizer_model == DEFAULT_NUTRITION_NORMALIZER_MODEL
     assert settings.bot_profile == DEFAULT_BOT_PROFILE
     assert settings.bot_profiles_dir == DEFAULT_BOT_PROFILES_DIR
     assert settings.bot_policy_version == DEFAULT_BOT_POLICY_VERSION
@@ -117,8 +125,11 @@ def test_defaults_are_applied() -> None:
     )
     assert settings.memory_max_message_chars == DEFAULT_MEMORY_MAX_MESSAGE_CHARS
     assert settings.memory_compacted_max_chars == DEFAULT_MEMORY_COMPACTED_MAX_CHARS
+    assert not settings.debug_conversation_log_enabled
+    assert settings.debug_conversation_log_dir == DEFAULT_DEBUG_CONVERSATION_LOG_DIR
     assert not settings.analytics_consent_enabled
     assert not settings.training_consent_enabled
+    assert settings.bot_timezone == DEFAULT_BOT_TIMEZONE
 
 
 def test_abuse_limit_settings_are_configurable() -> None:
@@ -163,6 +174,18 @@ def test_llm_fallback_settings_are_configurable() -> None:
     assert settings.nvidia_model == "nvidia/example-model"
 
 
+def test_nutrition_normalizer_settings_are_configurable() -> None:
+    env = valid_env() | {
+        "NUTRITION_NORMALIZER_PROVIDER": "OLLAMA",
+        "NUTRITION_NORMALIZER_MODEL": "small-local-normalizer",
+    }
+
+    settings = Settings.from_env(env)
+
+    assert settings.nutrition_normalizer_provider == "ollama"
+    assert settings.nutrition_normalizer_model == "small-local-normalizer"
+
+
 def test_memory_settings_are_configurable() -> None:
     env = valid_env() | {
         "MEMORY_ENABLED": "false",
@@ -181,3 +204,40 @@ def test_memory_settings_are_configurable() -> None:
     assert settings.memory_compaction_source_messages == 3
     assert settings.memory_max_message_chars == 1000
     assert settings.memory_compacted_max_chars == 700
+
+
+def test_debug_conversation_log_settings_are_configurable() -> None:
+    env = valid_env() | {
+        "DEBUG_CONVERSATION_LOG_ENABLED": "true",
+        "DEBUG_CONVERSATION_LOG_DIR": "/tmp/botforge-debug-conversations",
+    }
+
+    settings = Settings.from_env(env)
+
+    assert settings.debug_conversation_log_enabled is True
+    assert settings.debug_conversation_log_dir == "/tmp/botforge-debug-conversations"
+
+
+def test_debug_conversation_log_is_blocked_in_production_by_default() -> None:
+    env = valid_env() | {
+        "BOTFORGE_ENV": "production",
+        "DEBUG_CONVERSATION_LOG_ENABLED": "true",
+    }
+
+    with pytest.raises(SettingsError, match="DEBUG_CONVERSATION_LOG_ENABLED"):
+        Settings.from_env(env)
+
+
+def test_bot_timezone_is_configurable() -> None:
+    env = valid_env() | {"BOT_TIMEZONE": "UTC"}
+
+    settings = Settings.from_env(env)
+
+    assert settings.bot_timezone == "UTC"
+
+
+def test_invalid_bot_timezone_fails_fast() -> None:
+    env = valid_env() | {"BOT_TIMEZONE": "Europe/NotAPlace"}
+
+    with pytest.raises(SettingsError, match="BOT_TIMEZONE"):
+        Settings.from_env(env)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -23,6 +23,12 @@ class FakeCursor:
             self.rowcount = 1
         elif "DELETE FROM conversation_messages" in normalized:
             self.rowcount = 3
+        elif "DELETE FROM langchain_chat_history" in normalized:
+            self.rowcount = 5
+        elif "DELETE FROM langchain_chat_sessions" in normalized:
+            self.rowcount = 2
+        elif "DELETE FROM nutrition_daily_logs" in normalized:
+            self.rowcount = 2
         elif "DELETE FROM user_memory_summaries" in normalized:
             self.rowcount = 1
         elif "UPDATE inbound_messages" in normalized:
@@ -69,7 +75,7 @@ def test_memory_clear_also_scrubs_answered_inbound_bootstrap(
     result = clear_memory_for_telegram_user(telegram_id=456)
 
     assert result is not None
-    assert result.conversation_memory == 3
+    assert result.conversation_memory == 10
     assert result.compacted_memory == 1
     assert connection.committed is True
     assert connection.rolled_back is False
@@ -79,5 +85,17 @@ def test_memory_clear_also_scrubs_answered_inbound_bootstrap(
         "UPDATE inbound_messages SET text = NULL, raw_update = NULL" in statement
         and "status = 'answered'" in statement
         and "message_type = 'text'" in statement
+        for statement in connection.cursor_obj.statements
+    )
+    assert any(
+        "DELETE FROM langchain_chat_history WHERE session_id IN" in statement
+        for statement in connection.cursor_obj.statements
+    )
+    assert any(
+        "DELETE FROM langchain_chat_sessions WHERE user_id = %s" in statement
+        for statement in connection.cursor_obj.statements
+    )
+    assert any(
+        "DELETE FROM nutrition_daily_logs WHERE user_id = %s" in statement
         for statement in connection.cursor_obj.statements
     )

--- a/tests/test_debug_conversation_log.py
+++ b/tests/test_debug_conversation_log.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timezone
+
+from helpers import make_settings
+
+from forge_bot.debug_conversation_log import (
+    DebugConversationTurn,
+    append_debug_conversation_turn,
+)
+
+
+def test_debug_conversation_log_is_disabled_by_default(tmp_path) -> None:
+    settings = make_settings(debug_conversation_log_dir=str(tmp_path))
+
+    written = append_debug_conversation_turn(
+        DebugConversationTurn(
+            bot_profile_id="nutrition",
+            internal_user_id=7,
+            user_message="hola",
+            assistant_message="respuesta",
+        ),
+        settings=settings,
+    )
+
+    assert written is False
+    assert list(tmp_path.rglob("*.txt")) == []
+
+
+def test_debug_conversation_log_writes_plain_text_per_user_profile(tmp_path) -> None:
+    settings = make_settings(
+        debug_conversation_log_enabled=True,
+        debug_conversation_log_dir=str(tmp_path),
+    )
+
+    written = append_debug_conversation_turn(
+        DebugConversationTurn(
+            bot_profile_id="nutrition",
+            internal_user_id=7,
+            telegram_user_id=123,
+            telegram_chat_id=456,
+            telegram_message_id=99,
+            inbound_message_id=55,
+            request_id="req-1",
+            created_at=datetime(2026, 5, 24, 10, 0, tzinfo=timezone.utc),
+            user_message="Que ceno?",
+            assistant_message="Merluza con verduras.",
+        ),
+        settings=settings,
+    )
+
+    path = tmp_path / "nutrition" / "user_7.txt"
+    assert written is True
+    assert path.is_file()
+    content = path.read_text(encoding="utf-8")
+    assert "at: 2026-05-24T10:00:00+00:00" in content
+    assert "bot_profile_id: nutrition" in content
+    assert "internal_user_id: 7" in content
+    assert "telegram_user_id: 123" in content
+    assert "request_id: req-1" in content
+    assert "[USER]\nQue ceno?" in content
+    assert "[ASSISTANT]\nMerluza con verduras." in content
+
+
+def test_debug_conversation_log_sanitizes_path_parts(tmp_path) -> None:
+    settings = make_settings(
+        debug_conversation_log_enabled=True,
+        debug_conversation_log_dir=str(tmp_path),
+    )
+
+    written = append_debug_conversation_turn(
+        DebugConversationTurn(
+            bot_profile_id="../nutrition profile",
+            telegram_user_id=123,
+            user_message="hola",
+            assistant_message="respuesta",
+        ),
+        settings=settings,
+    )
+
+    assert written is True
+    assert (tmp_path / "nutrition_profile" / "telegram_123.txt").is_file()

--- a/tests/test_get_plan.py
+++ b/tests/test_get_plan.py
@@ -1,0 +1,120 @@
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from forge_bot.commands import auth_guard
+from forge_bot.commands import get_plan as get_plan_module
+from forge_bot.commands.get_plan import get_plan
+from forge_bot.nutrition.plan_store import ActiveNutritionPlanDocuments
+
+
+class FakeMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+        self.documents: list[tuple[str, bytes]] = []
+
+    async def reply_text(self, text: str) -> None:
+        self.replies.append(text)
+
+    async def reply_document(self, *, document: Any, filename: str) -> None:
+        self.documents.append((filename, document.getvalue()))
+
+
+def update() -> Any:
+    return SimpleNamespace(
+        effective_user=SimpleNamespace(id=123),
+        message=FakeMessage(),
+    )
+
+
+def active_documents() -> ActiveNutritionPlanDocuments:
+    situations = {
+        "plan_id": "active_plan",
+        "situaciones": {
+            "no_entreno": {
+                "suplementacion": [],
+                "momentos": {"cena": "comida_1"},
+            }
+        },
+    }
+    meals = {
+        "plan_id": "active_plan",
+        "comidas": {
+            "comida_1": {
+                "descripcion": "Cena",
+                "and": ["200g merluza", "verdura"],
+            }
+        },
+    }
+    return ActiveNutritionPlanDocuments(
+        plan_uuid="plan-uuid",
+        documents={"situaciones": situations, "comidas": meals},
+        combined={
+            "plan_id": "active_plan",
+            "situaciones": situations["situaciones"],
+            "comidas": meals["comidas"],
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def authorize(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth_guard, "verify_user", lambda telegram_id: True)
+    monkeypatch.setattr(
+        auth_guard,
+        "has_current_policy_acceptance",
+        lambda telegram_id: True,
+    )
+    monkeypatch.setattr(
+        get_plan_module,
+        "get_user_by_telegram_id",
+        lambda telegram_id: {"id": 7},
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_plan_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        get_plan_module,
+        "load_active_nutrition_plan_documents",
+        lambda user_id: active_documents(),
+    )
+    request = update()
+
+    await get_plan(request, SimpleNamespace(args=[]))
+
+    assert "Plan nutricional activo" in request.message.replies[0]
+    assert "Plan: active_plan" in request.message.replies[0]
+    assert "- no_entreno: 1 momentos" in request.message.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_get_plan_exports_meals_document(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        get_plan_module,
+        "load_active_nutrition_plan_documents",
+        lambda user_id: active_documents(),
+    )
+    request = update()
+
+    await get_plan(request, SimpleNamespace(args=["comidas"]))
+
+    assert request.message.documents[0][0] == "comidas.json"
+    payload = json.loads(request.message.documents[0][1].decode("utf-8"))
+    assert payload["comidas"]["comida_1"]["descripcion"] == "Cena"
+
+
+@pytest.mark.asyncio
+async def test_get_plan_without_active_plan(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        get_plan_module,
+        "load_active_nutrition_plan_documents",
+        lambda user_id: None,
+    )
+    request = update()
+
+    await get_plan(request, SimpleNamespace(args=[]))
+
+    assert "no tienes un plan nutricional activo" in request.message.replies[0]

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -30,19 +30,14 @@ async def test_help_hides_admin_invite_for_non_admin(
 
     await help_command(update, SimpleNamespace())
 
-    assert "/status - Check your linked identity." in update.message.replies[0]
-    assert "/privacy - Review stored data and controls." in update.message.replies[0]
-    assert "/memory_clear - Clear personalization memory." in update.message.replies[0]
-    assert "/delete_my_data - Start data deletion." in update.message.replies[0]
-    assert (
-        "/set_plan - Upload your nutrition plan JSON files."
-        in (update.message.replies[0])
-    )
-    assert (
-        "/get_plan - Review or export your active nutrition plan."
-        in (update.message.replies[0])
-    )
-    assert "/invite" not in update.message.replies[0]
+    reply = update.message.replies[0]
+    assert "/status - Check your linked identity." in reply
+    assert "/privacy - Review stored data and controls." in reply
+    assert "/memory_clear - Clear personalization memory." in reply
+    assert "/delete_my_data - Start data deletion." in reply
+    assert "/set_plan - Upload your nutrition plan JSON files." in reply
+    assert "/get_plan - Review or export your active nutrition plan." in reply
+    assert "/invite" not in reply
 
 
 @pytest.mark.asyncio
@@ -52,12 +47,8 @@ async def test_help_shows_admin_invite_shape(monkeypatch: pytest.MonkeyPatch) ->
 
     await help_command(update, SimpleNamespace())
 
-    assert "/invite <role> <email>" in update.message.replies[0]
-    assert "/admin_users [limit]" in update.message.replies[0]
-    assert (
-        "/admin_memory <user_id|tg:telegram_id|email:value|username:value>"
-        in (update.message.replies[0])
-    )
-    assert (
-        "/campaign_invite <role> <expires_at> <max_uses>" in update.message.replies[0]
-    )
+    reply = update.message.replies[0]
+    assert "/invite <role> <email>" in reply
+    assert "/admin_users [limit]" in reply
+    assert "/admin_memory <user_id|tg:telegram_id|email:value|username:value>" in reply
+    assert "/campaign_invite <role> <expires_at> <max_uses>" in reply

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import pytest
 
+from forge_bot.commands import auth_guard
 from forge_bot.commands.help import help_command
 
 
@@ -21,11 +22,31 @@ def create_update() -> Any:
     )
 
 
+def allow_login(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth_guard, "verify_user", lambda telegram_id: True)
+    monkeypatch.setattr(
+        auth_guard,
+        "has_current_policy_acceptance",
+        lambda telegram_id: True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_help_requires_linked_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    update = create_update()
+    monkeypatch.setattr(auth_guard, "verify_user", lambda telegram_id: False)
+
+    await help_command(update, SimpleNamespace())
+
+    assert update.message.replies == [auth_guard.INVITE_REQUIRED_MESSAGE]
+
+
 @pytest.mark.asyncio
 async def test_help_hides_admin_invite_for_non_admin(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     update = create_update()
+    allow_login(monkeypatch)
     monkeypatch.setattr("forge_bot.commands.help.is_admin", lambda telegram_id: False)
 
     await help_command(update, SimpleNamespace())
@@ -43,6 +64,7 @@ async def test_help_hides_admin_invite_for_non_admin(
 @pytest.mark.asyncio
 async def test_help_shows_admin_invite_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     update = create_update()
+    allow_login(monkeypatch)
     monkeypatch.setattr("forge_bot.commands.help.is_admin", lambda telegram_id: True)
 
     await help_command(update, SimpleNamespace())

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -34,11 +34,13 @@ async def test_help_hides_admin_invite_for_non_admin(
     assert "/privacy - Review stored data and controls." in update.message.replies[0]
     assert "/memory_clear - Clear personalization memory." in update.message.replies[0]
     assert "/delete_my_data - Start data deletion." in update.message.replies[0]
-    assert "/set_plan - Upload your nutrition plan JSON files." in (
-        update.message.replies[0]
+    assert (
+        "/set_plan - Upload your nutrition plan JSON files."
+        in (update.message.replies[0])
     )
-    assert "/get_plan - Review or export your active nutrition plan." in (
-        update.message.replies[0]
+    assert (
+        "/get_plan - Review or export your active nutrition plan."
+        in (update.message.replies[0])
     )
     assert "/invite" not in update.message.replies[0]
 
@@ -52,8 +54,9 @@ async def test_help_shows_admin_invite_shape(monkeypatch: pytest.MonkeyPatch) ->
 
     assert "/invite <role> <email>" in update.message.replies[0]
     assert "/admin_users [limit]" in update.message.replies[0]
-    assert "/admin_memory <user_id|tg:telegram_id|email:value|username:value>" in (
-        update.message.replies[0]
+    assert (
+        "/admin_memory <user_id|tg:telegram_id|email:value|username:value>"
+        in (update.message.replies[0])
     )
     assert (
         "/campaign_invite <role> <expires_at> <max_uses>" in update.message.replies[0]

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -34,6 +34,12 @@ async def test_help_hides_admin_invite_for_non_admin(
     assert "/privacy - Review stored data and controls." in update.message.replies[0]
     assert "/memory_clear - Clear personalization memory." in update.message.replies[0]
     assert "/delete_my_data - Start data deletion." in update.message.replies[0]
+    assert "/set_plan - Upload your nutrition plan JSON files." in (
+        update.message.replies[0]
+    )
+    assert "/get_plan - Review or export your active nutrition plan." in (
+        update.message.replies[0]
+    )
     assert "/invite" not in update.message.replies[0]
 
 
@@ -45,6 +51,10 @@ async def test_help_shows_admin_invite_shape(monkeypatch: pytest.MonkeyPatch) ->
     await help_command(update, SimpleNamespace())
 
     assert "/invite <role> <email>" in update.message.replies[0]
+    assert "/admin_users [limit]" in update.message.replies[0]
+    assert "/admin_memory <user_id|tg:telegram_id|email:value|username:value>" in (
+        update.message.replies[0]
+    )
     assert (
         "/campaign_invite <role> <expires_at> <max_uses>" in update.message.replies[0]
     )

--- a/tests/test_invite_auth.py
+++ b/tests/test_invite_auth.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import pytest
 
+from forge_bot.commands import auth_guard
 from forge_bot.commands.auth import start, status
 from forge_bot.database import InviteRedemption
 
@@ -168,6 +169,7 @@ async def test_start_reports_already_linked_user(
 @pytest.mark.asyncio
 async def test_status_shows_identity_copy(monkeypatch: pytest.MonkeyPatch) -> None:
     update = create_update()
+    monkeypatch.setattr(auth_guard, "verify_user", lambda telegram_id: True)
     monkeypatch.setattr(
         "forge_bot.commands.auth.status_user",
         lambda telegram_id: {
@@ -191,6 +193,7 @@ async def test_status_handles_campaign_identity_without_email(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     update = create_update()
+    monkeypatch.setattr(auth_guard, "verify_user", lambda telegram_id: True)
     monkeypatch.setattr(
         "forge_bot.commands.auth.status_user",
         lambda telegram_id: {
@@ -206,15 +209,12 @@ async def test_status_handles_campaign_identity_without_email(
 
 
 @pytest.mark.asyncio
-async def test_status_reports_unlinked_identity(
+async def test_status_denies_unlinked_identity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     update = create_update()
-    monkeypatch.setattr("forge_bot.commands.auth.status_user", lambda telegram_id: None)
+    monkeypatch.setattr(auth_guard, "verify_user", lambda telegram_id: False)
 
     await status(update, create_context())
 
-    assert update.message.replies == [
-        "Identity not linked.\n\n"
-        "Next step: Open your invite link to connect your account"
-    ]
+    assert update.message.replies == [auth_guard.INVITE_REQUIRED_MESSAGE]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,14 @@ def test_runtime_processes_updates_concurrently() -> None:
     assert ".post_init(recover_and_drain_queued_messages)" in main_source
 
 
+def test_document_uploads_can_continue_set_plan_without_caption() -> None:
+    main_source = Path("src/forge_bot/main.py").read_text(encoding="utf-8")
+    document_handler = "MessageHandler(\n            filters.Document.ALL,"
+
+    assert document_handler in main_source
+    assert "filters.CaptionRegex" not in main_source
+
+
 @pytest.mark.asyncio
 async def test_startup_drain_replays_recoverable_queued_updates(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_memory_backend.py
+++ b/tests/test_memory_backend.py
@@ -1,0 +1,192 @@
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+
+from forge_bot.bot_profile import BotProfile, BotProfileError
+from forge_bot.memory_backend import (
+    LangChainPostgresMemoryBackend,
+    _session_id,
+    memory_backend_for_profile,
+)
+
+
+def fake_profile() -> BotProfile:
+    return BotProfile(
+        bot_profile_id="nutrition",
+        bot_display_name="Nutrition",
+        bot_description="Test profile",
+        system_prompt="Be helpful.",
+        domain_rules=("Do not leak secrets.",),
+        disclaimer_text="Test only.",
+        default_language="es",
+        llm_provider="nvidia",
+        llm_model="nvidia/test-model",
+        memory_enabled=True,
+        memory_backend="postgres",
+        analytics_enabled=False,
+    )
+
+
+def fake_settings(**overrides: object) -> SimpleNamespace:
+    values = {
+        "memory_recent_messages": 2,
+        "memory_compaction_trigger_messages": 3,
+        "memory_compaction_source_messages": 2,
+        "memory_max_message_chars": 4000,
+        "memory_compacted_max_chars": 2000,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_profile_memory_backend_selects_langchain_postgres() -> None:
+    profile = replace(fake_profile(), memory_backend="langchain_postgres")
+
+    backend = memory_backend_for_profile(profile)
+
+    assert isinstance(backend, LangChainPostgresMemoryBackend)
+
+
+def test_profile_memory_backend_rejects_unknown_value() -> None:
+    profile = replace(fake_profile(), memory_backend="unknown_backend")
+
+    with pytest.raises(BotProfileError, match="Unsupported memory backend"):
+        memory_backend_for_profile(profile)
+
+
+def test_session_id_is_stable_uuid_for_user_profile_pair() -> None:
+    session_id = _session_id(user_id=42, bot_profile_id="nutrition")
+
+    assert session_id == _session_id(user_id=42, bot_profile_id="nutrition")
+    assert session_id != _session_id(user_id=42, bot_profile_id="default_dev")
+    assert len(session_id) == 36
+
+
+def test_langchain_backend_returns_prompt_context_from_official_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = LangChainPostgresMemoryBackend()
+    monkeypatch.setattr("forge_bot.memory_backend.get_settings", fake_settings)
+    monkeypatch.setattr(backend, "_ensure_session_mapping", lambda **kwargs: True)
+    monkeypatch.setattr(
+        backend,
+        "_read_summary_state",
+        lambda **kwargs: ("prefiere cenas simples", 0),
+    )
+    monkeypatch.setattr(
+        backend,
+        "_get_recent_langchain_messages",
+        lambda **kwargs: [
+            HumanMessage(content="Que ceno?"),
+            AIMessage(content="Merluza con verduras."),
+        ],
+    )
+
+    context = backend.get_context(user_id=1, bot_profile_id="nutrition")
+
+    assert context.compacted_user_memory == "prefiere cenas simples"
+    assert context.recent_conversation_messages == [
+        {"role": "user", "content": "Que ceno?"},
+        {"role": "assistant", "content": "Merluza con verduras."},
+    ]
+
+
+def test_langchain_backend_stores_turn_with_truncated_messages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = LangChainPostgresMemoryBackend()
+    stored_messages: list[BaseMessage] = []
+
+    monkeypatch.setattr(
+        "forge_bot.memory_backend.get_settings",
+        lambda: fake_settings(memory_max_message_chars=5),
+    )
+    monkeypatch.setattr(backend, "_ensure_session_mapping", lambda **kwargs: True)
+    monkeypatch.setattr(
+        backend,
+        "_add_langchain_messages",
+        lambda *, messages, **kwargs: stored_messages.extend(messages),
+    )
+
+    stored = backend.store_successful_turn(
+        user_id=1,
+        bot_profile_id="nutrition",
+        user_message="hola usuario",
+        assistant_message="respuesta larga",
+    )
+
+    assert stored is True
+    assert isinstance(stored_messages[0], HumanMessage)
+    assert stored_messages[0].content == "hola"
+    assert isinstance(stored_messages[1], AIMessage)
+    assert stored_messages[1].content == "respu"
+
+
+@pytest.mark.asyncio
+async def test_langchain_backend_compacts_unsummarized_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = LangChainPostgresMemoryBackend()
+    saved: list[dict[str, object]] = []
+    summarized_inputs: list[list[dict[str, str]]] = []
+
+    monkeypatch.setattr(
+        "forge_bot.memory_backend.get_settings",
+        lambda: fake_settings(
+            memory_compaction_trigger_messages=3,
+            memory_compaction_source_messages=2,
+            memory_compacted_max_chars=7,
+        ),
+    )
+    monkeypatch.setattr(
+        backend,
+        "_read_summary_state",
+        lambda **kwargs: ("resumen previo", 1),
+    )
+    monkeypatch.setattr(
+        backend,
+        "_get_unsummarized_langchain_messages",
+        lambda **kwargs: [
+            AIMessage(content="respuesta 1"),
+            HumanMessage(content="pregunta 2"),
+            AIMessage(content="respuesta 2"),
+        ],
+    )
+    monkeypatch.setattr(
+        backend,
+        "_save_summary_state",
+        lambda **kwargs: saved.append(kwargs),
+    )
+
+    async def summarize(
+        existing_summary: str | None,
+        source_messages: list[dict[str, str]],
+        max_chars: int,
+    ) -> str:
+        assert existing_summary == "resumen previo"
+        assert max_chars == 7
+        summarized_inputs.append(source_messages)
+        return "resumen actualizado largo"
+
+    await backend.compact_memory_if_needed(
+        user_id=1,
+        bot_profile_id="nutrition",
+        summarizer=summarize,
+    )
+
+    assert summarized_inputs == [
+        [
+            {"role": "assistant", "content": "respuesta 1"},
+            {"role": "user", "content": "pregunta 2"},
+        ]
+    ]
+    assert saved == [
+        {
+            "user_id": 1,
+            "bot_profile_id": "nutrition",
+            "summary": "resumen",
+            "source_message_count": 3,
+        }
+    ]

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -85,6 +85,8 @@ def test_langchain_chat_memory_migration_uses_official_history_schema() -> None:
     assert "session_id UUID NOT NULL" in contents
     assert "message JSONB NOT NULL" in contents
     assert "idx_langchain_chat_history_session_id" in contents
+    assert "ON langchain_chat_history (session_id)" in contents
+    assert "ON langchain_chat_history (session_id, id)" not in contents
     assert "CREATE TABLE IF NOT EXISTS langchain_chat_sessions" in contents
 
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -73,3 +73,78 @@ def test_conversation_memory_migration_tracks_recent_and_compacted_memory() -> N
     assert "CHECK (role IN ('user', 'assistant'))" in contents
     assert "CREATE TABLE IF NOT EXISTS user_memory_summaries" in contents
     assert "UNIQUE (user_id, bot_profile_id)" in contents
+
+
+def test_langchain_chat_memory_migration_uses_official_history_schema() -> None:
+    migration = Path("migrations/versions/20260524_0009_add_langchain_chat_memory.py")
+    contents = migration.read_text(encoding="utf-8")
+
+    assert 'revision: str = "20260524_0009"' in contents
+    assert 'down_revision: str | Sequence[str] | None = "20260519_0008"' in contents
+    assert "CREATE TABLE IF NOT EXISTS langchain_chat_history" in contents
+    assert "session_id UUID NOT NULL" in contents
+    assert "message JSONB NOT NULL" in contents
+    assert "idx_langchain_chat_history_session_id" in contents
+    assert "CREATE TABLE IF NOT EXISTS langchain_chat_sessions" in contents
+
+
+def test_nutrition_daily_logs_migration_tracks_editable_day_state() -> None:
+    migration = Path(
+        "migrations/versions/20260524_0010_create_nutrition_daily_logs.py"
+    )
+
+    contents = migration.read_text()
+
+    assert 'revision: str = "20260524_0010"' in contents
+    assert 'down_revision: str | Sequence[str] | None = "20260524_0009"' in contents
+    assert "CREATE TABLE IF NOT EXISTS nutrition_daily_logs" in contents
+    assert "user_id INTEGER NOT NULL REFERENCES users(id)" in contents
+    assert "situation_key TEXT NULL" in contents
+    assert "situation_updated_at TIMESTAMPTZ NULL" in contents
+    assert "meals JSONB NOT NULL DEFAULT '{}'::jsonb" in contents
+    assert "UNIQUE (user_id, bot_profile_id, log_date)" in contents
+
+
+def test_langchain_history_window_index_migration_supports_bounded_reads() -> None:
+    migration = Path(
+        "migrations/versions/20260524_0011_add_langchain_history_window_index.py"
+    )
+
+    contents = migration.read_text()
+
+    assert 'revision: str = "20260524_0011"' in contents
+    assert 'down_revision: str | Sequence[str] | None = "20260524_0010"' in contents
+    assert "idx_langchain_chat_history_session_id_id" in contents
+    assert "ON langchain_chat_history (session_id, id)" in contents
+
+
+def test_nutrition_plan_storage_migration_tracks_active_user_plan() -> None:
+    migration = Path("migrations/versions/20260524_0012_create_nutrition_plans.py")
+
+    contents = migration.read_text()
+
+    assert 'revision: str = "20260524_0012"' in contents
+    assert 'down_revision: str | Sequence[str] | None = "20260524_0011"' in contents
+    assert "CREATE EXTENSION IF NOT EXISTS pgcrypto" in contents
+    assert "CREATE TABLE IF NOT EXISTS nutrition_plans" in contents
+    assert "user_id INTEGER NOT NULL REFERENCES users(id)" in contents
+    assert "status IN ('draft', 'active', 'failed', 'archived')" in contents
+    assert "ux_nutrition_plans_one_active_per_user" in contents
+    assert "CREATE TABLE IF NOT EXISTS nutrition_plan_documents" in contents
+    assert "document_type IN ('meal_plan')" in contents
+
+
+def test_nutrition_plan_document_split_migration_tracks_source_documents() -> None:
+    migration = Path(
+        "migrations/versions/20260524_0013_split_nutrition_plan_documents.py"
+    )
+
+    contents = migration.read_text()
+
+    assert 'revision: str = "20260524_0013"' in contents
+    assert 'down_revision: str | Sequence[str] | None = "20260524_0012"' in contents
+    assert "nutrition_plan_documents_document_type_check" in contents
+    assert "'situaciones'" in contents
+    assert "'comidas'" in contents
+    assert "'reglas_adaptacion'" in contents
+    assert "'recetas'" in contents

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -91,9 +91,7 @@ def test_langchain_chat_memory_migration_uses_official_history_schema() -> None:
 
 
 def test_nutrition_daily_logs_migration_tracks_editable_day_state() -> None:
-    migration = Path(
-        "migrations/versions/20260524_0010_create_nutrition_daily_logs.py"
-    )
+    migration = Path("migrations/versions/20260524_0010_create_nutrition_daily_logs.py")
 
     contents = migration.read_text()
 

--- a/tests/test_nutrition_daily_state.py
+++ b/tests/test_nutrition_daily_state.py
@@ -1,0 +1,151 @@
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+from forge_bot.nutrition.daily_state import (
+    NutritionDailyLog,
+    build_daily_update,
+    message_cancels_training,
+    message_changes_day_type,
+    preview_daily_update,
+    to_prompt_payload,
+)
+from forge_bot.nutrition.intent import classify_nutrition_message
+from forge_bot.nutrition.plan import load_nutrition_plan_file
+
+
+def _sample_plan():
+    return load_nutrition_plan_file(Path("tests/fixtures/nutrition_plan.json"))
+
+
+def test_daily_update_detects_training_cancellation_as_actual_rest_day() -> None:
+    plan = _sample_plan()
+    message = "Al final no he ido al crossfit, que ceno?"
+
+    update = build_daily_update(
+        plan=plan,
+        message=message,
+        understanding=classify_nutrition_message(message),
+        normalized_message=None,
+    )
+
+    assert update.situation_key == "no_entreno"
+    assert update.note is not None
+    assert "Tipo de dia actualizado a no_entreno" in update.note
+    assert message_cancels_training(message) is True
+    assert message_changes_day_type(message) is True
+
+
+def test_daily_update_detects_activity_replacement_as_day_type() -> None:
+    plan = _sample_plan()
+    message = "Al final cambio crossfit por natacion, que ceno?"
+
+    update = build_daily_update(
+        plan=plan,
+        message=message,
+        understanding=classify_nutrition_message(message),
+        normalized_message=None,
+    )
+
+    assert update.situation_key == "natacion"
+    assert update.note is not None
+    assert "Tipo de dia actualizado a natacion" in update.note
+    assert message_changes_day_type(message) is True
+
+
+def test_daily_update_detects_current_activity_without_previous_activity() -> None:
+    plan = _sample_plan()
+    message = "Al final voy a natacion, que ceno?"
+
+    update = build_daily_update(
+        plan=plan,
+        message=message,
+        understanding=classify_nutrition_message(message),
+        normalized_message=None,
+    )
+
+    assert update.situation_key == "natacion"
+
+
+def test_daily_update_does_not_store_hypothetical_situation() -> None:
+    plan = _sample_plan()
+    message = "Futbol, que ceno?"
+
+    update = build_daily_update(
+        plan=plan,
+        message=message,
+        understanding=classify_nutrition_message(message),
+        normalized_message=None,
+    )
+
+    assert update.situation_key is None
+
+
+def test_daily_update_detects_skipped_meal_moment() -> None:
+    plan = _sample_plan()
+    message = "Que ceno hoy dia de no entreno? Me he saltado la merienda."
+
+    update = build_daily_update(
+        plan=plan,
+        message=message,
+        understanding=classify_nutrition_message(message),
+        normalized_message=None,
+    )
+
+    assert update.situation_key == "no_entreno"
+    assert update.skipped_moments == ("merienda",)
+
+
+def test_preview_daily_update_does_not_persist_but_projects_prompt_state() -> None:
+    plan = _sample_plan()
+    update = build_daily_update(
+        plan=plan,
+        message="Hoy no entreno, que ceno?",
+        understanding=classify_nutrition_message("Hoy no entreno, que ceno?"),
+        normalized_message=None,
+    )
+
+    preview = preview_daily_update(
+        log=None,
+        user_id=7,
+        bot_profile_id="nutrition",
+        log_date=date(2026, 5, 24),
+        plan=plan,
+        update=update,
+    )
+
+    assert preview is not None
+    assert preview.id == 0
+    assert preview.situation_key == "no_entreno"
+
+
+def test_daily_log_prompt_payload_is_compact_and_uses_day_type() -> None:
+    log = NutritionDailyLog(
+        id=1,
+        user_id=7,
+        bot_profile_id="nutrition",
+        log_date=date(2026, 5, 24),
+        plan_id="demo",
+        situation_key="no_entreno",
+        situation_updated_at=datetime(2026, 5, 24, 20, 0, tzinfo=timezone.utc),
+        meals={
+            "desayuno": {
+                "status": "completed",
+                "completed": True,
+                "text": "tostada",
+            }
+        },
+        notes=({"text": "cambio de dia"},),
+    )
+
+    payload = to_prompt_payload(log)
+
+    assert payload is not None
+    assert payload["tipo_dia"] == "no_entreno"
+    assert payload["situation_key"] == "no_entreno"
+    assert payload["meals"] == {
+        "desayuno": {
+            "status": "completed",
+            "completed": True,
+            "text": "tostada",
+        }
+    }

--- a/tests/test_nutrition_intent.py
+++ b/tests/test_nutrition_intent.py
@@ -1,0 +1,75 @@
+import pytest
+
+from forge_bot.nutrition.intent import classify_nutrition_message
+
+
+@pytest.mark.parametrize(
+    ("message", "expected_intent"),
+    [
+        (
+            "Hazme la planificacion de la semana: lunes CrossFit, miercoles futbol "
+            "y viernes no entreno.",
+            "weekly_planning",
+        ),
+        ("Dame la lista de la compra.", "shopping_list"),
+        ("Que ceno hoy dia de no entreno?", "recommend_meal"),
+        (
+            "Voy a cenar salmon con ensalada, le meto aguacate?",
+            "adjust_existing_meal",
+        ),
+        (
+            "He comido secreto y chuletas, como compenso la cena?",
+            "recover_from_high_fat_meal",
+        ),
+        (
+            "Me acabo de dar un atracon de dulces y un gofre.",
+            "recover_from_high_carb_meal",
+        ),
+        ("Anoche me tome dos cervezas.", "alcohol_recovery_or_guidance"),
+        ("Con respecto al plan, como vamos hoy?", "evaluate_day"),
+        ("Cuanta proteina llevo?", "calculate_macros"),
+        ("Estoy reventado del CrossFit, dime algo facil.", "recovery_guidance"),
+        ("Puedo tomar creatina?", "supplement_guidance"),
+        (
+            "Quiero dejar pollo congelado para varios dias.",
+            "batch_cooking_or_recipe_preparation",
+        ),
+        ("Te paso una receta de arroz con atun y huevo.", "recipe_submission"),
+        ("/set_plan", "plan_generation"),
+        ("Tengo hambre pero no quiero liarla.", "hunger_management"),
+    ],
+)
+def test_classify_nutrition_messages(message: str, expected_intent: str) -> None:
+    understanding = classify_nutrition_message(message)
+
+    assert understanding.intent == expected_intent
+
+
+def test_classify_weekly_planning_extracts_days_foods_and_people() -> None:
+    understanding = classify_nutrition_message(
+        "Hazme la planificacion de la semana. Yo lunes CrossFit, miercoles futbol, "
+        "viernes no entreno. Mi pareja hace CrossFit jueves. Mete salmon el lunes."
+    )
+
+    assert understanding.intent == "multi_person_meal_planning"
+    assert understanding.mentioned_days == ("lunes", "miercoles", "jueves", "viernes")
+    assert "salmon" in understanding.foods
+    assert understanding.people == ("pareja",)
+
+
+def test_classify_deviations_are_preserved_for_follow_up_adjustments() -> None:
+    understanding = classify_nutrition_message(
+        "Que ceno hoy dia de no entreno? Me he saltado la media manana."
+    )
+
+    assert understanding.intent == "log_meal"
+    assert understanding.deviations == ("skipped_meal",)
+
+
+def test_classify_macro_day_request_as_full_day_context() -> None:
+    understanding = classify_nutrition_message(
+        "Cuantos macros tengo que tomar un dia de futbol?"
+    )
+
+    assert understanding.intent == "calculate_macros"
+    assert understanding.asks_for_full_day is True

--- a/tests/test_nutrition_live_nvidia.py
+++ b/tests/test_nutrition_live_nvidia.py
@@ -13,6 +13,7 @@ pytestmark = pytest.mark.skipif(
     reason="live NVIDIA tests are opt-in; set RUN_LIVE_NVIDIA_TESTS=1",
 )
 
+
 def _nvidia_provider() -> tuple[NvidiaNimProvider, str]:
     load_dotenv(Path(".env"))
     api_key = os.getenv("NVIDIA_API_KEY", "").strip()

--- a/tests/test_nutrition_live_nvidia.py
+++ b/tests/test_nutrition_live_nvidia.py
@@ -1,0 +1,104 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+from dotenv import load_dotenv
+
+from forge_bot.engine import NvidiaNimProvider
+from forge_bot.nutrition.plan import load_nutrition_plan_file
+from forge_bot.nutrition.router import resolve_meal_context
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("RUN_LIVE_NVIDIA_TESTS") != "1",
+    reason="live NVIDIA tests are opt-in; set RUN_LIVE_NVIDIA_TESTS=1",
+)
+
+NUTRITION_PROFILE_ROOT = Path("bot_profiles/nutrition")
+
+
+def _nvidia_provider() -> tuple[NvidiaNimProvider, str]:
+    load_dotenv(Path(".env"))
+    api_key = os.getenv("NVIDIA_API_KEY", "").strip()
+    base_url = os.getenv("NVIDIA_BASE_URL", "").strip()
+    model = os.getenv("NVIDIA_MODEL", "").strip()
+    if not api_key or api_key == "<nvidia_api_key>":
+        pytest.skip("NVIDIA_API_KEY is not configured")
+    if not base_url:
+        pytest.skip("NVIDIA_BASE_URL is not configured")
+    if not model:
+        pytest.skip("NVIDIA_MODEL is not configured")
+    return (
+        NvidiaNimProvider(
+            api_key=api_key,
+            base_url=base_url,
+            model=model,
+            timeout_seconds=60,
+        ),
+        model,
+    )
+
+
+@pytest.mark.asyncio
+async def test_live_nvidia_chat_smoke() -> None:
+    provider, model = _nvidia_provider()
+
+    answer = await provider.chat(
+        model=model,
+        messages=[
+            {
+                "role": "system",
+                "content": "/no_think\nResponde solo con: prueba nvidia ok",
+            },
+            {"role": "user", "content": "ping"},
+        ],
+    )
+
+    assert "nvidia" in answer.lower()
+    assert "ok" in answer.lower()
+
+
+@pytest.mark.asyncio
+async def test_live_nvidia_answers_from_resolved_nutrition_chunk() -> None:
+    provider, model = _nvidia_provider()
+    plan = load_nutrition_plan_file(NUTRITION_PROFILE_ROOT, "demo_plan.json")
+    resolution = resolve_meal_context(
+        plan,
+        "Hoy tengo crossfit, que como al mediodia?",
+    )
+    assert resolution.is_resolved
+    assert resolution.meal_block_key == "comida_2"
+
+    context = {
+        "situation_key": resolution.situation_key,
+        "moment_key": resolution.moment_key,
+        "meal_block_key": resolution.meal_block_key,
+        "supplementation": resolution.supplementation,
+        "meal_block": resolution.meal_block,
+    }
+    answer = await provider.chat(
+        model=model,
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "/no_think\n"
+                    "Eres un bot nutricionista. Responde en espanol usando solo "
+                    "el bloque nutricional dado. No inventes cantidades. "
+                    "Devuelve una respuesta breve y practica."
+                ),
+            },
+            {
+                "role": "user",
+                "content": (
+                    "Mensaje original: Hoy tengo crossfit, que como al mediodia?\n"
+                    "Contexto nutricional resuelto:\n"
+                    f"{json.dumps(context, ensure_ascii=False)}"
+                ),
+            },
+        ],
+    )
+
+    normalized = answer.lower()
+    assert "30g" in normalized or "140g" in normalized
+    assert "360g" in normalized or "495g" in normalized

--- a/tests/test_nutrition_live_nvidia.py
+++ b/tests/test_nutrition_live_nvidia.py
@@ -1,21 +1,17 @@
-import json
 import os
 from pathlib import Path
 
 import pytest
 from dotenv import load_dotenv
 
+from forge_bot.bot_profile import load_active_bot_profile
 from forge_bot.engine import NvidiaNimProvider
-from forge_bot.nutrition.plan import load_nutrition_plan_file
-from forge_bot.nutrition.router import resolve_meal_context
+from forge_bot.engine import answer as engine_answer
 
 pytestmark = pytest.mark.skipif(
     os.getenv("RUN_LIVE_NVIDIA_TESTS") != "1",
     reason="live NVIDIA tests are opt-in; set RUN_LIVE_NVIDIA_TESTS=1",
 )
-
-NUTRITION_PROFILE_ROOT = Path("bot_profiles/nutrition")
-
 
 def _nvidia_provider() -> tuple[NvidiaNimProvider, str]:
     load_dotenv(Path(".env"))
@@ -59,44 +55,15 @@ async def test_live_nvidia_chat_smoke() -> None:
 
 
 @pytest.mark.asyncio
-async def test_live_nvidia_answers_from_resolved_nutrition_chunk() -> None:
-    provider, model = _nvidia_provider()
-    plan = load_nutrition_plan_file(NUTRITION_PROFILE_ROOT, "demo_plan.json")
-    resolution = resolve_meal_context(
-        plan,
-        "Hoy tengo crossfit, que como al mediodia?",
-    )
-    assert resolution.is_resolved
-    assert resolution.meal_block_key == "comida_2"
+async def test_live_nvidia_engine_answers_from_resolved_nutrition_chunk() -> None:
+    _nvidia_provider()
+    profile = load_active_bot_profile("nutrition", "bot_profiles")
 
-    context = {
-        "situation_key": resolution.situation_key,
-        "moment_key": resolution.moment_key,
-        "meal_block_key": resolution.meal_block_key,
-        "supplementation": resolution.supplementation,
-        "meal_block": resolution.meal_block,
-    }
-    answer = await provider.chat(
-        model=model,
-        messages=[
-            {
-                "role": "system",
-                "content": (
-                    "/no_think\n"
-                    "Eres un bot nutricionista. Responde en espanol usando solo "
-                    "el bloque nutricional dado. No inventes cantidades. "
-                    "Devuelve una respuesta breve y practica."
-                ),
-            },
-            {
-                "role": "user",
-                "content": (
-                    "Mensaje original: Hoy tengo crossfit, que como al mediodia?\n"
-                    "Contexto nutricional resuelto:\n"
-                    f"{json.dumps(context, ensure_ascii=False)}"
-                ),
-            },
-        ],
+    answer = await engine_answer(
+        "Juanca",
+        "Hoy tengo crossfit, que como al mediodia?",
+        profile=profile,
+        request_id="live-nutrition-router-test",
     )
 
     normalized = answer.lower()

--- a/tests/test_nutrition_orchestrator.py
+++ b/tests/test_nutrition_orchestrator.py
@@ -1,0 +1,613 @@
+import json
+from dataclasses import replace
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from forge_bot.bot_profile import load_active_bot_profile
+from forge_bot.nutrition import orchestrator as nutrition_orchestrator
+from forge_bot.nutrition.daily_state import NutritionDailyLog
+from forge_bot.nutrition.orchestrator import (
+    prepare_nutrition_prompt,
+    prepare_nutrition_prompt_async,
+)
+
+
+def _nutrition_profile():
+    return replace(
+        load_active_bot_profile("nutrition", "bot_profiles"),
+        nutrition_plan_path=Path("tests/fixtures/nutrition_plan.json"),
+    )
+
+
+def _payload(runtime_instruction: str) -> dict[str, object]:
+    start = runtime_instruction.index('{"message_understanding"')
+    return json.loads(runtime_instruction[start:])
+
+
+class FakeNormalizerClient:
+    def __init__(self, response: dict[str, object]) -> None:
+        self.response = response
+        self.models: list[str] = []
+        self.messages: list[list[dict[str, str]]] = []
+
+    async def chat(self, *, model: str, messages: list[dict[str, str]]) -> str:
+        self.models.append(model)
+        self.messages.append(messages)
+        return json.dumps(self.response)
+
+
+def _write_custom_plan(path: Path) -> Path:
+    plan_path = path / "custom_plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "plan_id": "custom_user_plan",
+                "momentos": {
+                    "media_manana": {
+                        "label": "Media manana",
+                        "aliases": ["media manana", "snack manana"],
+                    },
+                    "cena": {"label": "Cena", "aliases": ["cena", "cenar"]},
+                },
+                "situaciones": {
+                    "pilates": {
+                        "label": "Pilates",
+                        "aliases": ["pilates"],
+                        "momentos": {
+                            "media_manana": "snack_pilates",
+                            "cena": "cena_pilates",
+                        },
+                    }
+                },
+                "comidas": {
+                    "snack_pilates": {
+                        "descripcion": "Snack de media manana",
+                        "and": ["1 yogur proteico"],
+                    },
+                    "cena_pilates": {
+                        "descripcion": "Cena ligera",
+                        "and": ["240g pollo", "verdura"],
+                    },
+                },
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    return plan_path
+
+
+def test_prepare_nutrition_prompt_resolves_single_meal_chunk() -> None:
+    setup = prepare_nutrition_prompt(
+        _nutrition_profile(),
+        "Hoy no entreno, que ceno?",
+    )
+
+    assert setup.direct_answer is None
+    assert setup.include_memory is True
+    assert setup.prompt_profile.context_documents == ()
+    assert setup.runtime_instructions
+
+    payload = _payload(setup.runtime_instructions[0])
+    assert payload["message_understanding"]["intent"] == "recommend_meal"
+    assert payload["nutrition_context"]["mode"] == "single_meal"
+    assert payload["nutrition_context"]["situation_key"] == "no_entreno"
+    assert payload["nutrition_context"]["moment_key"] == "cena"
+    assert payload["nutrition_context"]["meal_block_key"] == "comida_3"
+
+
+def test_prepare_nutrition_prompt_uses_recent_context_for_follow_up() -> None:
+    setup = prepare_nutrition_prompt(
+        _nutrition_profile(),
+        "cena",
+        recent_conversation_messages=[
+            {"role": "user", "content": "Que como hoy dia de no entreno?"},
+            {"role": "assistant", "content": "Dime el momento."},
+        ],
+    )
+
+    assert setup.direct_answer is None
+    payload = _payload(setup.runtime_instructions[0])
+    assert payload["nutrition_context"]["situation_key"] == "no_entreno"
+    assert payload["nutrition_context"]["moment_key"] == "cena"
+
+
+def test_prepare_nutrition_prompt_preserves_deviation_context() -> None:
+    setup = prepare_nutrition_prompt(
+        _nutrition_profile(),
+        "Que ceno hoy dia de no entreno? Me he saltado la media manana.",
+    )
+
+    assert setup.direct_answer is None
+    payload = _payload(setup.runtime_instructions[0])
+    assert payload["message_understanding"]["intent"] == "log_meal"
+    assert payload["message_understanding"]["deviations"] == ["skipped_meal"]
+    assert payload["nutrition_context"]["situation_key"] == "no_entreno"
+    assert payload["nutrition_context"]["moment_key"] == "cena"
+
+
+def test_prepare_nutrition_prompt_prioritizes_target_meal_over_daily_log() -> None:
+    setup = prepare_nutrition_prompt(
+        _nutrition_profile(),
+        (
+            "Hola, hoy es dia de futbol y en el desayuno tome una tostada con "
+            "jamon y en la comida lentejas, que puedo tomar para la cena para "
+            "compensar las proteinas que me faltaron en la comida?"
+        ),
+    )
+
+    assert setup.direct_answer is None
+    payload = _payload(setup.runtime_instructions[0])
+    assert payload["message_understanding"]["intent"] == "recommend_meal"
+    assert payload["nutrition_context"]["situation_key"] == "futbol"
+    assert payload["nutrition_context"]["moment_key"] == "cena"
+    assert payload["nutrition_context"]["meal_block_key"] == "comida_3"
+
+
+def test_prepare_nutrition_prompt_asks_for_missing_context_without_llm() -> None:
+    setup = prepare_nutrition_prompt(
+        _nutrition_profile(),
+        "Hoy tengo CrossFit",
+    )
+
+    assert setup.runtime_instructions == ()
+    assert setup.direct_answer is not None
+    assert "dime el momento" in setup.direct_answer
+
+
+def test_prepare_nutrition_prompt_builds_weekly_planning_context() -> None:
+    setup = prepare_nutrition_prompt(
+        _nutrition_profile(),
+        (
+            "Hazme un plan de comidas para la semana: lunes CrossFit, miercoles "
+            "futbol, viernes no entreno y el resto no entreno."
+        ),
+    )
+
+    assert setup.direct_answer is None
+    assert setup.include_memory is True
+    payload = _payload(setup.runtime_instructions[0])
+    context = payload["nutrition_context"]
+    assert context["mode"] == "weekly_planning"
+    assert set(context["situations"]) == {"crossfit", "futbol", "no_entreno"}
+    assert {"comida_1", "comida_2", "comida_3", "comida_4", "comida_5"}.issubset(
+        set(context["meal_blocks"])
+    )
+
+
+def test_prepare_nutrition_prompt_resolves_day_macros_without_meal_loop() -> None:
+    setup = prepare_nutrition_prompt(
+        _nutrition_profile(),
+        (
+            "Quiero saber los macros exactos que tengo un dia de futbol entre "
+            "todas las comidas que tengo que hacer segun mi plan nutricional"
+        ),
+    )
+
+    assert setup.direct_answer is None
+    assert setup.include_memory is True
+    payload = _payload(setup.runtime_instructions[0])
+    assert payload["message_understanding"]["intent"] == "calculate_macros"
+    assert payload["message_understanding"]["asks_for_full_day"] is True
+    assert payload["nutrition_context"]["mode"] == "full_day"
+    assert payload["nutrition_context"]["situation_key"] == "futbol"
+    assert {
+        item["moment_key"] for item in payload["nutrition_context"]["meal_blocks"]
+    } == {"desayuno", "almuerzo", "merienda", "cena"}
+
+
+def test_prepare_nutrition_prompt_uses_assistant_context_for_short_follow_up() -> None:
+    setup = prepare_nutrition_prompt(
+        _nutrition_profile(),
+        "Futbol",
+        recent_conversation_messages=[
+            {"role": "user", "content": "Y si meriendo un batido de proteinas?"},
+            {
+                "role": "assistant",
+                "content": "Para la merienda, dime primero el tipo de dia.",
+            },
+        ],
+    )
+
+    assert setup.direct_answer is None
+    payload = _payload(setup.runtime_instructions[0])
+    assert payload["nutrition_context"]["situation_key"] == "futbol"
+    assert payload["nutrition_context"]["moment_key"] == "merienda"
+
+
+def test_prepare_nutrition_prompt_keeps_memory_for_non_plan_messages() -> None:
+    setup = prepare_nutrition_prompt(
+        _nutrition_profile(),
+        "Te acuerdas de lo ultimo que te pregunte?",
+    )
+
+    assert setup.direct_answer is None
+    assert setup.runtime_instructions == ()
+    assert setup.include_memory is True
+    assert setup.prompt_profile.context_documents == ()
+
+
+def test_prepare_nutrition_prompt_without_db_plan_suggests_set_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profile = replace(_nutrition_profile(), nutrition_plan_path=None)
+    monkeypatch.setattr(
+        nutrition_orchestrator,
+        "load_active_nutrition_plan",
+        lambda *, user_id: None,
+    )
+
+    setup = prepare_nutrition_prompt(
+        profile,
+        "Hoy no entreno, que ceno?",
+        internal_user_id=7,
+    )
+
+    assert setup.direct_answer is not None
+    assert "/set_plan" in setup.direct_answer
+
+
+def test_prepare_nutrition_prompt_without_db_plan_keeps_memory_question(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profile = replace(_nutrition_profile(), nutrition_plan_path=None)
+    monkeypatch.setattr(
+        nutrition_orchestrator,
+        "load_active_nutrition_plan",
+        lambda *, user_id: None,
+    )
+
+    setup = prepare_nutrition_prompt(
+        profile,
+        "Te acuerdas de lo ultimo que te dije?",
+        internal_user_id=7,
+    )
+
+    assert setup.direct_answer is None
+    assert setup.runtime_instructions == ()
+
+
+def test_prepare_nutrition_prompt_shopping_list_uses_plan_and_memory() -> None:
+    setup = prepare_nutrition_prompt(
+        _nutrition_profile(),
+        "Dame la lista de la compra.",
+    )
+
+    assert setup.direct_answer is None
+    assert setup.include_memory is True
+    payload = _payload(setup.runtime_instructions[0])
+    assert payload["message_understanding"]["intent"] == "shopping_list"
+    assert payload["nutrition_context"]["mode"] == "shopping_list"
+    assert "no_entreno" in payload["nutrition_context"]["situations"]
+
+
+def test_prepare_nutrition_prompt_uses_daily_log_for_short_follow_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log = NutritionDailyLog(
+        id=10,
+        user_id=7,
+        bot_profile_id="nutrition",
+        log_date=date(2026, 5, 24),
+        plan_id="demo_nutrition_plan",
+        situation_key="no_entreno",
+        meals={},
+        notes=(),
+    )
+
+    monkeypatch.setattr(
+        nutrition_orchestrator.nutrition_daily_state,
+        "load_daily_log",
+        lambda **kwargs: log,
+    )
+
+    setup = prepare_nutrition_prompt(
+        _nutrition_profile(),
+        "que ceno?",
+        internal_user_id=7,
+        current_date=date(2026, 5, 24),
+    )
+
+    assert setup.direct_answer is None
+    payload = _payload(setup.runtime_instructions[0])
+    assert payload["nutrition_context"]["situation_key"] == "no_entreno"
+    assert payload["nutrition_context"]["moment_key"] == "cena"
+    assert payload["nutrition_context"]["daily_log"]["tipo_dia"] == "no_entreno"
+
+
+def test_prepare_nutrition_prompt_uses_actual_day_after_training_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updates: list[object] = []
+    log = NutritionDailyLog(
+        id=11,
+        user_id=7,
+        bot_profile_id="nutrition",
+        log_date=date(2026, 5, 24),
+        plan_id="demo_nutrition_plan",
+        situation_key="no_entreno",
+        meals={},
+        notes=({"text": "crossfit cancelado"},),
+    )
+
+    def fake_apply_daily_update(**kwargs: object) -> NutritionDailyLog:
+        updates.append(kwargs["update"])
+        return log
+
+    monkeypatch.setattr(
+        nutrition_orchestrator.nutrition_daily_state,
+        "load_daily_log",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        nutrition_orchestrator.nutrition_daily_state,
+        "apply_daily_update",
+        fake_apply_daily_update,
+    )
+
+    setup = prepare_nutrition_prompt(
+        _nutrition_profile(),
+        "Al final no he ido al crossfit, que ceno?",
+        internal_user_id=7,
+        current_date=date(2026, 5, 24),
+    )
+
+    assert setup.direct_answer is None
+    assert not updates
+    assert setup.post_success_actions
+    setup.post_success_actions[0]()
+    assert getattr(updates[0], "situation_key") == "no_entreno"
+    payload = _payload(setup.runtime_instructions[0])
+    assert payload["nutrition_context"]["situation_key"] == "no_entreno"
+    assert payload["nutrition_context"]["moment_key"] == "cena"
+    assert payload["nutrition_context"]["daily_log"]["tipo_dia"] == "no_entreno"
+
+
+def test_prepare_nutrition_prompt_routes_activity_replacement_to_actual_day(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    updates: list[object] = []
+    log = NutritionDailyLog(
+        id=12,
+        user_id=7,
+        bot_profile_id="nutrition",
+        log_date=date(2026, 5, 24),
+        plan_id="demo_nutrition_plan",
+        situation_key="natacion",
+        meals={},
+        notes=({"text": "crossfit cambiado por natacion"},),
+    )
+
+    def fake_apply_daily_update(**kwargs: object) -> NutritionDailyLog:
+        updates.append(kwargs["update"])
+        return log
+
+    monkeypatch.setattr(
+        nutrition_orchestrator.nutrition_daily_state,
+        "load_daily_log",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        nutrition_orchestrator.nutrition_daily_state,
+        "apply_daily_update",
+        fake_apply_daily_update,
+    )
+
+    setup = prepare_nutrition_prompt(
+        _nutrition_profile(),
+        "Al final cambio crossfit por natacion, que ceno?",
+        internal_user_id=7,
+        current_date=date(2026, 5, 24),
+    )
+
+    assert setup.direct_answer is None
+    assert not updates
+    assert setup.post_success_actions
+    setup.post_success_actions[0]()
+    assert getattr(updates[0], "situation_key") == "natacion"
+    payload = _payload(setup.runtime_instructions[0])
+    assert payload["nutrition_context"]["situation_key"] == "natacion"
+    assert payload["nutrition_context"]["moment_key"] == "cena"
+
+
+@pytest.mark.asyncio
+async def test_async_prompt_uses_llm_normalizer_with_user_plan_keys(
+    tmp_path: Path,
+) -> None:
+    profile = replace(
+        _nutrition_profile(),
+        nutrition_plan_path=_write_custom_plan(tmp_path),
+    )
+    normalizer = FakeNormalizerClient(
+        {
+            "intent": "recommend_meal",
+            "situation_key": "pilates",
+            "situation_keys": ["pilates"],
+            "target_moment_key": "media_manana",
+            "mentioned_moment_keys": ["media_manana"],
+            "logged_meals": [],
+            "goal": "resolver snack personalizado",
+            "confidence": "high",
+        }
+    )
+
+    setup = await prepare_nutrition_prompt_async(
+        profile,
+        "Mi pareja va a pilates y quiere su snack de media manana",
+        normalizer_client=normalizer,
+        normalizer_model="nvidia/cheap-normalizer",
+    )
+
+    assert normalizer.models == ["nvidia/cheap-normalizer"]
+    normalizer_prompt = normalizer.messages[0][0]["content"]
+    assert "pilates" in normalizer_prompt
+    assert "media_manana" in normalizer_prompt
+    assert "snack_pilates" not in normalizer_prompt
+
+    assert setup.direct_answer is None
+    payload = _payload(setup.runtime_instructions[0])
+    assert payload["normalized_message"]["situation_key"] == "pilates"
+    assert payload["normalized_message"]["target_moment_key"] == "media_manana"
+    assert payload["nutrition_context"]["situation_key"] == "pilates"
+    assert payload["nutrition_context"]["moment_key"] == "media_manana"
+    assert payload["nutrition_context"]["meal_block_key"] == "snack_pilates"
+
+
+@pytest.mark.asyncio
+async def test_async_prompt_sends_memory_to_normalizer(
+    tmp_path: Path,
+) -> None:
+    profile = replace(
+        _nutrition_profile(),
+        nutrition_plan_path=_write_custom_plan(tmp_path),
+    )
+    normalizer = FakeNormalizerClient(
+        {
+            "intent": "recommend_meal",
+            "situation_key": "pilates",
+            "target_moment_key": "cena",
+            "confidence": "high",
+        }
+    )
+
+    setup = await prepare_nutrition_prompt_async(
+        profile,
+        "y para cenar?",
+        compacted_user_memory="La conversacion activa era sobre pilates.",
+        recent_conversation_messages=[
+            {"role": "user", "content": "Hoy mi pareja va a pilates."},
+        ],
+        normalizer_client=normalizer,
+        normalizer_model="nvidia/cheap-normalizer",
+    )
+
+    normalizer_prompt = normalizer.messages[0][0]["content"]
+    assert "Conversation context" in normalizer_prompt
+    assert "La conversacion activa era sobre pilates." in normalizer_prompt
+    assert "Hoy mi pareja va a pilates." in normalizer_prompt
+    assert setup.direct_answer is None
+
+
+@pytest.mark.asyncio
+async def test_async_prompt_ignores_invalid_llm_normalizer_keys(
+    tmp_path: Path,
+) -> None:
+    profile = replace(
+        _nutrition_profile(),
+        nutrition_plan_path=_write_custom_plan(tmp_path),
+    )
+    normalizer = FakeNormalizerClient(
+        {
+            "intent": "recommend_meal",
+            "situation_key": "futbol",
+            "target_moment_key": "desayuno",
+            "confidence": "high",
+        }
+    )
+
+    setup = await prepare_nutrition_prompt_async(
+        profile,
+        "Pilates, que cena toca?",
+        normalizer_client=normalizer,
+        normalizer_model="nvidia/cheap-normalizer",
+    )
+
+    assert setup.direct_answer is None
+    assert setup.normalized_message is not None
+    assert setup.normalized_message.situation_key is None
+    assert setup.normalized_message.target_moment_key is None
+    assert "ignored_invalid_situation_key" in setup.normalized_message.warnings
+    payload = _payload(setup.runtime_instructions[0])
+    assert payload["nutrition_context"]["situation_key"] == "pilates"
+    assert payload["nutrition_context"]["moment_key"] == "cena"
+
+
+@pytest.mark.asyncio
+async def test_async_prompt_ignores_low_confidence_normalizer_route(
+    tmp_path: Path,
+) -> None:
+    profile = replace(
+        _nutrition_profile(),
+        nutrition_plan_path=_write_custom_plan(tmp_path),
+    )
+    normalizer = FakeNormalizerClient(
+        {
+            "intent": "recommend_meal",
+            "situation_key": "pilates",
+            "target_moment_key": "cena",
+            "confidence": "low",
+        }
+    )
+
+    setup = await prepare_nutrition_prompt_async(
+        profile,
+        "resolver esto",
+        normalizer_client=normalizer,
+        normalizer_model="nvidia/cheap-normalizer",
+    )
+
+    assert setup.direct_answer is None
+    assert setup.runtime_instructions == ()
+    assert setup.normalized_message is not None
+    assert setup.normalized_message.confidence == 0.3
+
+
+@pytest.mark.asyncio
+async def test_async_prompt_delegates_unclear_follow_up_to_llm_with_context() -> None:
+    normalizer = FakeNormalizerClient(
+        {
+            "intent": "adjust_existing_meal",
+            "goal": "seguir conversacion sobre batido de proteinas",
+            "confidence": "medium",
+        }
+    )
+
+    setup = await prepare_nutrition_prompt_async(
+        _nutrition_profile(),
+        "El batido de proteinas es un cacito de 70 ml de hsn evolate 2.0",
+        compacted_user_memory=(
+            "El usuario estaba valorando un batido para merienda en dia de futbol."
+        ),
+        recent_conversation_messages=[
+            {"role": "user", "content": "Y si meriendo un batido de proteinas?"},
+            {"role": "assistant", "content": "Lo revisamos con tu plan de futbol."},
+        ],
+        normalizer_client=normalizer,
+        normalizer_model="nvidia/cheap-normalizer",
+    )
+
+    assert setup.direct_answer is None
+    assert setup.include_memory is True
+    payload = _payload(setup.runtime_instructions[0])
+    assert payload["nutrition_context"]["mode"] == "single_meal"
+    assert payload["nutrition_context"]["situation_key"] == "futbol"
+    assert payload["nutrition_context"]["moment_key"] == "merienda"
+
+
+@pytest.mark.asyncio
+async def test_async_prompt_uses_contextual_fallback_instead_of_looping() -> None:
+    normalizer = FakeNormalizerClient(
+        {
+            "intent": "adjust_existing_meal",
+            "goal": "seguir conversacion sobre batido de proteinas",
+            "confidence": "medium",
+        }
+    )
+
+    setup = await prepare_nutrition_prompt_async(
+        _nutrition_profile(),
+        "El batido de proteinas es un cacito de 70 ml de hsn evolate 2.0",
+        recent_conversation_messages=[
+            {"role": "user", "content": "Quiero ajustar el batido."},
+        ],
+        normalizer_client=normalizer,
+        normalizer_model="nvidia/cheap-normalizer",
+    )
+
+    assert setup.direct_answer is None
+    assert setup.include_memory is True
+    payload = _payload(setup.runtime_instructions[0])
+    assert payload["nutrition_context"]["mode"] == "unresolved_with_memory_fallback"
+    assert payload["nutrition_context"]["resolution_status"] == "missing_situation"

--- a/tests/test_nutrition_plan_store.py
+++ b/tests/test_nutrition_plan_store.py
@@ -113,9 +113,7 @@ def test_save_active_nutrition_plan_archives_previous_and_inserts_document(
         if "INSERT INTO nutrition_plan_documents" in statement
     )
     document_types = [
-        params[1]
-        for params in connection.cursor_obj.params
-        if len(params) == 3
+        params[1] for params in connection.cursor_obj.params if len(params) == 3
     ]
     assert document_insert_count == 4
     assert "situaciones" in document_types

--- a/tests/test_nutrition_plan_store.py
+++ b/tests/test_nutrition_plan_store.py
@@ -1,0 +1,225 @@
+from typing import Any
+
+from forge_bot.nutrition.plan_store import (
+    load_active_nutrition_plan,
+    save_active_nutrition_plan,
+    save_nutrition_plan_part,
+)
+
+
+def sample_plan_data() -> dict[str, Any]:
+    return {
+        "plan_id": "sample_plan",
+        "momentos": {"cena": {"label": "Cena", "aliases": ["cena"]}},
+        "situaciones": {
+            "no_entreno": {
+                "label": "No entreno",
+                "aliases": ["no entreno"],
+                "suplementacion": [],
+                "momentos": {"cena": "comida_1"},
+            }
+        },
+        "comidas": {
+            "comida_1": {
+                "descripcion": "Cena",
+                "and": ["200g merluza", "verdura"],
+            }
+        },
+        "reglas_adaptacion": {
+            "principios": ["comidas.json manda sobre cualquier receta."]
+        },
+        "recetas": [
+            {
+                "nombre": "merluza_con_ensalada",
+                "nombre_visible": "Merluza con ensalada",
+            }
+        ],
+    }
+
+
+class FakeCursor:
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+        self.params: list[tuple[Any, ...]] = []
+        self.fetchone_queue: list[dict[str, Any] | None] = []
+        self.fetchall_queue: list[list[dict[str, Any]]] = []
+
+    def __enter__(self) -> "FakeCursor":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def execute(self, statement: str, params: tuple[Any, ...]) -> None:
+        self.statements.append(" ".join(statement.split()))
+        self.params.append(params)
+
+    def fetchone(self) -> dict[str, Any] | None:
+        return self.fetchone_queue.pop(0)
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        return self.fetchall_queue.pop(0)
+
+
+class FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_obj = FakeCursor()
+        self.committed = False
+        self.rolled_back = False
+        self.closed = False
+
+    def cursor(self) -> FakeCursor:
+        return self.cursor_obj
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def rollback(self) -> None:
+        self.rolled_back = True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_save_active_nutrition_plan_archives_previous_and_inserts_document(
+    monkeypatch,
+) -> None:
+    connection = FakeConnection()
+    connection.cursor_obj.fetchone_queue.append({"id": "plan-uuid"})
+    monkeypatch.setattr("forge_bot.nutrition.plan_store.conect_db", lambda: connection)
+
+    saved = save_active_nutrition_plan(
+        user_id=7,
+        plan_data=sample_plan_data(),
+        source_filename="plan.json",
+    )
+
+    assert saved.plan_uuid == "plan-uuid"
+    assert saved.plan.plan_id == "sample_plan"
+    assert connection.committed is True
+    statements = connection.cursor_obj.statements
+    assert any(
+        "UPDATE nutrition_plans SET status = 'archived'" in statement
+        for statement in statements
+    )
+    assert any("INSERT INTO nutrition_plans" in statement for statement in statements)
+    document_insert_count = sum(
+        1
+        for statement in statements
+        if "INSERT INTO nutrition_plan_documents" in statement
+    )
+    document_types = [
+        params[1]
+        for params in connection.cursor_obj.params
+        if len(params) == 3
+    ]
+    assert document_insert_count == 4
+    assert "situaciones" in document_types
+    assert "comidas" in document_types
+    assert "reglas_adaptacion" in document_types
+    assert "recetas" in document_types
+
+
+def test_load_active_nutrition_plan_parses_stored_json(monkeypatch) -> None:
+    connection = FakeConnection()
+    connection.cursor_obj.fetchall_queue.append(
+        [
+            {
+                "plan_uuid": "plan-uuid",
+                "document_type": "situaciones",
+                "content": {
+                    "plan_id": "sample_plan",
+                    "situaciones": sample_plan_data()["situaciones"],
+                },
+            },
+            {
+                "plan_uuid": "plan-uuid",
+                "document_type": "comidas",
+                "content": {
+                    "plan_id": "sample_plan",
+                    "comidas": sample_plan_data()["comidas"],
+                },
+            },
+        ]
+    )
+    monkeypatch.setattr("forge_bot.nutrition.plan_store.conect_db", lambda: connection)
+
+    plan = load_active_nutrition_plan(user_id=7)
+
+    assert plan is not None
+    assert plan.plan_id == "sample_plan"
+    assert plan.situations.keys() == {"no_entreno"}
+    assert connection.closed is True
+
+
+def test_save_nutrition_plan_part_waits_for_missing_document(monkeypatch) -> None:
+    connection = FakeConnection()
+    connection.cursor_obj.fetchone_queue.extend([None, {"id": "draft-uuid"}])
+    connection.cursor_obj.fetchall_queue.append(
+        [
+            {
+                "document_type": "situaciones",
+                "content": {
+                    "plan_id": "sample_plan",
+                    "situaciones": sample_plan_data()["situaciones"],
+                },
+            }
+        ]
+    )
+    monkeypatch.setattr("forge_bot.nutrition.plan_store.conect_db", lambda: connection)
+
+    result = save_nutrition_plan_part(
+        user_id=7,
+        document_type="situaciones",
+        content={
+            "plan_id": "sample_plan",
+            "situaciones": sample_plan_data()["situaciones"],
+        },
+        source_filename="situaciones.json",
+    )
+
+    assert result.activated is False
+    assert result.missing_document_types == ("comidas",)
+    assert connection.committed is True
+
+
+def test_save_nutrition_plan_part_activates_when_both_documents_exist(
+    monkeypatch,
+) -> None:
+    connection = FakeConnection()
+    connection.cursor_obj.fetchone_queue.extend([None, {"id": "draft-uuid"}])
+    connection.cursor_obj.fetchall_queue.append(
+        [
+            {
+                "document_type": "situaciones",
+                "content": {
+                    "plan_id": "sample_plan",
+                    "situaciones": sample_plan_data()["situaciones"],
+                },
+            },
+            {
+                "document_type": "comidas",
+                "content": {
+                    "plan_id": "sample_plan",
+                    "comidas": sample_plan_data()["comidas"],
+                },
+            },
+        ]
+    )
+    monkeypatch.setattr("forge_bot.nutrition.plan_store.conect_db", lambda: connection)
+
+    result = save_nutrition_plan_part(
+        user_id=7,
+        document_type="comidas",
+        content={
+            "plan_id": "sample_plan",
+            "comidas": sample_plan_data()["comidas"],
+        },
+        source_filename="comidas.json",
+    )
+
+    assert result.activated is True
+    assert result.activated_plan is not None
+    assert result.activated_plan.plan_id == "sample_plan"
+    statements = connection.cursor_obj.statements
+    assert any("SET status = 'active'" in statement for statement in statements)

--- a/tests/test_nutrition_plan_store.py
+++ b/tests/test_nutrition_plan_store.py
@@ -37,6 +37,10 @@ def sample_plan_data() -> dict[str, Any]:
     }
 
 
+def jsonb_obj(value: object) -> Any:
+    return getattr(value, "obj", value)
+
+
 class FakeCursor:
     def __init__(self) -> None:
         self.statements: list[str] = []
@@ -118,6 +122,12 @@ def test_save_active_nutrition_plan_archives_previous_and_inserts_document(
     assert "comidas" in document_types
     assert "reglas_adaptacion" in document_types
     assert "recetas" in document_types
+    situations_content = next(
+        jsonb_obj(params[2])
+        for params in connection.cursor_obj.params
+        if len(params) == 3 and params[1] == "situaciones"
+    )
+    assert situations_content["momentos"] == sample_plan_data()["momentos"]
 
 
 def test_load_active_nutrition_plan_parses_stored_json(monkeypatch) -> None:
@@ -129,6 +139,7 @@ def test_load_active_nutrition_plan_parses_stored_json(monkeypatch) -> None:
                 "document_type": "situaciones",
                 "content": {
                     "plan_id": "sample_plan",
+                    "momentos": sample_plan_data()["momentos"],
                     "situaciones": sample_plan_data()["situaciones"],
                 },
             },
@@ -148,6 +159,7 @@ def test_load_active_nutrition_plan_parses_stored_json(monkeypatch) -> None:
 
     assert plan is not None
     assert plan.plan_id == "sample_plan"
+    assert plan.moments.keys() == {"cena"}
     assert plan.situations.keys() == {"no_entreno"}
     assert connection.closed is True
 
@@ -161,6 +173,7 @@ def test_save_nutrition_plan_part_waits_for_missing_document(monkeypatch) -> Non
                 "document_type": "situaciones",
                 "content": {
                     "plan_id": "sample_plan",
+                    "momentos": sample_plan_data()["momentos"],
                     "situaciones": sample_plan_data()["situaciones"],
                 },
             }
@@ -173,6 +186,7 @@ def test_save_nutrition_plan_part_waits_for_missing_document(monkeypatch) -> Non
         document_type="situaciones",
         content={
             "plan_id": "sample_plan",
+            "momentos": sample_plan_data()["momentos"],
             "situaciones": sample_plan_data()["situaciones"],
         },
         source_filename="situaciones.json",
@@ -181,6 +195,12 @@ def test_save_nutrition_plan_part_waits_for_missing_document(monkeypatch) -> Non
     assert result.activated is False
     assert result.missing_document_types == ("comidas",)
     assert connection.committed is True
+    upsert_content = next(
+        jsonb_obj(params[2])
+        for params in connection.cursor_obj.params
+        if len(params) == 3 and params[1] == "situaciones"
+    )
+    assert upsert_content["momentos"] == sample_plan_data()["momentos"]
 
 
 def test_save_nutrition_plan_part_activates_when_both_documents_exist(
@@ -194,6 +214,7 @@ def test_save_nutrition_plan_part_activates_when_both_documents_exist(
                 "document_type": "situaciones",
                 "content": {
                     "plan_id": "sample_plan",
+                    "momentos": sample_plan_data()["momentos"],
                     "situaciones": sample_plan_data()["situaciones"],
                 },
             },

--- a/tests/test_nutrition_router.py
+++ b/tests/test_nutrition_router.py
@@ -82,6 +82,82 @@ def test_plan_validation_rejects_invalid_moment_aliases() -> None:
         )
 
 
+def minimal_plan_with_meal(meal: dict[str, object]) -> dict[str, object]:
+    return {
+        "momentos": {
+            "almuerzo": {"aliases": ["almuerzo"]},
+        },
+        "situaciones": {
+            "no_entreno": {
+                "aliases": ["no entreno"],
+                "momentos": {"almuerzo": "comida_1"},
+            }
+        },
+        "comidas": {"comida_1": meal},
+    }
+
+
+def test_plan_validation_accepts_nested_and_or_meal_tree() -> None:
+    plan = parse_nutrition_plan(
+        minimal_plan_with_meal(
+            {
+                "descripcion": "Almuerzo",
+                "and": [
+                    {
+                        "nombre": "proteina",
+                        "or": ["200g pollo", "220g merluza"],
+                    },
+                    {
+                        "nombre": "hidrato_y_grasa",
+                        "and": ["80g arroz", "10g aceite"],
+                    },
+                ],
+                "warnings": ["Ajustar si hay hambre real."],
+            }
+        )
+    )
+
+    assert plan.meals["comida_1"]["descripcion"] == "Almuerzo"
+
+
+def test_plan_validation_rejects_meal_without_and_or_tree() -> None:
+    with pytest.raises(NutritionPlanError, match="exactly one logical operator"):
+        parse_nutrition_plan(minimal_plan_with_meal({"descripcion": "Almuerzo"}))
+
+
+def test_plan_validation_rejects_meal_with_both_and_or() -> None:
+    with pytest.raises(NutritionPlanError, match="exactly one logical operator"):
+        parse_nutrition_plan(
+            minimal_plan_with_meal(
+                {
+                    "descripcion": "Almuerzo",
+                    "and": ["200g pollo"],
+                    "or": ["220g merluza"],
+                }
+            )
+        )
+
+
+def test_plan_validation_rejects_empty_logical_group() -> None:
+    with pytest.raises(NutritionPlanError, match="non-empty list"):
+        parse_nutrition_plan(
+            minimal_plan_with_meal({"descripcion": "Almuerzo", "or": []})
+        )
+
+
+def test_plan_validation_rejects_invalid_logical_metadata() -> None:
+    with pytest.raises(NutritionPlanError, match="warnings"):
+        parse_nutrition_plan(
+            minimal_plan_with_meal(
+                {
+                    "descripcion": "Almuerzo",
+                    "and": ["200g pollo"],
+                    "warnings": ["ok", ""],
+                }
+            )
+        )
+
+
 def test_normalize_text_removes_accents_and_punctuation() -> None:
     assert normalize_text("¿Qué como al mediodía?") == "que como al mediodia"
 

--- a/tests/test_nutrition_router.py
+++ b/tests/test_nutrition_router.py
@@ -1,0 +1,164 @@
+from pathlib import Path
+
+import pytest
+
+from forge_bot.nutrition.plan import (
+    NutritionPlan,
+    NutritionPlanError,
+    load_nutrition_plan_file,
+    parse_nutrition_plan,
+)
+from forge_bot.nutrition.router import (
+    detect_moments,
+    detect_situations,
+    normalize_text,
+    resolve_meal_context,
+)
+
+DEMO_PLAN_PATH = Path("bot_profiles/nutrition/demo_plan.json")
+NUTRITION_PROFILE_ROOT = Path("bot_profiles/nutrition")
+
+
+@pytest.fixture
+def demo_plan() -> NutritionPlan:
+    return load_nutrition_plan_file(NUTRITION_PROFILE_ROOT, "demo_plan.json")
+
+
+def test_load_configured_nutrition_plan_file(demo_plan) -> None:
+    assert demo_plan.plan_id == "demo_nutrition_plan_v1"
+    assert "crossfit" in demo_plan.situations
+    assert "comida_2" in demo_plan.meals
+
+
+def test_configured_plan_loader_rejects_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(NutritionPlanError, match="could not be read"):
+        load_nutrition_plan_file(tmp_path, "missing.json")
+
+
+def test_configured_plan_loader_rejects_path_traversal(tmp_path: Path) -> None:
+    with pytest.raises(NutritionPlanError, match="inside the profile folder"):
+        load_nutrition_plan_file(tmp_path, "../outside.json")
+
+
+def test_demo_plan_file_exists() -> None:
+    assert DEMO_PLAN_PATH.is_file()
+
+
+def test_plan_validation_rejects_missing_meal_reference() -> None:
+    with pytest.raises(NutritionPlanError, match="references missing meal"):
+        parse_nutrition_plan(
+            {
+                "situaciones": {
+                    "crossfit": {
+                        "aliases": ["crossfit"],
+                        "momentos": {"almuerzo": "comida_missing"},
+                    }
+                },
+                "comidas": {
+                    "comida_1": {"descripcion": "ok", "and": ["25g whey"]}
+                },
+            }
+        )
+
+
+def test_normalize_text_removes_accents_and_punctuation() -> None:
+    assert normalize_text("¿Qué como al mediodía?") == "que como al mediodia"
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("hoy tengo crossfit", "crossfit"),
+        ("vengo del gym", "crossfit"),
+        ("partido de futbol al mediodia", "futbol"),
+        ("salida en bici por la manana", "ciclismo"),
+        ("hoy toca rodillo", "ciclismo"),
+        ("voy a correr series", "atletismo"),
+        ("dia de descanso", "no_entreno"),
+        ("hoy no entreno", "no_entreno"),
+    ],
+)
+def test_detect_situations_from_aliases(demo_plan, message: str, expected: str) -> None:
+    matches = detect_situations(demo_plan, message)
+
+    assert tuple(match.key for match in matches) == (expected,)
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("que desayuno hoy", "desayuno"),
+        ("que como al mediodia", "almuerzo"),
+        ("que comida toca", "almuerzo"),
+        ("que merienda hago", "merienda"),
+        ("pre entreno rapido", "merienda"),
+        ("que ceno por la noche", "cena"),
+    ],
+)
+def test_detect_moments(message: str, expected: str) -> None:
+    matches = detect_moments(message)
+
+    assert tuple(match.key for match in matches) == (expected,)
+
+
+@pytest.mark.parametrize(
+    ("message", "meal_key"),
+    [
+        ("Hoy tengo crossfit, que como al mediodia?", "comida_2"),
+        ("Tengo futbol, que ceno?", "comida_3"),
+        ("Hoy no entreno, que almuerzo?", "comida_5"),
+        ("Voy en bici, que merienda hago?", "comida_0"),
+        ("Tengo atletismo, que desayuno?", "comida_1"),
+    ],
+)
+def test_resolve_meal_context(demo_plan, message: str, meal_key: str) -> None:
+    resolution = resolve_meal_context(demo_plan, message)
+
+    assert resolution.status == "resolved"
+    assert resolution.is_resolved
+    assert resolution.meal_block_key == meal_key
+    assert resolution.meal_block is demo_plan.meals[meal_key]
+    assert resolution.supplementation == ("10g de creatina monohidrato creapure",)
+
+
+def test_resolve_missing_situation(demo_plan) -> None:
+    resolution = resolve_meal_context(demo_plan, "que como al mediodia?")
+
+    assert resolution.status == "missing_situation"
+    assert "CrossFit o entrenamiento de fuerza alta intensidad" in (
+        resolution.available_situations
+    )
+
+
+def test_resolve_missing_moment(demo_plan) -> None:
+    resolution = resolve_meal_context(demo_plan, "hoy tengo crossfit")
+
+    assert resolution.status == "missing_moment"
+    assert resolution.situation_key == "crossfit"
+    assert "almuerzo" in resolution.available_moments
+
+
+def test_resolve_ambiguous_situation(demo_plan) -> None:
+    resolution = resolve_meal_context(
+        demo_plan,
+        "hoy descanso pero hago bici suave, que como al mediodia?",
+    )
+
+    assert resolution.status == "ambiguous_situation"
+    assert tuple(match.key for match in resolution.situation_matches) == (
+        "ciclismo",
+        "no_entreno",
+    )
+
+
+def test_resolve_ambiguous_moment(demo_plan) -> None:
+    resolution = resolve_meal_context(
+        demo_plan,
+        "hoy tengo crossfit, comida y cena?",
+    )
+
+    assert resolution.status == "ambiguous_moment"
+    assert tuple(match.key for match in resolution.moment_matches) == (
+        "almuerzo",
+        "cena",
+    )

--- a/tests/test_nutrition_router.py
+++ b/tests/test_nutrition_router.py
@@ -55,9 +55,7 @@ def test_plan_validation_rejects_missing_meal_reference() -> None:
                         "momentos": {"almuerzo": "comida_missing"},
                     }
                 },
-                "comidas": {
-                    "comida_1": {"descripcion": "ok", "and": ["25g whey"]}
-                },
+                "comidas": {"comida_1": {"descripcion": "ok", "and": ["25g whey"]}},
             }
         )
 
@@ -75,9 +73,7 @@ def test_plan_validation_rejects_invalid_moment_aliases() -> None:
                         "momentos": {"almuerzo": "comida_1"},
                     }
                 },
-                "comidas": {
-                    "comida_1": {"descripcion": "ok", "and": ["25g whey"]}
-                },
+                "comidas": {"comida_1": {"descripcion": "ok", "and": ["25g whey"]}},
             }
         )
 

--- a/tests/test_nutrition_router.py
+++ b/tests/test_nutrition_router.py
@@ -21,23 +21,21 @@ NUTRITION_PROFILE_ROOT = Path("bot_profiles/nutrition")
 
 @pytest.fixture
 def demo_plan() -> NutritionPlan:
-    return load_nutrition_plan_file(NUTRITION_PROFILE_ROOT, "demo_plan.json")
+    return load_nutrition_plan_file(NUTRITION_PROFILE_ROOT / "demo_plan.json")
 
 
 def test_load_configured_nutrition_plan_file(demo_plan) -> None:
     assert demo_plan.plan_id == "demo_nutrition_plan_v1"
+    assert "media_manana" in demo_plan.moments
+    assert "pre_entreno" in demo_plan.moments
+    assert "post_entreno" in demo_plan.moments
     assert "crossfit" in demo_plan.situations
     assert "comida_2" in demo_plan.meals
 
 
 def test_configured_plan_loader_rejects_missing_file(tmp_path: Path) -> None:
     with pytest.raises(NutritionPlanError, match="could not be read"):
-        load_nutrition_plan_file(tmp_path, "missing.json")
-
-
-def test_configured_plan_loader_rejects_path_traversal(tmp_path: Path) -> None:
-    with pytest.raises(NutritionPlanError, match="inside the profile folder"):
-        load_nutrition_plan_file(tmp_path, "../outside.json")
+        load_nutrition_plan_file(tmp_path / "missing.json")
 
 
 def test_demo_plan_file_exists() -> None:
@@ -48,10 +46,33 @@ def test_plan_validation_rejects_missing_meal_reference() -> None:
     with pytest.raises(NutritionPlanError, match="references missing meal"):
         parse_nutrition_plan(
             {
+                "momentos": {
+                    "almuerzo": {"aliases": ["almuerzo"]},
+                },
                 "situaciones": {
                     "crossfit": {
                         "aliases": ["crossfit"],
                         "momentos": {"almuerzo": "comida_missing"},
+                    }
+                },
+                "comidas": {
+                    "comida_1": {"descripcion": "ok", "and": ["25g whey"]}
+                },
+            }
+        )
+
+
+def test_plan_validation_rejects_invalid_moment_aliases() -> None:
+    with pytest.raises(NutritionPlanError, match="aliases"):
+        parse_nutrition_plan(
+            {
+                "momentos": {
+                    "almuerzo": {"aliases": ["almuerzo", ""]},
+                },
+                "situaciones": {
+                    "crossfit": {
+                        "aliases": ["crossfit"],
+                        "momentos": {"almuerzo": "comida_1"},
                     }
                 },
                 "comidas": {
@@ -91,12 +112,29 @@ def test_detect_situations_from_aliases(demo_plan, message: str, expected: str) 
         ("que como al mediodia", "almuerzo"),
         ("que comida toca", "almuerzo"),
         ("que merienda hago", "merienda"),
-        ("pre entreno rapido", "merienda"),
+        ("pre entreno rapido", "pre_entreno"),
         ("que ceno por la noche", "cena"),
     ],
 )
-def test_detect_moments(message: str, expected: str) -> None:
-    matches = detect_moments(message)
+def test_detect_moments(demo_plan, message: str, expected: str) -> None:
+    matches = detect_moments(demo_plan, message)
+
+    assert tuple(match.key for match in matches) == (expected,)
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("que tomo a media mañana", "media_manana"),
+        ("despues del entreno que hago", "post_entreno"),
+    ],
+)
+def test_detect_plan_defined_moments(
+    demo_plan,
+    message: str,
+    expected: str,
+) -> None:
+    matches = detect_moments(demo_plan, message)
 
     assert tuple(match.key for match in matches) == (expected,)
 
@@ -121,6 +159,26 @@ def test_resolve_meal_context(demo_plan, message: str, meal_key: str) -> None:
     assert resolution.supplementation == ("10g de creatina monohidrato creapure",)
 
 
+def test_resolve_full_day_context_uses_only_canonical_plan_moments(demo_plan) -> None:
+    resolution = resolve_meal_context(
+        demo_plan,
+        "Dame todo lo que puedo comer hoy dia de ciclismo",
+    )
+
+    assert resolution.status == "resolved_day"
+    assert resolution.is_resolved
+    assert resolution.situation_key == "ciclismo"
+    assert tuple(
+        (day_meal.moment_key, day_meal.meal_block_key)
+        for day_meal in resolution.day_meal_blocks
+    ) == (
+        ("desayuno", "comida_1"),
+        ("almuerzo", "comida_2"),
+        ("merienda", "comida_0"),
+        ("cena", "comida_3"),
+    )
+
+
 def test_resolve_missing_situation(demo_plan) -> None:
     resolution = resolve_meal_context(demo_plan, "que como al mediodia?")
 
@@ -135,7 +193,23 @@ def test_resolve_missing_moment(demo_plan) -> None:
 
     assert resolution.status == "missing_moment"
     assert resolution.situation_key == "crossfit"
-    assert "almuerzo" in resolution.available_moments
+    assert resolution.available_moments == (
+        "Desayuno",
+        "Almuerzo",
+        "Merienda",
+        "Cena",
+    )
+
+
+def test_resolve_unmapped_plan_defined_moment(demo_plan) -> None:
+    resolution = resolve_meal_context(
+        demo_plan,
+        "hoy tengo crossfit, que tomo a media mañana?",
+    )
+
+    assert resolution.status == "invalid_mapping"
+    assert resolution.situation_key == "crossfit"
+    assert resolution.moment_key == "media_manana"
 
 
 def test_resolve_ambiguous_situation(demo_plan) -> None:

--- a/tests/test_nutrition_router.py
+++ b/tests/test_nutrition_router.py
@@ -15,22 +15,22 @@ from forge_bot.nutrition.router import (
     resolve_meal_context,
 )
 
-DEMO_PLAN_PATH = Path("bot_profiles/nutrition/demo_plan.json")
-NUTRITION_PROFILE_ROOT = Path("bot_profiles/nutrition")
+NUTRITION_PLAN_FIXTURE_PATH = Path("tests/fixtures/nutrition_plan.json")
+NUTRITION_FIXTURE_ROOT = Path("tests/fixtures")
 
 
 @pytest.fixture
-def demo_plan() -> NutritionPlan:
-    return load_nutrition_plan_file(NUTRITION_PROFILE_ROOT / "demo_plan.json")
+def sample_plan() -> NutritionPlan:
+    return load_nutrition_plan_file(NUTRITION_FIXTURE_ROOT / "nutrition_plan.json")
 
 
-def test_load_configured_nutrition_plan_file(demo_plan) -> None:
-    assert demo_plan.plan_id == "demo_nutrition_plan_v1"
-    assert "media_manana" in demo_plan.moments
-    assert "pre_entreno" in demo_plan.moments
-    assert "post_entreno" in demo_plan.moments
-    assert "crossfit" in demo_plan.situations
-    assert "comida_2" in demo_plan.meals
+def test_load_configured_nutrition_plan_file(sample_plan) -> None:
+    assert sample_plan.plan_id == "sample_nutrition_plan_v1"
+    assert "media_manana" in sample_plan.moments
+    assert "pre_entreno" in sample_plan.moments
+    assert "post_entreno" in sample_plan.moments
+    assert "crossfit" in sample_plan.situations
+    assert "comida_2" in sample_plan.meals
 
 
 def test_configured_plan_loader_rejects_missing_file(tmp_path: Path) -> None:
@@ -38,8 +38,8 @@ def test_configured_plan_loader_rejects_missing_file(tmp_path: Path) -> None:
         load_nutrition_plan_file(tmp_path / "missing.json")
 
 
-def test_demo_plan_file_exists() -> None:
-    assert DEMO_PLAN_PATH.is_file()
+def test_nutrition_plan_fixture_exists() -> None:
+    assert NUTRITION_PLAN_FIXTURE_PATH.is_file()
 
 
 def test_plan_validation_rejects_missing_meal_reference() -> None:
@@ -99,8 +99,12 @@ def test_normalize_text_removes_accents_and_punctuation() -> None:
         ("hoy no entreno", "no_entreno"),
     ],
 )
-def test_detect_situations_from_aliases(demo_plan, message: str, expected: str) -> None:
-    matches = detect_situations(demo_plan, message)
+def test_detect_situations_from_aliases(
+    sample_plan,
+    message: str,
+    expected: str,
+) -> None:
+    matches = detect_situations(sample_plan, message)
 
     assert tuple(match.key for match in matches) == (expected,)
 
@@ -116,8 +120,8 @@ def test_detect_situations_from_aliases(demo_plan, message: str, expected: str) 
         ("que ceno por la noche", "cena"),
     ],
 )
-def test_detect_moments(demo_plan, message: str, expected: str) -> None:
-    matches = detect_moments(demo_plan, message)
+def test_detect_moments(sample_plan, message: str, expected: str) -> None:
+    matches = detect_moments(sample_plan, message)
 
     assert tuple(match.key for match in matches) == (expected,)
 
@@ -130,11 +134,11 @@ def test_detect_moments(demo_plan, message: str, expected: str) -> None:
     ],
 )
 def test_detect_plan_defined_moments(
-    demo_plan,
+    sample_plan,
     message: str,
     expected: str,
 ) -> None:
-    matches = detect_moments(demo_plan, message)
+    matches = detect_moments(sample_plan, message)
 
     assert tuple(match.key for match in matches) == (expected,)
 
@@ -149,19 +153,19 @@ def test_detect_plan_defined_moments(
         ("Tengo atletismo, que desayuno?", "comida_1"),
     ],
 )
-def test_resolve_meal_context(demo_plan, message: str, meal_key: str) -> None:
-    resolution = resolve_meal_context(demo_plan, message)
+def test_resolve_meal_context(sample_plan, message: str, meal_key: str) -> None:
+    resolution = resolve_meal_context(sample_plan, message)
 
     assert resolution.status == "resolved"
     assert resolution.is_resolved
     assert resolution.meal_block_key == meal_key
-    assert resolution.meal_block is demo_plan.meals[meal_key]
+    assert resolution.meal_block is sample_plan.meals[meal_key]
     assert resolution.supplementation == ("10g de creatina monohidrato creapure",)
 
 
-def test_resolve_full_day_context_uses_only_canonical_plan_moments(demo_plan) -> None:
+def test_resolve_full_day_context_uses_only_canonical_plan_moments(sample_plan) -> None:
     resolution = resolve_meal_context(
-        demo_plan,
+        sample_plan,
         "Dame todo lo que puedo comer hoy dia de ciclismo",
     )
 
@@ -179,8 +183,8 @@ def test_resolve_full_day_context_uses_only_canonical_plan_moments(demo_plan) ->
     )
 
 
-def test_resolve_missing_situation(demo_plan) -> None:
-    resolution = resolve_meal_context(demo_plan, "que como al mediodia?")
+def test_resolve_missing_situation(sample_plan) -> None:
+    resolution = resolve_meal_context(sample_plan, "que como al mediodia?")
 
     assert resolution.status == "missing_situation"
     assert "CrossFit o entrenamiento de fuerza alta intensidad" in (
@@ -188,8 +192,8 @@ def test_resolve_missing_situation(demo_plan) -> None:
     )
 
 
-def test_resolve_missing_moment(demo_plan) -> None:
-    resolution = resolve_meal_context(demo_plan, "hoy tengo crossfit")
+def test_resolve_missing_moment(sample_plan) -> None:
+    resolution = resolve_meal_context(sample_plan, "hoy tengo crossfit")
 
     assert resolution.status == "missing_moment"
     assert resolution.situation_key == "crossfit"
@@ -201,9 +205,9 @@ def test_resolve_missing_moment(demo_plan) -> None:
     )
 
 
-def test_resolve_unmapped_plan_defined_moment(demo_plan) -> None:
+def test_resolve_unmapped_plan_defined_moment(sample_plan) -> None:
     resolution = resolve_meal_context(
-        demo_plan,
+        sample_plan,
         "hoy tengo crossfit, que tomo a media mañana?",
     )
 
@@ -212,9 +216,9 @@ def test_resolve_unmapped_plan_defined_moment(demo_plan) -> None:
     assert resolution.moment_key == "media_manana"
 
 
-def test_resolve_ambiguous_situation(demo_plan) -> None:
+def test_resolve_ambiguous_situation(sample_plan) -> None:
     resolution = resolve_meal_context(
-        demo_plan,
+        sample_plan,
         "hoy descanso pero hago bici suave, que como al mediodia?",
     )
 
@@ -225,9 +229,9 @@ def test_resolve_ambiguous_situation(demo_plan) -> None:
     )
 
 
-def test_resolve_ambiguous_moment(demo_plan) -> None:
+def test_resolve_ambiguous_moment(sample_plan) -> None:
     resolution = resolve_meal_context(
-        demo_plan,
+        sample_plan,
         "hoy tengo crossfit, comida y cena?",
     )
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -64,6 +64,21 @@ def make_callback_update(
     )
 
 
+@pytest.fixture(autouse=True)
+def allow_linked_command_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth_guard, "verify_user", lambda telegram_id: True)
+
+
+@pytest.mark.asyncio
+async def test_policy_requires_linked_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    update = make_update()
+    monkeypatch.setattr(auth_guard, "verify_user", lambda telegram_id: False)
+
+    await policy(update, SimpleNamespace())
+
+    assert update.message.replies == [auth_guard.INVITE_REQUIRED_MESSAGE]
+
+
 @pytest.mark.asyncio
 async def test_policy_returns_current_notice(monkeypatch: pytest.MonkeyPatch) -> None:
     update = make_update()

--- a/tests/test_privacy_controls.py
+++ b/tests/test_privacy_controls.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import pytest
 
+from forge_bot.commands import auth_guard
 from forge_bot.commands.privacy import delete_my_data, memory_clear, privacy
 from forge_bot.database import MemoryClearResult, UserDeletionResult
 
@@ -26,9 +27,26 @@ def create_context(args: list[str] | None = None) -> Any:
     return SimpleNamespace(args=args or [])
 
 
+def allow_linked_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth_guard, "verify_user", lambda telegram_id: True)
+
+
 @pytest.mark.asyncio
-async def test_privacy_returns_data_categories_and_controls() -> None:
+async def test_privacy_requires_linked_user(monkeypatch: pytest.MonkeyPatch) -> None:
     update = create_update()
+    monkeypatch.setattr(auth_guard, "verify_user", lambda telegram_id: False)
+
+    await privacy(update, create_context())
+
+    assert update.message.replies == [auth_guard.INVITE_REQUIRED_MESSAGE]
+
+
+@pytest.mark.asyncio
+async def test_privacy_returns_data_categories_and_controls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    update = create_update()
+    allow_linked_user(monkeypatch)
 
     await privacy(update, create_context())
 
@@ -47,6 +65,7 @@ async def test_memory_clear_clears_linked_user_memory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     update = create_update(user_id=456)
+    allow_linked_user(monkeypatch)
     calls: list[int] = []
 
     def clear_memory_for_telegram_user(telegram_id: int) -> MemoryClearResult:
@@ -71,6 +90,7 @@ async def test_memory_clear_reports_unlinked_user(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     update = create_update()
+    allow_linked_user(monkeypatch)
     monkeypatch.setattr(
         "forge_bot.commands.privacy.clear_memory_for_telegram_user",
         lambda telegram_id: None,
@@ -88,6 +108,7 @@ async def test_delete_my_data_first_call_creates_request_and_asks_for_confirmati
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     update = create_update(user_id=456)
+    allow_linked_user(monkeypatch)
     calls: list[int] = []
 
     def request_user_deletion(telegram_id: int) -> UserDeletionResult:
@@ -111,6 +132,7 @@ async def test_delete_my_data_confirm_deletes_linked_user(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     update = create_update(user_id=456)
+    allow_linked_user(monkeypatch)
     calls: list[int] = []
 
     def confirm_user_deletion(telegram_id: int) -> UserDeletionResult:
@@ -136,6 +158,7 @@ async def test_delete_my_data_confirm_reports_admin_manual_review(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     update = create_update()
+    allow_linked_user(monkeypatch)
     monkeypatch.setattr(
         "forge_bot.commands.privacy.confirm_user_deletion",
         lambda telegram_id: UserDeletionResult("manual_review_requested"),
@@ -151,6 +174,7 @@ async def test_delete_my_data_confirm_reports_unlinked_user(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     update = create_update()
+    allow_linked_user(monkeypatch)
     monkeypatch.setattr(
         "forge_bot.commands.privacy.confirm_user_deletion",
         lambda telegram_id: UserDeletionResult("not_linked"),

--- a/tests/test_request_lifecycle.py
+++ b/tests/test_request_lifecycle.py
@@ -144,6 +144,7 @@ def authorize_user(monkeypatch: pytest.MonkeyPatch) -> None:
 def default_abuse_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(router, "abuse_limiter", AbuseLimiter(make_settings))
     monkeypatch.setattr(router, "get_settings", lambda: make_settings())
+    monkeypatch.setattr(router, "get_user_by_telegram_id", lambda telegram_id: None)
     monkeypatch.setattr(
         router,
         "append_debug_conversation_turn",

--- a/tests/test_request_lifecycle.py
+++ b/tests/test_request_lifecycle.py
@@ -630,6 +630,75 @@ async def test_memory_context_is_sent_to_engine_and_turn_is_stored(
 
 
 @pytest.mark.asyncio
+async def test_operational_fallback_is_not_stored_as_memory_or_debug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authorize_user(monkeypatch)
+    state = UserRequestState()
+    update = fake_update(update_id=30051)
+    memory_backend = FakeMemoryBackend()
+    debug_turns: list[object] = []
+    compacted: list[object] = []
+
+    monkeypatch.setattr(router, "request_state", state)
+    monkeypatch.setattr(
+        router,
+        "persist_update",
+        lambda update: {"id": 57, "status": "persisted"},
+    )
+    monkeypatch.setattr(router, "mark_queued", lambda update_id: {"status": "queued"})
+    monkeypatch.setattr(
+        router,
+        "mark_processing",
+        lambda update_id: {"id": 57, "status": "processing"},
+    )
+    monkeypatch.setattr(router, "mark_answered", lambda update_id: None)
+    monkeypatch.setattr(engine, "load_default_profile", fake_memory_profile)
+    monkeypatch.setattr(router, "get_settings", lambda: make_settings())
+    monkeypatch.setattr(
+        router,
+        "get_user_by_telegram_id",
+        lambda telegram_id: {"id": 777, "username": "ada"},
+    )
+    monkeypatch.setattr(
+        router,
+        "memory_backend_for_profile",
+        lambda profile: memory_backend,
+    )
+    monkeypatch.setattr(
+        router,
+        "append_debug_conversation_turn",
+        lambda turn: debug_turns.append(turn) or True,
+    )
+
+    async def answer(
+        user: str,
+        msg: str,
+        profile: BotProfile | None = None,
+        **kwargs: object,
+    ) -> str:
+        del user, msg, profile, kwargs
+        return engine.GeneratedAnswer(
+            engine.AI_TIMEOUT_FALLBACK,
+            debug_log=False,
+            store_in_memory=False,
+        )
+
+    async def compact_turn(**kwargs: object) -> None:
+        compacted.append(kwargs)
+
+    monkeypatch.setattr(engine, "answer", answer)
+    monkeypatch.setattr(router, "_compact_successful_turn", compact_turn)
+
+    await router.ask_ia(cast(Any, update), cast(Any, SimpleNamespace(bot=FakeBot())))
+
+    assert update.message.replies == [engine.AI_TIMEOUT_FALLBACK]
+    assert debug_turns == []
+    assert memory_backend.stored_turns == []
+    assert compacted == []
+
+
+@pytest.mark.asyncio
 async def test_memory_compaction_runs_after_ai_lease_release(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_request_lifecycle.py
+++ b/tests/test_request_lifecycle.py
@@ -143,6 +143,7 @@ def authorize_user(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture(autouse=True)
 def default_abuse_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(router, "abuse_limiter", AbuseLimiter(make_settings))
+    monkeypatch.setattr(router, "get_settings", lambda: make_settings())
 
 
 @pytest.mark.asyncio
@@ -346,9 +347,7 @@ async def test_nvidia_profile_streams_drafts_before_final_answer(
     await router.ask_ia(cast(Any, update), cast(Any, SimpleNamespace(bot=bot)))
 
     streamed_drafts = [
-        draft["text"]
-        for draft in bot.drafts
-        if draft["text"] not in {".", "..", "..."}
+        draft["text"] for draft in bot.drafts if draft["text"] not in {".", "..", "..."}
     ]
     assert streamed_drafts == [
         "preparando",
@@ -565,9 +564,7 @@ async def test_memory_context_is_sent_to_engine_and_turn_is_stored(
     memory_backend = FakeMemoryBackend()
     memory_backend.context = SimpleNamespace(
         compacted_user_memory="Prefers vegetarian dinners.",
-        recent_conversation_messages=[
-            {"role": "user", "content": "I am vegetarian."}
-        ],
+        recent_conversation_messages=[{"role": "user", "content": "I am vegetarian."}],
     )
 
     monkeypatch.setattr(router, "request_state", state)

--- a/tests/test_request_lifecycle.py
+++ b/tests/test_request_lifecycle.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any, cast
@@ -26,9 +27,28 @@ class FakeMessage:
 class FakeBot:
     def __init__(self) -> None:
         self.chat_actions: list[tuple[int, str]] = []
+        self.drafts: list[dict[str, object]] = []
 
     async def send_chat_action(self, *, chat_id: int, action: str) -> None:
         self.chat_actions.append((chat_id, action))
+
+    async def send_message_draft(
+        self,
+        *,
+        chat_id: int,
+        draft_id: int,
+        text: str,
+        parse_mode: str | None = None,
+    ) -> bool:
+        self.drafts.append(
+            {
+                "chat_id": chat_id,
+                "draft_id": draft_id,
+                "text": text,
+                "parse_mode": parse_mode,
+            }
+        )
+        return True
 
 
 def fake_profile() -> BotProfile:
@@ -43,6 +63,7 @@ def fake_profile() -> BotProfile:
         llm_provider="ollama",
         llm_model="test-model",
         memory_enabled=False,
+        memory_backend="postgres",
         analytics_enabled=False,
     )
 
@@ -59,8 +80,46 @@ def fake_memory_profile() -> BotProfile:
         llm_provider="ollama",
         llm_model="test-model",
         memory_enabled=True,
+        memory_backend="postgres",
         analytics_enabled=False,
     )
+
+
+def fake_nvidia_profile() -> BotProfile:
+    return BotProfile(
+        bot_profile_id="nutrition",
+        bot_display_name="BotForge",
+        bot_description="Test profile",
+        system_prompt="Be helpful.",
+        domain_rules=("Do not leak secrets.",),
+        disclaimer_text="Test only.",
+        default_language="en",
+        llm_provider="nvidia",
+        llm_model="nvidia/test-model",
+        memory_enabled=False,
+        memory_backend="postgres",
+        analytics_enabled=False,
+    )
+
+
+class FakeMemoryBackend:
+    def __init__(self) -> None:
+        self.context = SimpleNamespace(
+            compacted_user_memory=None,
+            recent_conversation_messages=[],
+        )
+        self.stored_turns: list[dict[str, object]] = []
+
+    def get_context(self, **kwargs: object) -> SimpleNamespace:
+        del kwargs
+        return self.context
+
+    def store_successful_turn(self, **kwargs: object) -> bool:
+        self.stored_turns.append(kwargs)
+        return True
+
+    async def compact_memory_if_needed(self, **kwargs: object) -> None:
+        del kwargs
 
 
 def fake_update(*, update_id: int = 1001, text: str = "hello") -> SimpleNamespace:
@@ -203,6 +262,251 @@ async def test_request_state_is_cleared_after_success(
 
 
 @pytest.mark.asyncio
+async def test_slow_ai_response_sends_progress_notice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authorize_user(monkeypatch)
+    state = UserRequestState()
+    monkeypatch.setattr(router, "request_state", state)
+    monkeypatch.setattr(router, "PROCESSING_NOTICE_INITIAL_DELAY_SECONDS", 0.01)
+    monkeypatch.setattr(router, "PROCESSING_NOTICE_INTERVAL_SECONDS", 10)
+    update = fake_update(update_id=30032)
+
+    monkeypatch.setattr(
+        router,
+        "persist_update",
+        lambda update: {"status": "persisted"},
+    )
+    monkeypatch.setattr(router, "mark_queued", lambda update_id: {"status": "queued"})
+    monkeypatch.setattr(
+        router,
+        "mark_processing",
+        lambda update_id: {"status": "processing"},
+    )
+    monkeypatch.setattr(router, "mark_answered", lambda update_id: None)
+    monkeypatch.setattr(engine, "load_default_profile", fake_profile)
+
+    async def answer(
+        user: str,
+        msg: str,
+        profile: BotProfile | None = None,
+        **kwargs: object,
+    ) -> str:
+        del user, msg, profile, kwargs
+        await asyncio.sleep(0.02)
+        return "done"
+
+    monkeypatch.setattr(engine, "answer", answer)
+
+    await router.ask_ia(cast(Any, update), cast(Any, SimpleNamespace(bot=FakeBot())))
+
+    assert update.message.replies == [router.PROCESSING_NOTICE_MESSAGE, "done"]
+
+
+@pytest.mark.asyncio
+async def test_nvidia_profile_streams_drafts_before_final_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authorize_user(monkeypatch)
+    state = UserRequestState()
+    bot = FakeBot()
+    monkeypatch.setattr(router, "request_state", state)
+    monkeypatch.setattr(router, "STREAM_DRAFT_UPDATE_INTERVAL_SECONDS", 0)
+    update = fake_update(update_id=30034)
+
+    monkeypatch.setattr(
+        router,
+        "persist_update",
+        lambda update: {"status": "persisted"},
+    )
+    monkeypatch.setattr(router, "mark_queued", lambda update_id: {"status": "queued"})
+    monkeypatch.setattr(
+        router,
+        "mark_processing",
+        lambda update_id: {"status": "processing"},
+    )
+    monkeypatch.setattr(router, "mark_answered", lambda update_id: None)
+    monkeypatch.setattr(engine, "load_default_profile", fake_nvidia_profile)
+
+    async def answer_stream(
+        user: str,
+        msg: str,
+        *,
+        on_partial: Any,
+        profile: BotProfile | None = None,
+        **kwargs: object,
+    ) -> str:
+        del user, msg, profile, kwargs
+        await on_partial("preparando")
+        await on_partial("preparando cena")
+        return "cena lista"
+
+    monkeypatch.setattr(engine, "answer_stream", answer_stream)
+
+    await router.ask_ia(cast(Any, update), cast(Any, SimpleNamespace(bot=bot)))
+
+    streamed_drafts = [
+        draft["text"]
+        for draft in bot.drafts
+        if draft["text"] not in {".", "..", "..."}
+    ]
+    assert streamed_drafts == [
+        "preparando",
+        "preparando cena",
+    ]
+    assert bot.drafts[0]["draft_id"] == 30034
+    assert update.message.replies == ["cena lista"]
+
+
+@pytest.mark.asyncio
+async def test_streaming_profile_shows_loading_dots_before_first_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authorize_user(monkeypatch)
+    state = UserRequestState()
+    bot = FakeBot()
+    monkeypatch.setattr(router, "request_state", state)
+    monkeypatch.setattr(router, "STREAM_LOADING_DRAFT_INTERVAL_SECONDS", 0.01)
+    monkeypatch.setattr(router, "STREAM_DRAFT_UPDATE_INTERVAL_SECONDS", 0)
+    update = fake_update(update_id=30035)
+
+    monkeypatch.setattr(
+        router,
+        "persist_update",
+        lambda update: {"status": "persisted"},
+    )
+    monkeypatch.setattr(router, "mark_queued", lambda update_id: {"status": "queued"})
+    monkeypatch.setattr(
+        router,
+        "mark_processing",
+        lambda update_id: {"status": "processing"},
+    )
+    monkeypatch.setattr(router, "mark_answered", lambda update_id: None)
+    monkeypatch.setattr(engine, "load_default_profile", fake_nvidia_profile)
+
+    async def answer_stream(
+        user: str,
+        msg: str,
+        *,
+        on_partial: Any,
+        profile: BotProfile | None = None,
+        **kwargs: object,
+    ) -> str:
+        del user, msg, profile, kwargs
+        await asyncio.sleep(0.035)
+        await on_partial("respuesta parcial")
+        return "respuesta final"
+
+    monkeypatch.setattr(engine, "answer_stream", answer_stream)
+
+    await router.ask_ia(cast(Any, update), cast(Any, SimpleNamespace(bot=bot)))
+
+    draft_texts = [draft["text"] for draft in bot.drafts]
+    assert draft_texts[:3] == [".", "..", "..."]
+    assert "respuesta parcial" in draft_texts
+    assert update.message.replies == ["respuesta final"]
+
+
+@pytest.mark.asyncio
+async def test_very_slow_ai_response_sends_repeated_progress_notices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authorize_user(monkeypatch)
+    state = UserRequestState()
+    monkeypatch.setattr(router, "request_state", state)
+    monkeypatch.setattr(router, "PROCESSING_NOTICE_INITIAL_DELAY_SECONDS", 0.01)
+    monkeypatch.setattr(router, "PROCESSING_NOTICE_INTERVAL_SECONDS", 0.01)
+    update = fake_update(update_id=30033)
+
+    monkeypatch.setattr(
+        router,
+        "persist_update",
+        lambda update: {"status": "persisted"},
+    )
+    monkeypatch.setattr(router, "mark_queued", lambda update_id: {"status": "queued"})
+    monkeypatch.setattr(
+        router,
+        "mark_processing",
+        lambda update_id: {"status": "processing"},
+    )
+    monkeypatch.setattr(router, "mark_answered", lambda update_id: None)
+    monkeypatch.setattr(engine, "load_default_profile", fake_profile)
+
+    async def answer(
+        user: str,
+        msg: str,
+        profile: BotProfile | None = None,
+        **kwargs: object,
+    ) -> str:
+        del user, msg, profile, kwargs
+        await asyncio.sleep(0.035)
+        return "done"
+
+    monkeypatch.setattr(engine, "answer", answer)
+
+    await router.ask_ia(cast(Any, update), cast(Any, SimpleNamespace(bot=FakeBot())))
+
+    assert update.message.replies[:2] == [
+        router.PROCESSING_NOTICE_MESSAGE,
+        router.PROCESSING_NOTICE_REPEAT_MESSAGE,
+    ]
+    assert update.message.replies[-1] == "done"
+
+
+@pytest.mark.asyncio
+async def test_successful_turn_is_offered_to_debug_conversation_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    authorize_user(monkeypatch)
+    state = UserRequestState()
+    update = fake_update(update_id=30031, text="Que ceno?")
+    debug_turns: list[object] = []
+
+    monkeypatch.setattr(router, "request_state", state)
+    monkeypatch.setattr(
+        router,
+        "persist_update",
+        lambda update: {"id": 91, "status": "persisted"},
+    )
+    monkeypatch.setattr(router, "mark_queued", lambda update_id: {"status": "queued"})
+    monkeypatch.setattr(
+        router,
+        "mark_processing",
+        lambda update_id: {"id": 91, "status": "processing"},
+    )
+    monkeypatch.setattr(router, "mark_answered", lambda update_id: None)
+    monkeypatch.setattr(engine, "load_default_profile", fake_profile)
+    monkeypatch.setattr(
+        router,
+        "append_debug_conversation_turn",
+        lambda turn: debug_turns.append(turn) or True,
+    )
+
+    async def answer(
+        user: str,
+        msg: str,
+        profile: BotProfile | None = None,
+        **kwargs: object,
+    ) -> str:
+        del user, msg, profile, kwargs
+        return "Merluza con verduras."
+
+    monkeypatch.setattr(engine, "answer", answer)
+
+    await router.ask_ia(cast(Any, update), cast(Any, SimpleNamespace(bot=FakeBot())))
+
+    assert update.message.replies == ["Merluza con verduras."]
+    assert len(debug_turns) == 1
+    turn = debug_turns[0]
+    assert turn.bot_profile_id == "default_dev"
+    assert turn.telegram_user_id == 123
+    assert turn.telegram_chat_id == 456
+    assert turn.inbound_message_id == 91
+    assert turn.user_message == "Que ceno?"
+    assert turn.assistant_message == "Merluza con verduras."
+
+
+@pytest.mark.asyncio
 async def test_engine_receives_wait_time_after_global_ai_lease(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -258,7 +562,13 @@ async def test_memory_context_is_sent_to_engine_and_turn_is_stored(
     state = UserRequestState()
     update = fake_update(update_id=3005)
     answer_kwargs: list[dict[str, object]] = []
-    stored_turns: list[dict[str, object]] = []
+    memory_backend = FakeMemoryBackend()
+    memory_backend.context = SimpleNamespace(
+        compacted_user_memory="Prefers vegetarian dinners.",
+        recent_conversation_messages=[
+            {"role": "user", "content": "I am vegetarian."}
+        ],
+    )
 
     monkeypatch.setattr(router, "request_state", state)
     monkeypatch.setattr(
@@ -282,13 +592,8 @@ async def test_memory_context_is_sent_to_engine_and_turn_is_stored(
     )
     monkeypatch.setattr(
         router,
-        "get_memory_context",
-        lambda **kwargs: SimpleNamespace(
-            compacted_user_memory="Prefers vegetarian dinners.",
-            recent_conversation_messages=[
-                {"role": "user", "content": "I am vegetarian."}
-            ],
-        ),
+        "memory_backend_for_profile",
+        lambda profile: memory_backend,
     )
 
     async def answer(
@@ -301,16 +606,12 @@ async def test_memory_context_is_sent_to_engine_and_turn_is_stored(
         answer_kwargs.append(kwargs)
         return "try a vegetable stew"
 
-    async def store_turn(**kwargs: object) -> None:
-        stored_turns.append(kwargs)
-
     monkeypatch.setattr(engine, "answer", answer)
-    monkeypatch.setattr(
-        router,
-        "store_successful_turn",
-        lambda **kwargs: stored_turns.append(kwargs) or True,
-    )
-    monkeypatch.setattr(router, "_compact_successful_turn", store_turn)
+
+    async def compact_turn(**kwargs: object) -> None:
+        del kwargs
+
+    monkeypatch.setattr(router, "_compact_successful_turn", compact_turn)
 
     await router.ask_ia(cast(Any, update), cast(Any, SimpleNamespace(bot=FakeBot())))
 
@@ -319,10 +620,13 @@ async def test_memory_context_is_sent_to_engine_and_turn_is_stored(
     assert answer_kwargs[0]["recent_conversation_messages"] == [
         {"role": "user", "content": "I am vegetarian."}
     ]
-    assert stored_turns[0]["user_id"] == 777
-    assert stored_turns[0]["bot_profile_id"] == "default_dev"
-    assert stored_turns[0]["user_message"] == "hello"
-    assert stored_turns[0]["assistant_message"] == "try a vegetable stew"
+    assert answer_kwargs[0]["internal_user_id"] == 777
+    assert memory_backend.stored_turns[0]["user_id"] == 777
+    assert memory_backend.stored_turns[0]["bot_profile_id"] == "default_dev"
+    assert memory_backend.stored_turns[0]["user_message"] == "hello"
+    assert memory_backend.stored_turns[0]["assistant_message"] == (
+        "try a vegetable stew"
+    )
 
 
 @pytest.mark.asyncio
@@ -333,6 +637,7 @@ async def test_memory_compaction_runs_after_ai_lease_release(
     state = UserRequestState()
     update = fake_update(update_id=3006)
     events: list[str] = []
+    memory_backend = FakeMemoryBackend()
 
     class FakeLease:
         def __init__(self) -> None:
@@ -389,11 +694,8 @@ async def test_memory_compaction_runs_after_ai_lease_release(
     )
     monkeypatch.setattr(
         router,
-        "get_memory_context",
-        lambda **kwargs: SimpleNamespace(
-            compacted_user_memory=None,
-            recent_conversation_messages=[],
-        ),
+        "memory_backend_for_profile",
+        lambda profile: memory_backend,
     )
 
     async def answer(
@@ -412,7 +714,6 @@ async def test_memory_compaction_runs_after_ai_lease_release(
         events.append("compact")
 
     monkeypatch.setattr(engine, "answer", answer)
-    monkeypatch.setattr(router, "store_successful_turn", lambda **kwargs: True)
     monkeypatch.setattr(router, "_compact_successful_turn", compact_turn)
 
     await router.ask_ia(cast(Any, update), cast(Any, SimpleNamespace(bot=FakeBot())))

--- a/tests/test_request_lifecycle.py
+++ b/tests/test_request_lifecycle.py
@@ -144,6 +144,11 @@ def authorize_user(monkeypatch: pytest.MonkeyPatch) -> None:
 def default_abuse_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(router, "abuse_limiter", AbuseLimiter(make_settings))
     monkeypatch.setattr(router, "get_settings", lambda: make_settings())
+    monkeypatch.setattr(
+        router,
+        "append_debug_conversation_turn",
+        lambda turn: True,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_safety.py
+++ b/tests/test_runtime_safety.py
@@ -2,13 +2,14 @@ import asyncio
 import logging
 import ssl
 from dataclasses import replace
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
 
 from forge_bot import engine
-from forge_bot.bot_profile import BotProfile
+from forge_bot.bot_profile import BotProfile, BotProfileContextDocument
 from forge_bot.commands import auth_guard
 
 
@@ -151,6 +152,61 @@ async def test_ai_response_is_truncated(monkeypatch: pytest.MonkeyPatch) -> None
     result = await engine.answer("Ada", "hello")
 
     assert result == "abc"
+
+
+@pytest.mark.asyncio
+async def test_ai_response_is_normalized_for_telegram_html(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def successful_to_thread(*args: object, **kwargs: object) -> object:
+        return SimpleNamespace(
+            message=SimpleNamespace(
+                content="### **Cena**\n* 330g de merluza\n* `20g aceite`"
+            )
+        )
+
+    monkeypatch.setattr(engine, "get_settings", lambda: fake_settings())
+    monkeypatch.setattr(engine, "load_active_bot_profile", lambda *args: fake_profile())
+    monkeypatch.setattr("forge_bot.engine.ollama.Client", fake_ollama_client)
+    monkeypatch.setattr("forge_bot.engine.asyncio.to_thread", successful_to_thread)
+
+    result = await engine.answer("Ada", "hello")
+
+    assert result == "<b>Cena</b>\n- 330g de merluza\n- 20g aceite"
+
+
+@pytest.mark.asyncio
+async def test_memory_query_sends_recent_conversation_to_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_messages: list[list[dict[str, str]]] = []
+
+    class FakeProvider:
+        name = "ollama"
+
+        async def chat(self, *, model: str, messages: list[dict[str, str]]) -> str:
+            del model
+            captured_messages.append(messages)
+            return "Lo ultimo que me preguntaste fue que cenar dia de no entreno."
+
+    monkeypatch.setattr(engine, "get_settings", lambda: fake_settings())
+    monkeypatch.setattr(engine, "load_active_bot_profile", lambda *args: fake_profile())
+    monkeypatch.setattr(engine, "_build_provider", lambda name: FakeProvider())
+
+    result = await engine.answer(
+        "Ada",
+        "Que ha sido lo ultimo que te he preguntado?",
+        recent_conversation_messages=[
+            {"role": "user", "content": "Que ceno hoy dia de no entreno?"},
+            {"role": "assistant", "content": "Cena de no entreno..."},
+        ],
+    )
+
+    assert result == "Lo ultimo que me preguntaste fue que cenar dia de no entreno."
+    system_message = captured_messages[0][0]["content"]
+    assert "Available conversation context" in system_message
+    assert "Do not say you have no memory" in system_message
+    assert "user: Que ceno hoy dia de no entreno?" in system_message
 
 
 @pytest.mark.asyncio
@@ -337,6 +393,266 @@ async def test_explicit_primary_provider_overrides_profile_provider(
 
     assert result == "ollama answer"
     assert used_providers == ["ollama"]
+
+
+@pytest.mark.asyncio
+async def test_nutrition_profile_sends_only_resolved_plan_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_messages: list[list[dict[str, str]]] = []
+
+    class FakeProvider:
+        name = "nvidia"
+
+        async def chat(self, *, model: str, messages: list[dict[str, str]]) -> str:
+            del model
+            captured_messages.append(messages)
+            return "nutrition answer"
+
+    nutrition_profile = replace(
+        fake_profile(),
+        bot_profile_id="nutrition",
+        llm_provider="nvidia",
+        nutrition_plan_path=Path("bot_profiles/nutrition/demo_plan.json"),
+        context_documents=(
+            BotProfileContextDocument(
+                name="demo_plan.json",
+                content='{"comida_5": "should not be sent"}',
+            ),
+        ),
+    )
+    monkeypatch.setattr(engine, "get_settings", lambda: fake_settings())
+    monkeypatch.setattr(
+        engine,
+        "load_active_bot_profile",
+        lambda *args: nutrition_profile,
+    )
+    monkeypatch.setattr(engine, "_build_provider", lambda name: FakeProvider())
+
+    result = await engine.answer(
+        "Ada",
+        "Hoy tengo crossfit, que como al mediodia?",
+    )
+
+    assert result == "nutrition answer"
+    system_message = captured_messages[0][0]["content"]
+    assert "Resolved nutrition plan context" in system_message
+    assert '"meal_block_key": "comida_2"' in system_message
+    assert "Profile context documents:" not in system_message
+    assert "comida_5" not in system_message
+
+
+@pytest.mark.asyncio
+async def test_nutrition_profile_sanitizes_resolved_answer_without_extra_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeProvider:
+        name = "nvidia"
+
+        async def chat(self, *, model: str, messages: list[dict[str, str]]) -> str:
+            del model, messages
+            return "### **Cena**\n* " + ("respuesta larga " * 200)
+
+    nutrition_profile = replace(
+        fake_profile(),
+        bot_profile_id="nutrition",
+        llm_provider="nvidia",
+        nutrition_plan_path=Path("bot_profiles/nutrition/demo_plan.json"),
+    )
+    monkeypatch.setattr(
+        engine,
+        "get_settings",
+        lambda: fake_settings(ai_max_response_chars=4000),
+    )
+    monkeypatch.setattr(
+        engine,
+        "load_active_bot_profile",
+        lambda *args: nutrition_profile,
+    )
+    monkeypatch.setattr(engine, "_build_provider", lambda name: FakeProvider())
+
+    result = await engine.answer("Ada", "Hoy no entreno, que ceno?")
+
+    assert len(result) > 900
+    assert "*" not in result
+    assert "###" not in result
+    assert result.startswith("<b>Cena</b>\n- respuesta larga")
+
+
+@pytest.mark.asyncio
+async def test_nutrition_profile_sends_resolved_full_day_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_messages: list[list[dict[str, str]]] = []
+
+    class FakeProvider:
+        name = "nvidia"
+
+        async def chat(self, *, model: str, messages: list[dict[str, str]]) -> str:
+            del model
+            captured_messages.append(messages)
+            return "full day nutrition answer"
+
+    nutrition_profile = replace(
+        fake_profile(),
+        bot_profile_id="nutrition",
+        llm_provider="nvidia",
+        nutrition_plan_path=Path("bot_profiles/nutrition/demo_plan.json"),
+        context_documents=(
+            BotProfileContextDocument(
+                name="demo_plan.json",
+                content='{"comida_5": "should not be sent"}',
+            ),
+        ),
+    )
+    monkeypatch.setattr(engine, "get_settings", lambda: fake_settings())
+    monkeypatch.setattr(
+        engine,
+        "load_active_bot_profile",
+        lambda *args: nutrition_profile,
+    )
+    monkeypatch.setattr(engine, "_build_provider", lambda name: FakeProvider())
+
+    result = await engine.answer(
+        "Ada",
+        "Dame todo lo que puedo comer hoy dia de ciclismo",
+    )
+
+    assert result == "full day nutrition answer"
+    system_message = captured_messages[0][0]["content"]
+    assert '"mode": "full_day"' in system_message
+    assert '"situation_key": "ciclismo"' in system_message
+    assert '"moment_key": "desayuno"' in system_message
+    assert '"moment_key": "almuerzo"' in system_message
+    assert '"moment_key": "merienda"' in system_message
+    assert '"moment_key": "cena"' in system_message
+    assert '"meal_block_key": "comida_5"' not in system_message
+    assert "Profile context documents:" not in system_message
+
+
+@pytest.mark.asyncio
+async def test_nutrition_profile_missing_moment_asks_without_llm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider_called = False
+
+    class FakeProvider:
+        name = "nvidia"
+
+        async def chat(self, *, model: str, messages: list[dict[str, str]]) -> str:
+            nonlocal provider_called
+            del model, messages
+            provider_called = True
+            return "should not be used"
+
+    nutrition_profile = replace(
+        fake_profile(),
+        bot_profile_id="nutrition",
+        llm_provider="nvidia",
+        nutrition_plan_path=Path("bot_profiles/nutrition/demo_plan.json"),
+    )
+    monkeypatch.setattr(engine, "get_settings", lambda: fake_settings())
+    monkeypatch.setattr(
+        engine,
+        "load_active_bot_profile",
+        lambda *args: nutrition_profile,
+    )
+    monkeypatch.setattr(engine, "_build_provider", lambda name: FakeProvider())
+
+    result = await engine.answer("Ada", "Hoy tengo crossfit")
+
+    assert "dime el momento" in result
+    assert not provider_called
+
+
+@pytest.mark.asyncio
+async def test_nutrition_profile_resolves_follow_up_moment_from_recent_user_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_messages: list[list[dict[str, str]]] = []
+
+    class FakeProvider:
+        name = "nvidia"
+
+        async def chat(self, *, model: str, messages: list[dict[str, str]]) -> str:
+            del model
+            captured_messages.append(messages)
+            return "cena no entreno"
+
+    nutrition_profile = replace(
+        fake_profile(),
+        bot_profile_id="nutrition",
+        llm_provider="nvidia",
+        nutrition_plan_path=Path("bot_profiles/nutrition/demo_plan.json"),
+    )
+    monkeypatch.setattr(engine, "get_settings", lambda: fake_settings())
+    monkeypatch.setattr(
+        engine,
+        "load_active_bot_profile",
+        lambda *args: nutrition_profile,
+    )
+    monkeypatch.setattr(engine, "_build_provider", lambda name: FakeProvider())
+
+    result = await engine.answer(
+        "Ada",
+        "Cena",
+        recent_conversation_messages=[
+            {"role": "user", "content": "Que como hoy dia de no entreno?"},
+            {"role": "assistant", "content": "Te lo ajusto, pero dime el momento."},
+        ],
+    )
+
+    assert result == "cena no entreno"
+    system_message = captured_messages[0][0]["content"]
+    assert '"situation_key": "no_entreno"' in system_message
+    assert '"moment_key": "cena"' in system_message
+    assert '"meal_block_key": "comida_3"' in system_message
+    assert "Recent conversation:" not in system_message
+
+
+@pytest.mark.asyncio
+async def test_nutrition_profile_resolves_follow_up_situation_from_recent_user_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_messages: list[list[dict[str, str]]] = []
+
+    class FakeProvider:
+        name = "nvidia"
+
+        async def chat(self, *, model: str, messages: list[dict[str, str]]) -> str:
+            del model
+            captured_messages.append(messages)
+            return "cena no entreno"
+
+    nutrition_profile = replace(
+        fake_profile(),
+        bot_profile_id="nutrition",
+        llm_provider="nvidia",
+        nutrition_plan_path=Path("bot_profiles/nutrition/demo_plan.json"),
+    )
+    monkeypatch.setattr(engine, "get_settings", lambda: fake_settings())
+    monkeypatch.setattr(
+        engine,
+        "load_active_bot_profile",
+        lambda *args: nutrition_profile,
+    )
+    monkeypatch.setattr(engine, "_build_provider", lambda name: FakeProvider())
+
+    result = await engine.answer(
+        "Ada",
+        "No entreno",
+        recent_conversation_messages=[
+            {"role": "user", "content": "Cena"},
+            {"role": "assistant", "content": "Dime que tipo de dia es."},
+        ],
+    )
+
+    assert result == "cena no entreno"
+    system_message = captured_messages[0][0]["content"]
+    assert '"situation_key": "no_entreno"' in system_message
+    assert '"moment_key": "cena"' in system_message
+    assert '"meal_block_key": "comida_3"' in system_message
+    assert "Recent conversation:" not in system_message
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_safety.py
+++ b/tests/test_runtime_safety.py
@@ -114,6 +114,8 @@ async def test_ai_timeout_returns_fallback(monkeypatch: pytest.MonkeyPatch) -> N
     result = await engine.answer("Ada", "hello")
 
     assert result == engine.AI_TIMEOUT_FALLBACK
+    assert engine.answer_should_be_stored_in_memory(result) is False
+    assert engine.answer_should_be_debug_logged(result) is False
 
 
 @pytest.mark.asyncio
@@ -135,6 +137,8 @@ async def test_ai_exception_returns_fallback_without_logging_message(
         result = await engine.answer("Ada", private_message)
 
     assert result == engine.AI_ERROR_FALLBACK
+    assert engine.answer_should_be_stored_in_memory(result) is False
+    assert engine.answer_should_be_debug_logged(result) is False
     assert private_message not in caplog.text
     assert "message_chars=" in caplog.text
 
@@ -240,6 +244,7 @@ async def test_fallback_provider_answers_when_ollama_fails(
     result = await engine.answer("Ada", "hello", request_id="req-1")
 
     assert result == "fallback answer"
+    assert engine.answer_should_be_stored_in_memory(result) is True
 
 
 @pytest.mark.asyncio
@@ -269,6 +274,7 @@ async def test_fallback_provider_timeout_returns_timeout_fallback(
     result = await engine.answer("Ada", "hello", request_id="req-1")
 
     assert result == engine.AI_TIMEOUT_FALLBACK
+    assert engine.answer_should_be_stored_in_memory(result) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_safety.py
+++ b/tests/test_runtime_safety.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+import ssl
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -37,12 +39,12 @@ def fake_profile() -> BotProfile:
 def fake_settings(**overrides: object) -> SimpleNamespace:
     values: dict[str, object] = {
         "ollama_host": "http://ollama:11434",
-        "llm_primary_provider": "ollama",
+        "llm_primary_provider": "profile",
         "llm_fallback_provider": "nvidia",
         "llm_fallback_queue_wait_seconds": 100,
         "nvidia_api_key": "",
         "nvidia_base_url": "https://integrate.api.nvidia.com/v1",
-        "nvidia_model": "nvidia/test-model",
+        "nvidia_model": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
         "bot_profile": "default_dev",
         "bot_profiles_dir": "bot_profiles",
         "ai_timeout_seconds": 1,
@@ -76,6 +78,17 @@ def test_nvidia_provider_normalizes_https_base_url() -> None:
     )
 
     assert provider._base_url == "https://example.test/v1"
+
+
+def test_nvidia_provider_uses_certifi_ssl_context() -> None:
+    provider = engine.NvidiaNimProvider(
+        api_key="secret-key",
+        base_url="https://example.test/v1/",
+        model="nvidia/test-model",
+        timeout_seconds=1,
+    )
+
+    assert isinstance(provider._ssl_context, ssl.SSLContext)
 
 
 @pytest.mark.asyncio
@@ -249,6 +262,78 @@ async def test_queue_wait_under_threshold_uses_primary_provider(
     monkeypatch.setattr(engine, "_build_provider", lambda name: FakeProvider(name))
 
     result = await engine.answer("Ada", "hello", queue_wait_seconds=99)
+
+    assert result == "ollama answer"
+    assert used_providers == ["ollama"]
+
+
+@pytest.mark.asyncio
+async def test_profile_primary_provider_uses_profile_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    used_providers: list[str] = []
+
+    class FakeProvider:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        async def chat(self, *, model: str, messages: list[dict[str, str]]) -> str:
+            used_providers.append(self.name)
+            return f"{self.name} answer"
+
+    nvidia_profile = replace(
+        fake_profile(),
+        llm_provider="nvidia",
+        llm_model="nvidia/test-model",
+    )
+
+    monkeypatch.setattr(engine, "get_settings", lambda: fake_settings())
+    monkeypatch.setattr(
+        engine,
+        "load_active_bot_profile",
+        lambda *args: nvidia_profile,
+    )
+    monkeypatch.setattr(engine, "_build_provider", lambda name: FakeProvider(name))
+
+    result = await engine.answer("Ada", "hello")
+
+    assert result == "nvidia answer"
+    assert used_providers == ["nvidia"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_primary_provider_overrides_profile_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    used_providers: list[str] = []
+
+    class FakeProvider:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        async def chat(self, *, model: str, messages: list[dict[str, str]]) -> str:
+            used_providers.append(self.name)
+            return f"{self.name} answer"
+
+    nvidia_profile = replace(
+        fake_profile(),
+        llm_provider="nvidia",
+        llm_model="nvidia/test-model",
+    )
+
+    monkeypatch.setattr(
+        engine,
+        "get_settings",
+        lambda: fake_settings(llm_primary_provider="ollama"),
+    )
+    monkeypatch.setattr(
+        engine,
+        "load_active_bot_profile",
+        lambda *args: nvidia_profile,
+    )
+    monkeypatch.setattr(engine, "_build_provider", lambda name: FakeProvider(name))
+
+    result = await engine.answer("Ada", "hello")
 
     assert result == "ollama answer"
     assert used_providers == ["ollama"]

--- a/tests/test_runtime_safety.py
+++ b/tests/test_runtime_safety.py
@@ -33,6 +33,7 @@ def fake_profile() -> BotProfile:
         llm_provider="ollama",
         llm_model="test-model",
         memory_enabled=False,
+        memory_backend="postgres",
         analytics_enabled=False,
     )
 
@@ -46,8 +47,11 @@ def fake_settings(**overrides: object) -> SimpleNamespace:
         "nvidia_api_key": "",
         "nvidia_base_url": "https://integrate.api.nvidia.com/v1",
         "nvidia_model": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+        "nutrition_normalizer_provider": "off",
+        "nutrition_normalizer_model": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
         "bot_profile": "default_dev",
         "bot_profiles_dir": "bot_profiles",
+        "bot_timezone": "Europe/Madrid",
         "ai_timeout_seconds": 1,
         "ai_max_response_chars": 4000,
     }
@@ -413,10 +417,10 @@ async def test_nutrition_profile_sends_only_resolved_plan_chunk(
         fake_profile(),
         bot_profile_id="nutrition",
         llm_provider="nvidia",
-        nutrition_plan_path=Path("bot_profiles/nutrition/demo_plan.json"),
+        nutrition_plan_path=Path("tests/fixtures/nutrition_plan.json"),
         context_documents=(
             BotProfileContextDocument(
-                name="demo_plan.json",
+                name="sample_plan.json",
                 content='{"comida_5": "should not be sent"}',
             ),
         ),
@@ -443,6 +447,58 @@ async def test_nutrition_profile_sends_only_resolved_plan_chunk(
 
 
 @pytest.mark.asyncio
+async def test_nutrition_profile_uses_configured_normalizer_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    used_models: list[str] = []
+
+    class FakeProvider:
+        name = "nvidia"
+
+        async def chat(self, *, model: str, messages: list[dict[str, str]]) -> str:
+            used_models.append(model)
+            system_message = messages[0]["content"]
+            if "Normalize one Spanish nutrition-bot user message" in system_message:
+                return (
+                    '{"intent":"recommend_meal","situation_key":"futbol",'
+                    '"situation_keys":["futbol"],"target_moment_key":"cena",'
+                    '"mentioned_moment_keys":["cena"],"logged_meals":[],'
+                    '"goal":"resolver cena","confidence":"high"}'
+                )
+            return "nutrition answer"
+
+    nutrition_profile = replace(
+        fake_profile(),
+        bot_profile_id="nutrition",
+        llm_provider="nvidia",
+        llm_model="nvidia/final-answer-model",
+        nutrition_plan_path=Path("tests/fixtures/nutrition_plan.json"),
+    )
+    monkeypatch.setattr(
+        engine,
+        "get_settings",
+        lambda: fake_settings(
+            nutrition_normalizer_provider="nvidia",
+            nutrition_normalizer_model="nvidia/cheap-normalizer",
+        ),
+    )
+    monkeypatch.setattr(
+        engine,
+        "load_active_bot_profile",
+        lambda *args: nutrition_profile,
+    )
+    monkeypatch.setattr(engine, "_build_provider", lambda name: FakeProvider())
+
+    result = await engine.answer(
+        "Ada",
+        "Hola, hoy es dia de futbol, que puedo tomar para la cena?",
+    )
+
+    assert result == "nutrition answer"
+    assert used_models == ["nvidia/cheap-normalizer", "nvidia/final-answer-model"]
+
+
+@pytest.mark.asyncio
 async def test_nutrition_profile_sanitizes_resolved_answer_without_extra_cap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -457,7 +513,7 @@ async def test_nutrition_profile_sanitizes_resolved_answer_without_extra_cap(
         fake_profile(),
         bot_profile_id="nutrition",
         llm_provider="nvidia",
-        nutrition_plan_path=Path("bot_profiles/nutrition/demo_plan.json"),
+        nutrition_plan_path=Path("tests/fixtures/nutrition_plan.json"),
     )
     monkeypatch.setattr(
         engine,
@@ -497,10 +553,10 @@ async def test_nutrition_profile_sends_resolved_full_day_chunks(
         fake_profile(),
         bot_profile_id="nutrition",
         llm_provider="nvidia",
-        nutrition_plan_path=Path("bot_profiles/nutrition/demo_plan.json"),
+        nutrition_plan_path=Path("tests/fixtures/nutrition_plan.json"),
         context_documents=(
             BotProfileContextDocument(
-                name="demo_plan.json",
+                name="sample_plan.json",
                 content='{"comida_5": "should not be sent"}',
             ),
         ),
@@ -549,7 +605,7 @@ async def test_nutrition_profile_missing_moment_asks_without_llm(
         fake_profile(),
         bot_profile_id="nutrition",
         llm_provider="nvidia",
-        nutrition_plan_path=Path("bot_profiles/nutrition/demo_plan.json"),
+        nutrition_plan_path=Path("tests/fixtures/nutrition_plan.json"),
     )
     monkeypatch.setattr(engine, "get_settings", lambda: fake_settings())
     monkeypatch.setattr(
@@ -583,7 +639,7 @@ async def test_nutrition_profile_resolves_follow_up_moment_from_recent_user_mess
         fake_profile(),
         bot_profile_id="nutrition",
         llm_provider="nvidia",
-        nutrition_plan_path=Path("bot_profiles/nutrition/demo_plan.json"),
+        nutrition_plan_path=Path("tests/fixtures/nutrition_plan.json"),
     )
     monkeypatch.setattr(engine, "get_settings", lambda: fake_settings())
     monkeypatch.setattr(
@@ -607,7 +663,7 @@ async def test_nutrition_profile_resolves_follow_up_moment_from_recent_user_mess
     assert '"situation_key": "no_entreno"' in system_message
     assert '"moment_key": "cena"' in system_message
     assert '"meal_block_key": "comida_3"' in system_message
-    assert "Recent conversation:" not in system_message
+    assert "Recent conversation:" in system_message
 
 
 @pytest.mark.asyncio
@@ -628,7 +684,7 @@ async def test_nutrition_profile_resolves_follow_up_situation_from_recent_user_m
         fake_profile(),
         bot_profile_id="nutrition",
         llm_provider="nvidia",
-        nutrition_plan_path=Path("bot_profiles/nutrition/demo_plan.json"),
+        nutrition_plan_path=Path("tests/fixtures/nutrition_plan.json"),
     )
     monkeypatch.setattr(engine, "get_settings", lambda: fake_settings())
     monkeypatch.setattr(
@@ -652,7 +708,7 @@ async def test_nutrition_profile_resolves_follow_up_situation_from_recent_user_m
     assert '"situation_key": "no_entreno"' in system_message
     assert '"moment_key": "cena"' in system_message
     assert '"meal_block_key": "comida_3"' in system_message
-    assert "Recent conversation:" not in system_message
+    assert "Recent conversation:" in system_message
 
 
 @pytest.mark.asyncio

--- a/tests/test_set_plan.py
+++ b/tests/test_set_plan.py
@@ -174,15 +174,13 @@ async def test_set_plan_accepts_partial_situations_json(
         "/set_plan "
         + json.dumps(
             {
-                "momentos": {
-                    "cena": {"label": "Cena", "aliases": ["cena", "noche"]}
-                },
+                "momentos": {"cena": {"label": "Cena", "aliases": ["cena", "noche"]}},
                 "situaciones": {
                     "no_entreno": {
                         "momentos": {"cena": "comida_1"},
                         "suplementacion": [],
                     }
-                }
+                },
             }
         )
     )

--- a/tests/test_set_plan.py
+++ b/tests/test_set_plan.py
@@ -174,6 +174,9 @@ async def test_set_plan_accepts_partial_situations_json(
         "/set_plan "
         + json.dumps(
             {
+                "momentos": {
+                    "cena": {"label": "Cena", "aliases": ["cena", "noche"]}
+                },
                 "situaciones": {
                     "no_entreno": {
                         "momentos": {"cena": "comida_1"},
@@ -187,6 +190,9 @@ async def test_set_plan_accepts_partial_situations_json(
     await set_plan(update, SimpleNamespace(args=[]))
 
     assert partial_calls[0]["document_type"] == "situaciones"
+    assert partial_calls[0]["content"]["momentos"] == {
+        "cena": {"label": "Cena", "aliases": ["cena", "noche"]}
+    }
     assert "Parte del plan guardada." in update.message.replies[0]
     assert "Falta: comidas" in update.message.replies[0]
 

--- a/tests/test_set_plan.py
+++ b/tests/test_set_plan.py
@@ -1,0 +1,241 @@
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from forge_bot.bot_profile import BotProfile
+from forge_bot.commands import auth_guard
+from forge_bot.commands import set_plan as set_plan_module
+from forge_bot.commands.set_plan import set_plan
+from forge_bot.nutrition.plan import parse_nutrition_plan
+
+
+class FakeMessage:
+    def __init__(self, text: str | None, document: object | None = None) -> None:
+        self.text = text
+        self.document = document
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str) -> None:
+        self.replies.append(text)
+
+
+def nutrition_profile() -> BotProfile:
+    return BotProfile(
+        bot_profile_id="nutrition",
+        bot_display_name="Nutrition",
+        bot_description="Nutrition bot",
+        system_prompt="Be useful.",
+        domain_rules=("Use the plan.",),
+        disclaimer_text="Test.",
+        default_language="es",
+        llm_provider="nvidia",
+        llm_model="nvidia/test",
+        memory_enabled=True,
+        memory_backend="langchain_postgres",
+        analytics_enabled=False,
+    )
+
+
+def sample_plan_data() -> dict[str, Any]:
+    return {
+        "plan_id": "uploaded_plan",
+        "momentos": {"cena": {"label": "Cena", "aliases": ["cena"]}},
+        "situaciones": {
+            "no_entreno": {
+                "label": "No entreno",
+                "aliases": ["no entreno"],
+                "suplementacion": [],
+                "momentos": {"cena": "comida_1"},
+            }
+        },
+        "comidas": {
+            "comida_1": {
+                "descripcion": "Cena",
+                "and": ["200g merluza", "verdura"],
+            }
+        },
+    }
+
+
+def update_with_text(text: str) -> Any:
+    return SimpleNamespace(
+        effective_user=SimpleNamespace(id=123),
+        message=FakeMessage(text),
+    )
+
+
+class FakeTelegramFile:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+    async def download_as_bytearray(self) -> bytearray:
+        return bytearray(self.content.encode("utf-8"))
+
+
+class FakeDocument:
+    def __init__(self, *, file_name: str, content: str) -> None:
+        self.file_name = file_name
+        self.mime_type = "application/json"
+        self.file_size = len(content.encode("utf-8"))
+        self.content = content
+
+    async def get_file(self) -> FakeTelegramFile:
+        return FakeTelegramFile(self.content)
+
+
+def update_with_document(document: FakeDocument) -> Any:
+    return SimpleNamespace(
+        effective_user=SimpleNamespace(id=123),
+        message=FakeMessage(None, document=document),
+    )
+
+
+@pytest.fixture(autouse=True)
+def authorize(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth_guard, "verify_user", lambda telegram_id: True)
+    monkeypatch.setattr(
+        auth_guard,
+        "has_current_policy_acceptance",
+        lambda telegram_id: True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_plan_pasted_json_saves_active_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    saved_payloads: list[dict[str, Any]] = []
+
+    def fake_save_active_nutrition_plan(**kwargs: object) -> SimpleNamespace:
+        saved_payloads.append(dict(kwargs["plan_data"]))  # type: ignore[index]
+        return SimpleNamespace(plan=parse_nutrition_plan(kwargs["plan_data"]))  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        set_plan_module,
+        "get_user_by_telegram_id",
+        lambda telegram_id: {"id": 7},
+    )
+    monkeypatch.setattr(
+        set_plan_module.engine,
+        "load_default_profile",
+        nutrition_profile,
+    )
+    monkeypatch.setattr(
+        set_plan_module.engine,
+        "build_nutrition_normalizer",
+        lambda profile: None,
+    )
+    monkeypatch.setattr(
+        set_plan_module,
+        "save_active_nutrition_plan",
+        fake_save_active_nutrition_plan,
+    )
+    update = update_with_text("/set_plan " + json.dumps(sample_plan_data()))
+
+    await set_plan(update, SimpleNamespace(args=[]))
+
+    assert saved_payloads[0]["plan_id"] == "uploaded_plan"
+    assert "Plan nutricional activo actualizado." in update.message.replies[0]
+    assert "Normalizacion: validacion local" in update.message.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_set_plan_accepts_partial_situations_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    partial_calls: list[dict[str, object]] = []
+
+    def fake_save_nutrition_plan_part(**kwargs: object) -> SimpleNamespace:
+        partial_calls.append(dict(kwargs))
+        return SimpleNamespace(
+            activated=False,
+            document_type="situaciones",
+            missing_document_types=("comidas",),
+        )
+
+    monkeypatch.setattr(
+        set_plan_module,
+        "get_user_by_telegram_id",
+        lambda telegram_id: {"id": 7},
+    )
+    monkeypatch.setattr(
+        set_plan_module.engine,
+        "load_default_profile",
+        nutrition_profile,
+    )
+    monkeypatch.setattr(
+        set_plan_module,
+        "save_nutrition_plan_part",
+        fake_save_nutrition_plan_part,
+    )
+    update = update_with_text(
+        "/set_plan "
+        + json.dumps(
+            {
+                "situaciones": {
+                    "no_entreno": {
+                        "momentos": {"cena": "comida_1"},
+                        "suplementacion": [],
+                    }
+                }
+            }
+        )
+    )
+
+    await set_plan(update, SimpleNamespace(args=[]))
+
+    assert partial_calls[0]["document_type"] == "situaciones"
+    assert "Parte del plan guardada." in update.message.replies[0]
+    assert "Falta: comidas" in update.message.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_set_plan_accepts_document_without_caption(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    partial_calls: list[dict[str, object]] = []
+
+    def fake_save_nutrition_plan_part(**kwargs: object) -> SimpleNamespace:
+        partial_calls.append(dict(kwargs))
+        return SimpleNamespace(
+            activated=False,
+            document_type="comidas",
+            missing_document_types=("situaciones",),
+        )
+
+    monkeypatch.setattr(
+        set_plan_module,
+        "get_user_by_telegram_id",
+        lambda telegram_id: {"id": 7},
+    )
+    monkeypatch.setattr(
+        set_plan_module.engine,
+        "load_default_profile",
+        nutrition_profile,
+    )
+    monkeypatch.setattr(
+        set_plan_module,
+        "save_nutrition_plan_part",
+        fake_save_nutrition_plan_part,
+    )
+    document = FakeDocument(
+        file_name="comidas.json",
+        content=json.dumps({"comidas": sample_plan_data()["comidas"]}),
+    )
+
+    await set_plan(update_with_document(document), SimpleNamespace(args=[]))
+
+    assert partial_calls[0]["document_type"] == "comidas"
+    assert partial_calls[0]["source_filename"] == "comidas.json"
+
+
+@pytest.mark.asyncio
+async def test_set_plan_without_payload_explains_mobile_upload_flow() -> None:
+    update = update_with_text("/set_plan")
+
+    await set_plan(update, SimpleNamespace(args=[]))
+
+    assert "Listo para cargar tu plan." in update.message.replies[0]
+    assert "Desde movil no hace falta caption" in update.message.replies[0]


### PR DESCRIPTION
## Summary

This PR brings the nutrition bot epic into `main` as an integration branch. It includes the first usable nutrition flow: a user can upload their own plan JSON, the bot stores it in PostgreSQL, routes natural language to the relevant meal block, and answers with compact plan context instead of sending the full plan to the final model.

## What Changed

- Added the `nutrition` bot profile, Spanish guardrails, and NVIDIA model defaults for higher-quality answers.
- Added nutrition design docs covering user journeys, user stories, data contracts, response behavior, open considerations, roadmap, and orchestration.
- Added plan parsing and routing around `situaciones` + `comidas`, including nested `and`/`or` validation and compact context selection.
- Added PostgreSQL storage for user nutrition plans and plan documents as JSONB, preserving per-user `momentos` aliases.
- Added `/set_plan` and `/get_plan` so authenticated users can store and review their own active nutrition plan.
- Added LangChain-based orchestration for nutrition message understanding, optional normalization, daily state, and final answer context.
- Added a pluggable memory backend with `langchain_postgres` for the nutrition profile.
- Added daily nutrition logs for same-day context such as current activity, skipped meals, and logged meals.
- Added admin/debug tools for inspecting memory and optionally writing local conversation transcripts in development.
- Added streaming/progress UX improvements for long NVIDIA responses and Telegram drafts where available.
- Added Docker dev overlay and updated local setup docs.

## Final Review Fixes

- Moved the LangChain `(session_id, id)` index to a single migration owner so upgrade/downgrade state remains coherent.
- Preserved root-level `momentos` through split uploads, active-plan storage, and JSONB document recomposition.
- Marked timeout/error fallbacks as operational answers so they are sent to the user but not reused as memory.
- Added recursive validation for `comidas` `and`/`or` trees, including nested groups and invalid-node cases.
- Matched the full GitHub Actions quality workflow locally, including Black, isort, Bandit, and Radon.
- Replaced LangChain memory SQL f-strings with `psycopg.sql.Identifier` composition.

## Issue Mapping / Overlap

This PR intentionally touches more than one nutrition issue because the MVP needs routing, persistence, memory, and orchestration to work together.

- #79: main epic integration branch for the nutrition bot.
- #80: substantially covered by the nutrition profile, prompt, and guardrails.
- #81: substantially covered by `nutrition_plans` and `nutrition_plan_documents` JSONB persistence.
- #82: partially covered. The current contract is now `situaciones` + `comidas` rather than a standalone `meal_blocks` user file.
- #83: changed in scope. The implemented flow is `/set_plan`, not `/new_plan`, and accepts split JSON files or combined JSON.
- #84: not fully covered. V1 now focuses on JSON / TXT uploads; PDF extraction is still out of scope.
- #85: partially covered by the plan normalizer. It does not yet generate complete plans from arbitrary free text/PDF.
- #86: changed in scope. Valid uploads become active plans directly; draft support exists internally for split uploads but there is no review/activation UX yet.
- #87: partially covered. Only one active plan per user is enforced, but there is no separate activate-draft command.
- #88: substantially covered for first active-plan answers through routed `comidas` context.
- #90: partially covered by daily log storage and deferred updates; full daily tracking UX remains to build.
- #92: covered by the design docs added under `bot_profiles/nutrition/docs/`.
- #93: partially covered by LangChain memory backend, progress notices, debug transcripts, and memory cleanup updates.
- #94: covered by local situations routing and selected plan chunk delivery.
- #95: initial implementation only. LangChain orchestration and model routing are in place; MCP boundaries, recipe RAG, and local-model routing remain future work.

Related platform issues that are only incidentally touched:

- #61: this adds Telegram JSON/TXT plan document handling for nutrition only, not generic file upload / Drive storage.
- #63: not implemented; recipe RAG is documented as future work.
- #73: not implemented; this adds focused unit/live-test hooks, not a full LLM evaluation suite.

## Validation

Local validation:

- `.venv/bin/ruff format --check src tests`
- `.venv/bin/ruff check src tests`
- `.venv/bin/black --check src tests`
- `.venv/bin/isort --check-only src tests`
- `.venv/bin/mypy src`
- `.venv/bin/bandit -r src -ll`
- `.venv/bin/radon cc src tests -s -a`
- `env -i PATH="$PATH" HOME="$HOME" PYTHON_DOTENV_DISABLED=1 .venv/bin/pytest -q` -> `282 passed, 2 skipped`
- `docker compose config`
- `docker compose -f docker-compose.yml -f docker-compose.dev.yml config`

GitHub Actions on head `829a841`:

- Code Quality: pass
- Tests Python 3.10: pass
- Tests Python 3.12: pass

## Notes For Review

- This PR deliberately avoids closing the individual issues automatically because several should be updated or split after reviewing the new MVP direction.
- The implemented user-facing plan flow is `/set_plan` + `/get_plan`; docs now reflect that instead of the earlier `/new_plan` draft-first idea.
- Recipes/RAG, PDF extraction, full weekly-plan persistence, and advanced admin recipe review are still outside this PR.